### PR TITLE
Replace live recooking with managed streams

### DIFF
--- a/.agents/skills/blacknode-workflow/SKILL.md
+++ b/.agents/skills/blacknode-workflow/SKILL.md
@@ -74,13 +74,31 @@ blacknode export-framework templates\text-pipeline.json --target nvidia-agent-st
 3. Prefer `run_template_in_editor` for demo paths that should appear in the UI.
 4. For custom graphs, call `create_workflow`, `add_node`, and `connect_nodes`.
 5. Call `validate_workflow` after each meaningful mutation.
-6. Call `run_workflow` for headless execution or `cook_editor_node` for live UI execution.
-7. Call `list_recent_runs` and `get_run` to inspect replay events, model calls, tool calls, and errors.
-8. Call `export_python` when the user needs a handoff script.
-9. Use `blacknode import-python`, `/import/python`, the editor `Import` button, or canvas file drop when a workflow JSON, Python export, or LangGraph export should be restored as a visual graph.
+6. Call `run_workflow` for a headless one-shot run or `cook_editor_node` for a one-shot editor cook. Managed stream nodes may remain active after the cook completes.
+7. Call `get_editor_runtime_status` to inspect managed camera streams, persistent controllers, and robot drivers.
+8. Call `stop_editor_runtime_services` when the user asks to stop a demo or physical-robot safety requires shutdown.
+9. Call `list_recent_runs` and `get_run` to inspect replay events, model calls, tool calls, and errors.
+10. Call `export_python` when the user needs a handoff script.
+11. Use `blacknode import-python`, `/import/python`, the editor `Import` button, or canvas file drop when a workflow JSON, Python export, or LangGraph export should be restored as a visual graph.
 
 Every mutation should be followed by validation. If validation reports a port
 or type error, inspect `get_node_schema` and fix the graph instead of guessing.
+
+## Managed Runtime Safety
+
+- A cook evaluates the graph once. Do not repeatedly cook a stream or controller
+  node to process new frames, detections, or robot feedback.
+- Nodes such as `CV2CameraStream`, `CV2ColorObjectStream`,
+  `CUDAImageFilterStream`, robot drivers, and
+  `ROS2ContinuousFollowDetectionJoint` own persistent background services.
+- Use `get_editor_runtime_status` after starting a persistent template to verify
+  its streams, controllers, and robot driver are active.
+- Use `stop_editor_runtime_services` for an explicit stop request, at the end of
+  a physical demo, or when stale/error status makes continued motion unsafe.
+  Robot-driver shutdown may disable actuator torque, so account for gravity and
+  support the arm when necessary.
+- Keep motion nodes disarmed by default. Arming authorizes motion; it does not
+  justify bypassing joint limits, stale-data suppression, or runtime checks.
 
 ## Agent Build Prompt
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -47,6 +47,31 @@ Do not commit local planning notes, generated scratch exports, API keys, run log
 - Template: a tracked workflow JSON file in `templates/` with `metadata.template: true`.
 - Learned node: a reusable MCP-created node type stored on disk and executed in
   Docker through the learned-node wrapper.
+- Managed runtime service: a camera/CUDA stream, persistent controller, ROS
+  process, or robot driver that continues after its starting cook completes.
+
+## One-Shot Cooks And Managed Services
+
+`run_workflow` and `cook_editor_node` each evaluate a graph target once. A
+managed node can start a background service during that cook, but frames,
+detections, joint feedback, and commands must flow through the service rather
+than repeatedly re-cooking the graph.
+
+Examples include `CV2CameraStream`, `CV2ColorObjectStream`,
+`CUDAImageFilterStream`, robot-driver nodes, and
+`ROS2ContinuousFollowDetectionJoint`.
+
+For MCP-controlled demos:
+
+1. Cook the persistent template or target once.
+2. Call `get_editor_runtime_status` and verify the expected services are active.
+3. Keep robot motion disarmed until the user explicitly authorizes it.
+4. Call `stop_editor_runtime_services` on an explicit stop request, at the end
+   of the physical demo, or when continued motion is unsafe.
+5. Re-check runtime status after stopping.
+
+The stop tool uses each package's normal shutdown path. A robot driver may
+disable actuator torque, so support the arm when gravity could move it.
 
 ## Learned Nodes vs PythonFn
 
@@ -300,6 +325,7 @@ client. MCP exposes read-only resources for quick context:
 - `blacknode://templates`
 - `blacknode://workflows`
 - `blacknode://editor/graph`
+- `blacknode://runtime/status`
 
 The NVIDIA NIM prompts exercise the full live-editor path:
 
@@ -319,6 +345,8 @@ before opening it.
 
 The live editor tools require `editor-server/server.py` to be running at
 `http://127.0.0.1:7777` or `BLACKNODE_EDITOR_URL` to point at the backend.
+Use `get_editor_runtime_status` for managed services and
+`stop_editor_runtime_services` for a safe global runtime shutdown.
 
 ## Editing Checklist For Agents
 

--- a/docs/mcp-test-prompts.md
+++ b/docs/mcp-test-prompts.md
@@ -37,6 +37,41 @@ Using the blacknode MCP resources, read blacknode://nodes and blacknode://templa
 
 Expected result: the client reads `blacknode://nodes` and `blacknode://templates` without needing a tool call.
 
+## Managed Runtime Status
+
+```text
+Using the blacknode MCP tools, inspect the running editor's managed runtime.
+Summarize active camera/CUDA streams, persistent controllers, ROS processes,
+and robot drivers. Do not stop anything.
+```
+
+Expected tool call: `get_editor_runtime_status`.
+
+Expected result: the response mirrors the editor's runtime status and clearly
+identifies whether any managed service is active.
+
+The same status is available read-only through
+`blacknode://runtime/status`.
+
+## Safe Runtime Stop
+
+Only run this prompt when ending a demo and after supporting any physical arm
+that could move when torque is disabled.
+
+```text
+Using the blacknode MCP tools, safely stop all editor-managed runtime services,
+then inspect runtime status and confirm that no persistent controller or robot
+driver remains active.
+```
+
+Expected tool sequence:
+
+1. `stop_editor_runtime_services`
+2. `get_editor_runtime_status`
+
+Expected result: camera/CUDA streams, persistent controllers, ROS processes,
+and robot drivers stop through their package shutdown paths.
+
 ## Open A Blank Editor Tab
 
 ```text

--- a/docs/quickstart-mcp.md
+++ b/docs/quickstart-mcp.md
@@ -123,6 +123,13 @@ After creating a learned node:
 - validate the workflow
 - open it in the editor
 - cook the final Output node
+
+Treat `cook_editor_node` as a one-shot cook. Managed camera streams,
+persistent controllers, and robot drivers may continue after the cook returns;
+do not repeatedly cook them for each frame. Use `get_editor_runtime_status` to
+inspect them. Use `stop_editor_runtime_services` when the user asks to stop the
+demo or physical-robot safety requires shutdown; robot shutdown may disable
+torque, so support an arm when gravity could move it.
 ```
 
 The Blacknode MCP server also exposes this same rule as:
@@ -184,6 +191,32 @@ Expected result:
 - The graph is organized on the canvas.
 - The Output node displays the cooked value.
 - The Runs panel records the execution.
+
+## Managed Runtime Tools
+
+Persistent workflow nodes outlive the one cook that starts them:
+
+| Tool | Use |
+|---|---|
+| `get_editor_runtime_status` | Inspect active camera/CUDA streams, continuous controllers, managed ROS processes, and robot drivers. |
+| `stop_editor_runtime_services` | Stop every editor-managed service through its normal shutdown path. Physical robot drivers may disable torque. |
+
+Runtime status is also available as the read-only MCP resource
+`blacknode://runtime/status`.
+
+After starting a persistent template, use:
+
+```text
+Using the blacknode MCP tools, inspect the editor runtime status and summarize
+active streams, persistent controllers, and robot drivers. Do not stop them.
+```
+
+To end a demo explicitly, use:
+
+```text
+Using the blacknode MCP tools, safely stop all editor-managed runtime services,
+then confirm that no persistent controller or robot driver remains active.
+```
 
 ## NVIDIA NIM Demo Prompt
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -166,7 +166,7 @@ In the browser:
 Expected result:
 
 - The Output node shows `Hello World`.
-- A small live cook status appears while the graph runs.
+- A small run status appears while the graph cooks once.
 - The run is saved in the **Runs** tab.
 
 ## 7. Build the Same Workflow by Hand

--- a/editor-server/run_store.py
+++ b/editor-server/run_store.py
@@ -27,11 +27,8 @@ from typing import Any, Iterable
 
 DEFAULT_MAX_RUNS = 200
 _RUN_FILE_GLOB = "*.json"
-# A long-lived live-cook run emits a start/success/done triple every frame
-# forever; without a cap, buf.events would grow without bound in memory and
-# blow up the JSON file written on finalize. Keep only the most recent
-# events -- run history is for inspecting what just happened, not scrubbing
-# hours of a live stream frame by frame.
+# Bound unusually event-heavy runs so a faulty or very large workflow cannot
+# grow the in-memory buffer and finalized JSON file without limit.
 MAX_BUFFERED_EVENTS = 2000
 
 

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -177,8 +177,6 @@ class UpdatePortsReq(BaseModel):
 class CookReq(BaseModel):
     node_id: str
     port: str = "output"
-    live: bool = False
-    rate_hz: float = 10.0
 
 class CookTargetReq(BaseModel):
     node_id: str
@@ -186,8 +184,6 @@ class CookTargetReq(BaseModel):
 
 class CookGraphReq(BaseModel):
     targets: list[CookTargetReq]
-    live: bool = False
-    rate_hz: float = 10.0
 
 class SetGraphReq(BaseModel):
     nodes: list[dict[str, Any]] = []
@@ -311,6 +307,12 @@ _RUNTIME_MODULES = {
     "robot": "blacknode.pkg.blacknode_robot.robot",
 }
 
+# Package reloads replace node functions before sys.modules is always updated.
+# Resolve stateful robot runtime helpers through the registered launcher—the
+# exact module globals that own the live subprocess table—so status and Stop
+# All cannot silently look at an empty duplicate module.
+_RUNTIME_REGISTRY_ANCHORS = {"robot": "RobotDriverLauncher"}
+
 
 def _runtime_module(module_name: str):
     module = sys.modules.get(module_name)
@@ -322,9 +324,20 @@ def _runtime_module(module_name: str):
         return None
 
 
-def _runtime_module_status(label: str, module_name: str) -> dict[str, Any]:
+def _runtime_callable(label: str, module_name: str, name: str):
+    anchor_name = _RUNTIME_REGISTRY_ANCHORS.get(label)
+    anchor = _NODE_REGISTRY.get(anchor_name) if anchor_name else None
+    candidate = getattr(anchor, "__globals__", {}).get(name) if anchor is not None else None
+    if callable(candidate):
+        return candidate
     runtime = _runtime_module(module_name)
-    if runtime is None or not hasattr(runtime, "runtime_status"):
+    candidate = getattr(runtime, name, None) if runtime is not None else None
+    return candidate if callable(candidate) else None
+
+
+def _runtime_module_status(label: str, module_name: str) -> dict[str, Any]:
+    status_fn = _runtime_callable(label, module_name, "runtime_status")
+    if status_fn is None:
         return {
             "ok": True,
             "active": False,
@@ -334,7 +347,7 @@ def _runtime_module_status(label: str, module_name: str) -> dict[str, Any]:
             "report": f"{label} runtime is not loaded",
         }
     try:
-        return dict(runtime.runtime_status())
+        return dict(status_fn())
     except Exception as exc:
         return {"ok": False, "active": False, "error": f"{type(exc).__name__}: {exc}"}
 
@@ -376,15 +389,15 @@ def _runtime_status() -> dict[str, Any]:
 
 
 def _stop_runtime_module(label: str, module_name: str) -> dict[str, Any]:
-    runtime = _runtime_module(module_name)
-    if runtime is None or not hasattr(runtime, "stop_runtime_services"):
+    stop_fn = _runtime_callable(label, module_name, "stop_runtime_services")
+    if stop_fn is None:
         return {
             "ok": True,
             "stopped": {"streams": 0, "managed_runs": 0, "detached": 0, "cv2_streams": 0, "reasoning_streams": 0},
             "report": f"{label} runtime is not loaded",
         }
     try:
-        return dict(runtime.stop_runtime_services())
+        return dict(stop_fn())
     except Exception as exc:
         return {
             "ok": False,
@@ -1989,74 +2002,6 @@ def _captured_cook_trace(
             _run_store.finalize_success(run_id, value=final_value)
 
 
-def _captured_cook_trace_live(
-    node_id: str,
-    port: str,
-    run_id: str,
-    stop_event: threading.Event,
-    targets: list[tuple[str, str]] | None,
-    rate_hz: float,
-):
-    """Like _captured_cook_trace, but repeats the cook indefinitely at
-    ``rate_hz`` until ``stop_event`` fires, finalizing the run store record
-    only once -- when the loop itself ends, not after every frame.
-
-    Each frame needs graph._cache/_dirty reset first (via _begin_fresh_cook),
-    otherwise _cook_trace's own cache-hit check would just replay the first
-    frame's cached values forever instead of re-invoking node functions --
-    silently freezing the "stream" on frame one.
-    """
-    final_value: Any = None
-    final_error: str | None = None
-    period = 1.0 / max(0.1, rate_hz)
-    try:
-        while not stop_event.is_set():
-            frame_started = time.monotonic()
-            _begin_fresh_cook(clear_status=False)
-            try:
-                for line in _cook_trace(node_id, port, stop_event, targets=targets):
-                    try:
-                        event = json.loads(line)
-                    except (ValueError, TypeError):
-                        event = None
-                    if isinstance(event, dict):
-                        stored_event = _event_for_storage(event)
-                        _run_store.record_event(run_id, stored_event)
-                        if stored_event.get("type") == "done":
-                            if stored_event.get("error"):
-                                final_error = stored_event.get("error")
-                            elif "value" in event:
-                                final_value = stored_event.get("value")
-                        elif stored_event.get("type") == "error" and final_error is None:
-                            final_error = stored_event.get("error")
-                    yield line
-            except _CookStopped:
-                break
-            except Exception as exc:  # noqa: BLE001
-                # A live loop reads from real hardware/network sources each
-                # frame (camera HTTP, ROS2 topics, serial bus) -- a transient
-                # failure there (one dropped frame, one timeout) is normal and
-                # must not permanently end continuous tracking. Report this
-                # frame as failed and keep looping instead of letting the
-                # exception escape and silently kill the whole live run.
-                frame_error = f"{type(exc).__name__}: {exc}"
-                _run_store.record_event(run_id, {"type": "done", "node_id": node_id, "port": port, "error": frame_error})
-                yield _json_line({"type": "done", "port": port, "error": frame_error})
-            # Sleep in small increments so a Stop click lands within ~100ms
-            # regardless of how low rate_hz is, instead of waiting out a
-            # long single sleep.
-            remaining = period - (time.monotonic() - frame_started)
-            while remaining > 0 and not stop_event.is_set():
-                nap = min(0.1, remaining)
-                time.sleep(nap)
-                remaining -= nap
-    finally:
-        if final_error is not None:
-            _run_store.finalize_error(run_id, error=final_error)
-        else:
-            _run_store.finalize_success(run_id, value=final_value)
-
-
 def _stream_in_worker(lines_factory, stop_event: threading.Event, port: str):
     import traceback
 
@@ -2099,12 +2044,7 @@ def cook_stream(req: CookReq):
     stop_event = _prepare_cook()
     _begin_fresh_cook()
     headers = {"X-Blacknode-Run-Id": run_id}
-    if req.live:
-        lines_factory = lambda: _captured_cook_trace_live(
-            req.node_id, req.port, run_id, stop_event, None, req.rate_hz,
-        )
-    else:
-        lines_factory = lambda: _captured_cook_trace(req.node_id, req.port, run_id, stop_event)
+    lines_factory = lambda: _captured_cook_trace(req.node_id, req.port, run_id, stop_event)
     return StreamingResponse(
         _stream_in_worker(lines_factory, stop_event, req.port),
         media_type="application/x-ndjson",
@@ -2144,14 +2084,9 @@ def cook_graph_stream(req: CookGraphReq):
     _begin_fresh_cook()
     headers = {"X-Blacknode-Run-Id": run_id}
     first_node, first_port = targets[0]
-    if req.live:
-        lines_factory = lambda: _captured_cook_trace_live(
-            first_node, first_port, run_id, stop_event, targets, req.rate_hz,
-        )
-    else:
-        lines_factory = lambda: _captured_cook_trace(
-            first_node, first_port, run_id, stop_event, targets=targets,
-        )
+    lines_factory = lambda: _captured_cook_trace(
+        first_node, first_port, run_id, stop_event, targets=targets,
+    )
     return StreamingResponse(
         _stream_in_worker(lines_factory, stop_event, "leaves"),
         media_type="application/x-ndjson",

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -118,7 +118,7 @@ export default function App() {
     checkServer, reset, newTab, insertTab, switchTab, closeTab, duplicateTab,
     openGraphAsTab, openWorkflowAsTab, renameTab, saveActiveWorkflow,
     diveIntoSubnet, exitSubnet, collapseToSubnet, organizeNodes, cookNode, stopCook, stopRuntimeServices, dismissCookStatus, applyRunReplay,
-    handleLearnedNodeEvent, updateParam, liveRun: activeLiveRun, stopLiveRun,
+    handleLearnedNodeEvent, updateParam,
   } = useStore()
 
   const rfInstance = useRef<ReactFlowInstance | null>(null)
@@ -994,17 +994,22 @@ export default function App() {
   const liveStreamCount = nodes.filter(n => (
     (
       n.data.type === 'ROS2ImageStream' ||
+      n.data.type === 'CV2CameraStream' ||
       n.data.type === 'CV2ColorObjectStream' ||
       n.data.type === 'VisionReasoningStream' ||
       n.data.type === 'CUDAImageFilterStream'
     ) &&
     n.data.portResults?.streaming === true
   )).length
-  const liveRunCount = nodes.filter(n => n.data.type === 'ROS2Run' && n.data.portResults?.running === true).length
-  const runtimeActive = liveStreamCount > 0 || liveRunCount > 0
+  const managedRunCount = nodes.filter(n => n.data.type === 'ROS2Run' && n.data.portResults?.running === true).length
+  const controllerCount = nodes.filter(n => (
+    n.data.type === 'ROS2ContinuousFollowDetectionJoint' && n.data.portResults?.running === true
+  )).length
+  const runtimeActive = liveStreamCount > 0 || managedRunCount > 0 || controllerCount > 0
   const runtimeLabel = [
     liveStreamCount ? `${liveStreamCount} stream${liveStreamCount === 1 ? '' : 's'}` : '',
-    liveRunCount ? `${liveRunCount} run${liveRunCount === 1 ? '' : 's'}` : '',
+    managedRunCount ? `${managedRunCount} run${managedRunCount === 1 ? '' : 's'}` : '',
+    controllerCount ? `${controllerCount} controller${controllerCount === 1 ? '' : 's'}` : '',
   ].filter(Boolean).join(' + ')
 
   return (
@@ -1083,23 +1088,6 @@ export default function App() {
             >
               <span className="bn-top-live-dot" />
               <span>{runtimeStopPending ? 'Stopping...' : `Streaming${runtimeLabel ? ` · ${runtimeLabel}` : ''}`}</span>
-              <span className="bn-top-streaming-stop">Stop</span>
-            </button>
-          )}
-
-          {activeLiveRun && (
-            <button
-              className="bn-top-button bn-top-streaming-button"
-              onClick={() => stopLiveRun()}
-              style={activeLiveRun.hasArmedNode ? { background: 'var(--err)', borderColor: 'var(--err)', color: '#fff' } : undefined}
-              title={
-                activeLiveRun.hasArmedNode
-                  ? `Live re-cook of "${activeLiveRun.label}" is armed and sending continuous motion commands. Click to stop.`
-                  : `Live re-cook of "${activeLiveRun.label}" is running. Click to stop.`
-              }
-            >
-              <span className="bn-top-live-dot" />
-              <span>{activeLiveRun.hasArmedNode ? '⚠ Live (armed)' : 'Live'} · {activeLiveRun.label}</span>
               <span className="bn-top-streaming-stop">Stop</span>
             </button>
           )}

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -356,10 +356,10 @@ export const api = {
   ollamaModels: (endpointUrl: string) =>
     req<{ ok: boolean; models: string[]; error?: string }>('GET', `/ollama/models?endpoint_url=${encodeURIComponent(endpointUrl)}`),
   stopRuntime: () => req<RuntimeStopResult>('POST', '/runtime/stop'),
-  cookStream: (node_id: string, port = 'output', onEvent: (event: CookEvent) => void, signal?: AbortSignal, live?: { rateHz: number }) =>
-    streamCook('/cook-stream', { node_id, port, live: Boolean(live), rate_hz: live?.rateHz ?? 10 }, `${node_id}.${port}`, onEvent, signal),
-  cookGraphStream: (targets: GraphRunTarget[], onEvent: (event: CookEvent) => void, signal?: AbortSignal, live?: { rateHz: number }) =>
-    streamCook('/cook-graph-stream', { targets: targets.map(target => ({ node_id: target.id, port: target.port })), live: Boolean(live), rate_hz: live?.rateHz ?? 10 }, `${targets.length} terminal nodes`, onEvent, signal),
+  cookStream: (node_id: string, port = 'output', onEvent: (event: CookEvent) => void, signal?: AbortSignal) =>
+    streamCook('/cook-stream', { node_id, port }, `${node_id}.${port}`, onEvent, signal),
+  cookGraphStream: (targets: GraphRunTarget[], onEvent: (event: CookEvent) => void, signal?: AbortSignal) =>
+    streamCook('/cook-graph-stream', { targets: targets.map(target => ({ node_id: target.id, port: target.port })) }, `${targets.length} terminal nodes`, onEvent, signal),
   cookSubgraphStream: (subnet_id: string, node_id: string, port = 'output', onEvent: (event: CookEvent) => void, signal?: AbortSignal) =>
     streamCook(`/nodes/${subnet_id}/cook-stream`, { node_id, port }, `${node_id}.${port}`, onEvent, signal),
   cookSubgraphGraphStream: (subnet_id: string, targets: GraphRunTarget[], onEvent: (event: CookEvent) => void, signal?: AbortSignal) =>

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -2,7 +2,7 @@ import { memo, useState, useRef, useEffect } from 'react'
 import { Handle, Position, NodeProps, useUpdateNodeInternals } from 'reactflow'
 import { NodeResizer } from '@reactflow/node-resizer'
 import '@reactflow/node-resizer/dist/style.css'
-import { useStore, hasArmedUpstream } from '../store'
+import { useStore } from '../store'
 import { portColor } from '../portColors'
 import { headerColor } from '../categories'
 import { isWireOnlyInput } from '../inputControls'
@@ -281,8 +281,6 @@ function NodeImageInput({
 
 function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const cookNode    = useStore(s => s.cookNode)
-  const stopLiveRun = useStore(s => s.stopLiveRun)
-  const liveRun     = useStore(s => s.liveRun)
   const updateParam = useStore(s => s.updateParam)
   const resizeNode  = useStore(s => s.resizeNode)
   const disconnectEdge = useStore(s => s.disconnectEdge)
@@ -638,38 +636,6 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
           }}
         >
           {data.cooking ? '…' : '▶'}
-        </button>
-        <button
-          onClick={e => {
-            e.stopPropagation()
-            if (liveRun?.nodeId === id) {
-              stopLiveRun()
-              return
-            }
-            if (hasArmedUpstream(nodes, edges, [id])) {
-              const ok = window.confirm(
-                'This chain includes a node with armed=true. Live mode will keep sending real motion ' +
-                'commands to the robot at the live rate until you stop it. Continue?'
-              )
-              if (!ok) return
-            }
-            void cookNode(id, data.outputs[0] ?? 'output', undefined, { rateHz: 10 })
-          }}
-          title={liveRun?.nodeId === id ? 'Stop live re-cook' : 'Live: keep re-cooking this chain until stopped'}
-          style={{
-            background: liveRun?.nodeId === id ? 'var(--err)' : 'rgba(0,0,0,.2)',
-            border: 'none',
-            borderRadius: 4,
-            color: '#fff',
-            cursor: 'pointer',
-            fontSize: 10,
-            padding: '2px 7px',
-            fontFamily: 'var(--font-ui)',
-            flexShrink: 0,
-            marginLeft: 4,
-          }}
-        >
-          {liveRun?.nodeId === id ? '■' : '⟳'}
         </button>
       </div>
 

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -64,18 +64,6 @@ export interface RunReplayState {
   message?: string
 }
 
-// A live run keeps re-cooking the same target chain until stopped (see
-// cookNode's `live` option). hasArmedNode flags whether any upstream node
-// has an `armed: true` param, so the UI can show a persistent Stop control
-// instead of relying on the user to find the node again -- an armed node in
-// a live loop sends real, continuous motion commands at rate_hz.
-export interface LiveRunState {
-  nodeId: string
-  port: string
-  label: string
-  hasArmedNode: boolean
-}
-
 interface UndoSnapshot {
   activeTabId: string
   graph: GraphSnapshot
@@ -112,7 +100,6 @@ interface Store {
   cookActive: boolean
   cookStatusHidden: boolean
   runReplay: RunReplayState
-  liveRun: LiveRunState | null
 
   loadNodeTypes: () => Promise<void>
   loadGraph: () => Promise<void>
@@ -192,9 +179,8 @@ interface Store {
     copyIdMap: Record<string, string> | null,
   ) => Promise<void>
   updateParam: (id: string, key: string, value: unknown) => Promise<void>
-  cookNode: (id: string, port?: string, graphTargets?: GraphRunTarget[], live?: { rateHz: number }) => Promise<void>
+  cookNode: (id: string, port?: string, graphTargets?: GraphRunTarget[]) => Promise<void>
   stopCook: () => void
-  stopLiveRun: () => void
   stopRuntimeServices: () => Promise<RuntimeStopResult>
   dismissCookStatus: () => void
   applyRunReplay: (record: RunRecord, cursor: number, playing: boolean) => void
@@ -594,28 +580,6 @@ function fullDetail(value: unknown): string | undefined {
 
 function appendCookLog(log: CookLogEntry[], entry: CookLogEntry): CookLogEntry[] {
   return [...log, entry].slice(-80)
-}
-
-// Live mode re-runs a chain forever until stopped -- if any upstream node
-// has armed=true (ROS2NativeSetJoint, ROS2RotateJoint,
-// ROS2NativeFollowDetectionJoint, ...), that means real, continuous motion
-// commands at the live rate, not just a repeated preview. Exported so the
-// UI can check this before starting live mode (to confirm) and cookNode can
-// check it after (to decide whether to show a persistent Stop control).
-export function hasArmedUpstream(nodes: Node<NodeData>[], edges: Edge[], startIds: Iterable<string>): boolean {
-  const visited = new Set<string>()
-  const stack = [...startIds]
-  while (stack.length > 0) {
-    const nid = stack.pop() as string
-    if (visited.has(nid)) continue
-    visited.add(nid)
-    const node = nodes.find(n => n.id === nid)
-    if (node?.data.params?.armed === true) return true
-    for (const edge of edges) {
-      if (edge.target === nid) stack.push(edge.source)
-    }
-  }
-  return false
 }
 
 const EMPTY_REPLAY: RunReplayState = {
@@ -1096,7 +1060,6 @@ export const useStore = create<Store>((set, get) => ({
   cookActive: false,
   cookStatusHidden: false,
   runReplay: EMPTY_REPLAY,
-  liveRun: null,
   subnetStack: [],
 
   checkServer: async () => {
@@ -2527,12 +2490,11 @@ export const useStore = create<Store>((set, get) => ({
     await api.updateParam(id, key, value)
   },
 
-  cookNode: async (id, port = 'output', graphTargets, live) => {
+  cookNode: async (id, port = 'output', graphTargets) => {
     const cookTabId = get().activeTabId
     const stack = get().subnetStack
     const activeSubnetId = stack.length > 0 ? stack[stack.length - 1].subnetId : null
     const cookNodes = get().nodes
-    const cookEdges = get().edges
     const targets = graphTargets?.length ? graphTargets : [{ id, port }]
     const graphRun = Boolean(graphTargets?.length)
     const targetIds = new Set(targets.map(target => target.id))
@@ -2543,7 +2505,7 @@ export const useStore = create<Store>((set, get) => ({
       ? `Graph (${targets.length} terminal node${targets.length === 1 ? '' : 's'})`
       : nodeRunLabel(cookNodes, id)
     const startNode = cookNodes.find(n => n.id === id)
-    const liveRunId = `live-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+    const replayRunId = `run-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
     const liveStartedAt = new Date().toISOString()
     const liveEvents: RunRecord['events'] = []
     let liveReplayDelay = 0
@@ -2553,7 +2515,7 @@ export const useStore = create<Store>((set, get) => ({
       liveEvents.push(stamped)
       const eventIndex = liveEvents.length - 1
       const record: RunRecord = {
-        run_id: liveRunId,
+        run_id: replayRunId,
         started_at: liveStartedAt,
         finished_at: stamped.type === 'done' || finalSuccess ? stamped.ts as string : null,
         duration_ms: null,
@@ -2576,29 +2538,13 @@ export const useStore = create<Store>((set, get) => ({
       const delay = liveReplayDelay
       liveReplayDelay += 170
       window.setTimeout(() => {
-        if (get().runReplay.runId !== liveRunId) return
+        if (get().runReplay.runId !== replayRunId) return
         get().applyRunReplay(record, eventIndex, stamped.type !== 'done' && !finalSuccess)
       }, delay)
     }
     const applyCookEvent = (event: CookEvent) => {
-      // The replay-scrub cascade schedules each event `delay += 170ms`
-      // further out -- fine for a bounded one-shot run, but a live stream
-      // never ends, so that delay would grow without bound. Skip it in
-      // live mode; there's no "final state" to scrub to yet anyway.
-      if (!live) queueLiveReplay(event)
+      queueLiveReplay(event)
       if (event.type === 'done') {
-        if (live) {
-          // Every frame of a live loop ends with its own `done` -- that
-          // means "this frame finished," not "the whole live run is over."
-          // Only log it; cookActive/liveRun/node.cooking get torn down
-          // once in cookNode's `finally`, when the stream actually closes.
-          set(s => ({
-            ...syncTabCookState(s, cookTabId, {
-              cookLog: appendCookLog(tabCookLog(s, cookTabId), cookEventLogEntry(event, s.activeTabId === cookTabId ? s.nodes : cookNodes)),
-            }),
-          }))
-          return
-        }
         set(s => ({
           ...syncTabCookState(s, cookTabId, {
             cookActive: false,
@@ -2701,8 +2647,6 @@ export const useStore = create<Store>((set, get) => ({
       ts: Date.now(),
     }]
 
-    const hasArmedNode = live ? hasArmedUpstream(cookNodes, cookEdges, targetIds) : false
-
     set(s => ({
       ...syncTabCookState(s, cookTabId, {
         cookActive: true,
@@ -2710,7 +2654,7 @@ export const useStore = create<Store>((set, get) => ({
         cookStatusHidden: false,
       }),
       runReplay: {
-        runId: liveRunId,
+        runId: replayRunId,
         cursor: -1,
         total: 0,
         playing: true,
@@ -2718,7 +2662,6 @@ export const useStore = create<Store>((set, get) => ({
         currentEventType: 'queued',
         message: graphRun ? `Queued all ${targets.length} terminal nodes` : `Queued ${runLabel}.${port}`,
       },
-      liveRun: live ? { nodeId: runNodeId, port: runPort, label: runLabel, hasArmedNode } : s.liveRun,
       nodes: s.nodes.map(n => ({
         ...n,
         data: targetIds.has(n.id)
@@ -2738,35 +2681,15 @@ export const useStore = create<Store>((set, get) => ({
 
     cookAbort = new AbortController()
     const signal = cookAbort.signal
-    // Live mode is only wired up for the top-level graph (see api.ts) --
-    // subnets still cook once per click. Rather than silently downgrading a
-    // "Live" click to a single cook with no explanation, say so.
-    if (live && activeSubnetId) {
-      set(s => ({
-        ...syncTabCookState(s, cookTabId, {
-          cookLog: appendCookLog(tabCookLog(s, cookTabId), {
-            id: `${Date.now()}-${id}-live-unsupported`,
-            kind: 'error',
-            label: runLabel,
-            message: 'Live mode is not supported inside a subnet yet -- cooking once instead.',
-            nodeId: graphRun ? undefined : id,
-            port: runPort,
-            ts: Date.now(),
-          }),
-        }),
-        liveRun: null,
-      }))
-    }
-    const liveOpts = live && !activeSubnetId ? { rateHz: live.rateHz } : undefined
     try {
       if (activeSubnetId && graphRun) {
         await api.cookSubgraphGraphStream(activeSubnetId, targets, applyCookEvent, signal)
       } else if (activeSubnetId) {
         await api.cookSubgraphStream(activeSubnetId, id, port, applyCookEvent, signal)
       } else if (graphRun) {
-        await api.cookGraphStream(targets, applyCookEvent, signal, liveOpts)
+        await api.cookGraphStream(targets, applyCookEvent, signal)
       } else {
-        await api.cookStream(id, port, applyCookEvent, signal, liveOpts)
+        await api.cookStream(id, port, applyCookEvent, signal)
       }
     } catch (e: any) {
       const stopped = e?.name === 'AbortError' || signal.aborted
@@ -2799,26 +2722,7 @@ export const useStore = create<Store>((set, get) => ({
       }))
     } finally {
       cookAbort = null
-      // Every frame of a live run suppresses the usual done-event cleanup
-      // (see applyCookEvent above), so this is the one place that always
-      // runs exactly once when the stream truly ends -- via Stop, a server-
-      // side error, or the connection closing -- regardless of which path
-      // got us here.
-      if (liveOpts) {
-        set(s => ({
-          ...syncTabCookState(s, cookTabId, { cookActive: false }),
-          liveRun: s.liveRun?.nodeId === runNodeId ? null : s.liveRun,
-          nodes: s.activeTabId === cookTabId
-            ? s.nodes.map(n => (targetIds.has(n.id) ? { ...n, data: { ...n.data, cooking: false } } : n))
-            : s.nodes,
-        }))
-      }
     }
-  },
-
-  stopLiveRun: () => {
-    set({ liveRun: null })
-    get().stopCook()
   },
 
   stopCook: () => {
@@ -2872,9 +2776,11 @@ export const useStore = create<Store>((set, get) => ({
       nodes: s.nodes.map(n => {
         const runtimeNode = (
           n.data.type === 'ROS2ImageStream' ||
+          n.data.type === 'CV2CameraStream' ||
           n.data.type === 'CV2ColorObjectStream' ||
           n.data.type === 'VisionReasoningStream' ||
           n.data.type === 'CUDAImageFilterStream' ||
+          n.data.type === 'ROS2ContinuousFollowDetectionJoint' ||
           n.data.type === 'ROS2Run' ||
           n.data.type === 'ROS2Launch'
         )

--- a/python/blacknode/mcp/server.py
+++ b/python/blacknode/mcp/server.py
@@ -45,6 +45,13 @@ WORKFLOW_BUILDER_INSTRUCTIONS = """When building Blacknode workflows:
 7. After creating a learned node, call list_learned_nodes, use it in the visual
    workflow, validate the graph, open it in the editor, and cook the final
    Output node.
+8. Treat cook_editor_node as a one-shot graph cook. Camera streams, robot
+   drivers, and persistent controller nodes may continue after that cook
+   completes; do not repeatedly cook them to process new frames.
+9. Use get_editor_runtime_status to inspect managed services. When the user
+   asks to stop a demo, or a physical-robot safety condition requires it, call
+   stop_editor_runtime_services. This stops streams and controllers and gives
+   robot drivers their normal shutdown path, which may disable torque.
 
 Learned-node code is registered as a node type, but it never runs in the
 Blacknode host process. It executes through the Docker sandbox wrapper.
@@ -122,6 +129,16 @@ def editor_graph_resource() -> str:
 def runs_resource() -> str:
     """Recent editor run summaries as JSON."""
     return _safe_editor_resource("blacknode://runs", tools.list_recent_runs)
+
+
+@mcp.resource(
+    "blacknode://runtime/status",
+    mime_type="application/json",
+    description="Managed stream, persistent controller, and robot-driver status.",
+)
+def runtime_status_resource() -> str:
+    """Current managed editor runtime status as JSON."""
+    return _safe_editor_resource("blacknode://runtime/status", tools.get_editor_runtime_status)
 
 
 @mcp.prompt(
@@ -339,8 +356,20 @@ def cook_editor_node(
     port: str = "value",
     editor_url: str | None = None,
 ) -> dict[str, Any]:
-    """Ask a running Blacknode editor UI to cook a node and update the canvas."""
+    """Cook a node once; managed stream nodes may continue independently."""
     return tools.cook_editor_node(node_id=node_id, port=port, editor_url=editor_url)
+
+
+@mcp.tool()
+def get_editor_runtime_status(editor_url: str | None = None) -> dict[str, Any]:
+    """Inspect managed streams, persistent controllers, and robot drivers."""
+    return tools.get_editor_runtime_status(editor_url=editor_url)
+
+
+@mcp.tool()
+def stop_editor_runtime_services(editor_url: str | None = None) -> dict[str, Any]:
+    """Safely stop all editor-managed services, including physical robot drivers."""
+    return tools.stop_editor_runtime_services(editor_url=editor_url)
 
 
 @mcp.tool()

--- a/python/blacknode/mcp/tools.py
+++ b/python/blacknode/mcp/tools.py
@@ -674,7 +674,34 @@ def cook_editor_node(
         "ok": bool(result.get("ok", True)),
         "editor_url": base_url,
         "action": result.get("action", result),
-        "note": "The open Blacknode editor will cook the node on its next action poll.",
+        "note": (
+            "The open Blacknode editor will cook the node once on its next action poll. "
+            "Managed stream nodes may keep running after that cook completes."
+        ),
+    }
+
+
+def get_editor_runtime_status(*, editor_url: str | None = None) -> dict[str, Any]:
+    """Inspect managed streams, robot drivers, and persistent controllers."""
+    base_url, result = _editor_request_json("GET", "/runtime/status", editor_url=editor_url)
+    return {
+        "ok": bool(result.get("ok", True)),
+        "editor_url": base_url,
+        "runtime": result,
+    }
+
+
+def stop_editor_runtime_services(*, editor_url: str | None = None) -> dict[str, Any]:
+    """Safely stop every managed stream/controller/driver owned by the editor."""
+    base_url, result = _editor_request_json("POST", "/runtime/stop", editor_url=editor_url)
+    return {
+        "ok": bool(result.get("ok", True)),
+        "editor_url": base_url,
+        "runtime": result,
+        "note": (
+            "Stopped managed runtime services. Robot drivers receive their normal shutdown "
+            "path, which may disable actuator torque."
+        ),
     }
 
 

--- a/skills/blacknode-workflow/SKILL.md
+++ b/skills/blacknode-workflow/SKILL.md
@@ -2,9 +2,10 @@
 name: blacknode-workflow
 description: >
   Use this skill when the task asks an agent to create, edit, validate, run,
-  export, debug, visualize, or open Blacknode workflows. Trigger phrases include
-  Blacknode, visual workflow, node graph, MCP workflow builder, run replay,
-  NVIDIA NIM workflow, workflow JSON, open in editor, and export to Python.
+  export, debug, visualize, extend, or open Blacknode workflows. Trigger phrases
+  include Blacknode, visual workflow, node graph, MCP workflow builder, run
+  replay, NVIDIA NIM workflow, workflow JSON, custom node, open in editor, and
+  framework export.
 ---
 
 # Blacknode Workflow
@@ -20,11 +21,12 @@ Use this skill for:
 - Loading, validating, or repairing `blacknode.workflow` JSON.
 - Opening a workflow in the running visual editor.
 - Running a workflow or template and inspecting the structured event log.
-- Exporting a workflow to readable Python.
+- Exporting or importing a workflow with Python round-trip, LangGraph, CrewAI, AutoGen, Swarm, or NVIDIA Agent Stack.
+- Creating persistent custom nodes and community node packs.
 - Creating NVIDIA NIM, local NIM, RAG, tool-agent, or research-pipeline demos.
 
 Use the ordinary answer path for prose-only questions. Use this skill when the
-workflow artifact, editor state, run trace, or exported Python matters.
+workflow artifact, editor state, run trace, custom node, or framework export matters.
 
 ## Available Surfaces
 
@@ -59,6 +61,10 @@ blacknode doctor
 blacknode validate templates\text-pipeline.json
 blacknode run templates\text-pipeline.json
 blacknode export-python templates\text-pipeline.json --output workflow.py
+blacknode import-python workflow.py --output imported.workflow.json
+blacknode export-framework templates\text-pipeline.json --target langgraph --output workflow.langgraph.py
+blacknode import-python workflow.langgraph.py --output imported-langgraph.workflow.json
+blacknode export-framework templates\text-pipeline.json --target nvidia-agent-stack --output workflow.nvidia-agent-stack.py
 ```
 
 ## MCP Flow
@@ -68,12 +74,94 @@ blacknode export-python templates\text-pipeline.json --output workflow.py
 3. Prefer `run_template_in_editor` for demo paths that should appear in the UI.
 4. For custom graphs, call `create_workflow`, `add_node`, and `connect_nodes`.
 5. Call `validate_workflow` after each meaningful mutation.
-6. Call `run_workflow` for headless execution or `cook_editor_node` for live UI execution.
-7. Call `list_recent_runs` and `get_run` to inspect replay events, model calls, tool calls, and errors.
-8. Call `export_python` when the user needs a handoff script.
+6. Call `run_workflow` for a headless one-shot run or `cook_editor_node` for a one-shot editor cook. Managed stream nodes may remain active after the cook completes.
+7. Call `get_editor_runtime_status` to inspect managed camera streams, persistent controllers, and robot drivers.
+8. Call `stop_editor_runtime_services` when the user asks to stop a demo or physical-robot safety requires shutdown.
+9. Call `list_recent_runs` and `get_run` to inspect replay events, model calls, tool calls, and errors.
+10. Call `export_python` when the user needs a handoff script.
+11. Use `blacknode import-python`, `/import/python`, the editor `Import` button, or canvas file drop when a workflow JSON, Python export, or LangGraph export should be restored as a visual graph.
 
 Every mutation should be followed by validation. If validation reports a port
 or type error, inspect `get_node_schema` and fix the graph instead of guessing.
+
+## Managed Runtime Safety
+
+- A cook evaluates the graph once. Do not repeatedly cook a stream or controller
+  node to process new frames, detections, or robot feedback.
+- Nodes such as `CV2CameraStream`, `CV2ColorObjectStream`,
+  `CUDAImageFilterStream`, robot drivers, and
+  `ROS2ContinuousFollowDetectionJoint` own persistent background services.
+- Use `get_editor_runtime_status` after starting a persistent template to verify
+  its streams, controllers, and robot driver are active.
+- Use `stop_editor_runtime_services` for an explicit stop request, at the end of
+  a physical demo, or when stale/error status makes continued motion unsafe.
+  Robot-driver shutdown may disable actuator torque, so account for gravity and
+  support the arm when necessary.
+- Keep motion nodes disarmed by default. Arming authorizes motion; it does not
+  justify bypassing joint limits, stale-data suppression, or runtime checks.
+
+## Agent Build Prompt
+
+When an agent builds a workflow, use this operating prompt:
+
+```text
+You are building a typed Blacknode workflow. Keep planning reasoning internal,
+then return a concise graph plan with node ids, node types, key params, edges,
+entrypoint, and expected result.
+
+Build loop:
+1. Understand the user goal and choose the smallest runnable graph.
+2. Inspect list_nodes or get_node_schema before using unfamiliar nodes.
+3. Create or load a workflow.
+4. Add nodes with stable, descriptive ids.
+5. Connect only declared output ports to declared input ports.
+6. Validate after each meaningful mutation.
+7. If validation fails, read the code, path, message, and suggestion, then fix
+   the graph instead of retrying the same edge.
+8. Run the final Output or explicit entrypoint.
+9. Open the workflow in the editor when the user needs visual proof.
+10. Export Python or a framework target only after validation is clean.
+```
+
+## Node Catalog Quick Map
+
+Use `list_nodes` for the live catalog. Current core groups:
+
+| Category | Use for | Common nodes |
+|---|---|---|
+| Values | Constants and model handles | `Text`, `Int`, `Float`, `Bool`, `Dict`, `Model` |
+| Core | Basic graph composition and output | `Concat`, `Output`, `Print`, `Switch`, `Literal`, `ForEach` |
+| AI | LLM calls, agent loops, tool calls | `LLMAgent`, `PythonFn`, `ToolCall`, `ToolBox`, `AgentLoop`, `EmbedText` |
+| NVIDIA | Hosted/local NIM and NVIDIA demo flows | `NIMAgent`, `NIMBenchmark`, `NIMDockerCommand`, `NIMHealthCheck`, `NVIDIASystemCheck` |
+| RAG | Chunking, simple indexing, retrieval context | `TextChunker`, `KeywordIndex`, `KeywordSearch`, `RAGContext` |
+| IO | Files, folders, HTTP, JSON, CSV | `FileRead`, `FileWrite`, `DirectoryList`, `HTTPGet`, `JSONParse`, `JSONDump`, `CSVRead`, `CSVWrite` |
+| API | HTTP request construction | `APIRequestBuilder`, `HTTPRequest` |
+| Database | SQLite operations | `SQLiteQuery`, `SQLiteExec` |
+| Flow | Data routing and collection transforms | `Branch`, `Gate`, `Map`, `Filter`, `Reduce` |
+| Search | Web/search result helpers | `WebSearchURL`, `SearchResultExtractor`, `SearchResultsFormat` |
+| Routing | Model/provider choice | `LLMModelRouter` |
+| Subnet | Visual subgraph boundaries | `SubnetInput`, `SubnetOutput`; build full `Subnet` nodes in the editor |
+
+## Graph Reliability Rules
+
+- Treat Blacknode workflows as DAGs. Do not create cycles or back-edges.
+- Always connect from `outputs` to `inputs`; never invent port names.
+- Respect types: `Any` accepts everything, exact type matches are valid, and
+  Text/Number compatibility is limited by `ports_compatible`.
+- Use adapter nodes when types do not match: `JSONParse`, `JSONDump`,
+  `PythonFn`, `Concat`, `Branch`, `Gate`, or a purpose-built custom node.
+- Keep ids stable and readable: `prompt`, `retriever`, `agent`, `report`,
+  `out` are better than generated ids when constructing demos.
+- Put the final user-visible value into an `Output` node or set an explicit
+  `entrypoint`.
+- Use `input_defaults` and params for fixed values; use edges for values that
+  should come from upstream nodes.
+- Do not save runtime-only fields such as `cookResult`, `cookError`,
+  `cooking`, or `cookPort`.
+- For NVIDIA demos, state clearly whether the workflow uses hosted NIM, a
+  generated local NIM launch command, or a custom OpenAI-compatible endpoint.
+- If MCP returns an error with `Suggestion:`, apply that suggestion before
+  trying another mutation.
 
 ## NVIDIA Workflow Pattern
 

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -20,6 +20,15 @@ class AgentSkillTests(unittest.TestCase):
                 self.assertIn("name: blacknode-workflow", text)
                 self.assertIn("blacknode mcp --transport streamable-http", text)
                 self.assertIn("validate_workflow", text)
+                self.assertIn("get_editor_runtime_status", text)
+                self.assertIn("stop_editor_runtime_services", text)
+                self.assertIn("one-shot editor cook", text)
+
+        self.assertEqual(
+            paths[0].read_text(encoding="utf-8"),
+            paths[1].read_text(encoding="utf-8"),
+            "canonical and repository-local Blacknode skills must stay synchronized",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -18,6 +19,20 @@ import server  # noqa: E402
 
 
 class EditorRuntimeTests(unittest.TestCase):
+    def test_robot_runtime_helpers_follow_registered_launcher_state(self):
+        status_fn = lambda: {"ok": True, "active": True, "managed_runs": [{"run_id": "robot"}]}
+        stop_fn = lambda: {"ok": True, "stopped": {"managed_runs": 1}}
+        anchor = SimpleNamespace(__globals__={
+            "runtime_status": status_fn,
+            "stop_runtime_services": stop_fn,
+        })
+        with (
+            patch.dict(server._NODE_REGISTRY, {"RobotDriverLauncher": anchor}),
+            patch.object(server, "_RUNTIME_REGISTRY_ANCHORS", {"robot": "RobotDriverLauncher"}),
+        ):
+            self.assertIs(server._runtime_callable("robot", "unused", "runtime_status"), status_fn)
+            self.assertIs(server._runtime_callable("robot", "unused", "stop_runtime_services"), stop_fn)
+
     def test_export_workflow_infers_entrypoint_for_multi_output_image_graph(self):
         workflow = {
             "kind": "blacknode.workflow",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,6 +18,24 @@ class NonTtyStringIO(io.StringIO):
 
 
 class McpServerTests(unittest.TestCase):
+    def test_agent_instructions_explain_one_shot_cooks_and_runtime_safety(self):
+        text = server.WORKFLOW_BUILDER_INSTRUCTIONS
+
+        self.assertIn("one-shot graph cook", text)
+        self.assertIn("get_editor_runtime_status", text)
+        self.assertIn("stop_editor_runtime_services", text)
+        self.assertIn("disable torque", text)
+
+    def test_runtime_status_resource_uses_editor_runtime_tool(self):
+        with patch.object(
+            server.tools,
+            "get_editor_runtime_status",
+            return_value={"ok": True, "runtime": {"active": True}},
+        ):
+            payload = server.runtime_status_resource()
+
+        self.assertIn('"active": true', payload)
+
     def test_stdio_terminal_hint_is_written_to_stderr_for_humans(self):
         stderr = TtyStringIO()
         with (

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -344,6 +344,47 @@ class CreateEditorWorkflowTabTests(unittest.TestCase):
             json.loads(requests[0][0].data.decode("utf-8")),
             {"node_id": "out", "port": "value"},
         )
+        self.assertIn("cook the node once", result["note"])
+
+    def test_gets_runtime_status_and_safely_stops_services(self):
+        requests = []
+
+        class FakeResponse:
+            def __init__(self, body):
+                self.body = body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps(self.body).encode("utf-8")
+
+        def fake_urlopen(req, timeout):
+            requests.append((req, timeout))
+            if req.full_url.endswith("/runtime/status"):
+                return FakeResponse({"ok": True, "active": True, "modules": {"robot": {"active": True}}})
+            if req.full_url.endswith("/runtime/stop"):
+                return FakeResponse({"ok": True, "stopped": {"managed_runs": 1}})
+            raise AssertionError(f"Unexpected URL: {req.full_url}")
+
+        with patch.object(t.urllib_request, "urlopen", side_effect=fake_urlopen):
+            status = t.get_editor_runtime_status(editor_url="http://editor")
+            stopped = t.stop_editor_runtime_services(editor_url="http://editor")
+
+        self.assertTrue(status["ok"])
+        self.assertTrue(status["runtime"]["modules"]["robot"]["active"])
+        self.assertEqual(stopped["runtime"]["stopped"]["managed_runs"], 1)
+        self.assertIn("disable actuator torque", stopped["note"])
+        self.assertEqual(
+            [(req.get_method(), req.full_url) for req, _ in requests],
+            [
+                ("GET", "http://editor/runtime/status"),
+                ("POST", "http://editor/runtime/stop"),
+            ],
+        )
 
     def test_runs_template_in_editor_and_cooks_output(self):
         requests = []


### PR DESCRIPTION
## What changed
- removed generic continuous graph re-cooking controls
- made runtime streaming controls manage persistent package services
- fixed robot runtime status and Stop All to use the live registered driver state
- updated editor/runtime documentation

## Why
Continuous camera and robot feedback belongs in managed stream services, not repeated workflow execution. This prevents duplicate cooks and preserves safe runtime ownership.

## Validation
- 307 Python tests passed (8 skipped)
- editor production build passed
- Cubee workflow validation passed