### PR TITLE
Add unified robot selector and expanding joint ports

### DIFF
--- a/.agents/skills/blacknode-workflow/SKILL.md
+++ b/.agents/skills/blacknode-workflow/SKILL.md
@@ -130,6 +130,9 @@ or type error, inspect `get_node_schema` and fix the graph instead of guessing.
 
 ## Robot Profile and Calibration Semantics
 
+- Use the generic `Robot` selector in new workflows. Built-in and saved profiles
+  appear in its dropdown; `RobotDriverPreset` and `RobotProfileLoad` are hidden
+  compatibility names for existing graphs.
 - Build custom robots with `RobotJointDefinition` → `RobotJointList` →
   `RobotDefinition` → `RobotProfileSave`. Prefer duplicating a built-in profile
   with `RobotProfileDuplicate` when it is a close mechanical starting point.
@@ -144,9 +147,13 @@ or type error, inspect `get_node_schema` and fix the graph instead of guessing.
   Recording observes hand-guided extrema; it never commands motion. Capture an
   explicit home pose, observe every configured joint, and keep a positive
   safety margin inside the physical extrema before saving.
-- Feed discovery hardware identity into `RobotProfileLoad` and
+- Feed discovery hardware identity into `Robot` and
   `RobotCalibrationRecorder` so the matching device calibration is selected.
   Never replace a missing hardware identity with a generic shared calibration.
+- USB VID/PID values come from discovery and may filter adapter models; they are
+  not random user-assigned IDs. The USB serial or device path identifies the
+  physical assembly for calibration. Leave manual identity overrides blank in
+  ordinary workflows.
 - Base-profile limits are provisional until the physical assembly is calibrated.
   Do not discover limits by driving an armed joint into a hard stop.
 

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ editor-server/blacknode_graph.json
 editor-server/api_keys.json
 editor-server/custom_models.json
 editor-server/runs/
+editor-server/robots/
 editor-server/.driver-*.json
 /trajectories/
 /robots/

--- a/docs/so-arm101-five-minute-demo.md
+++ b/docs/so-arm101-five-minute-demo.md
@@ -24,7 +24,9 @@ otherwise it prepares the local rosbridge service automatically.
 1. Start Blacknode and open **Templates**.
 2. Plug in and power the SO-ARM101.
 3. Open **SO-ARM101 Motion Test** from `blacknode-robot`.
-4. Confirm `RobotDriverPreset.preset` is `so_arm101`.
+4. Confirm the generic `Robot` dropdown is set to `so_arm101`. Its hardware
+   input is already connected to USB discovery, so a saved device calibration
+   is selected automatically.
 5. Keep `ROS2SetJoint.armed` set to `false`.
 6. Press **Run**.
 7. Inspect **Robot Connection Dashboard**. USB, driver, ROS 2, and live state

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -50,7 +50,9 @@ _run_store      = RunStore(_RUNS_DIR)
 _save_timer: threading.Timer | None = None
 _SUBGRAPH_NODE_TYPES = {"Subnet", "SubnetAsTool", "VisualAgentLoop"}
 _TOOLBOX_NODE_TYPES = {"ToolBox"}
-_DYNAMIC_PORT_TYPES = {*_SUBGRAPH_NODE_TYPES, "SubnetInput", "SubnetOutput", *_TOOLBOX_NODE_TYPES}
+_JOINT_LIST_NODE_TYPES = {"RobotJointList"}
+_NUMBERED_INPUT_NODE_TYPES = {*_TOOLBOX_NODE_TYPES, *_JOINT_LIST_NODE_TYPES}
+_DYNAMIC_PORT_TYPES = {*_SUBGRAPH_NODE_TYPES, "SubnetInput", "SubnetOutput", *_NUMBERED_INPUT_NODE_TYPES}
 _WORKFLOW_KIND = "blacknode.workflow"
 _WORKFLOW_SCHEMA_VERSION = 1
 _SECRET_FIELD_RE = re.compile(r"(api[_-]?key|token|secret|password|credential)", re.I)
@@ -591,6 +593,29 @@ def _sync_toolbox_ports(toolbox_meta: dict, edges: list[dict] | None = None) -> 
     toolbox_meta["input_defaults"] = {}
 
 
+def _joint_port_sort_key(port: str) -> tuple[int, str]:
+    match = re.fullmatch(r"joint_(\d+)", str(port))
+    return (int(match.group(1)), str(port)) if match else (999_999, str(port))
+
+
+def _sync_joint_list_ports(meta: dict, edges: list[dict] | None = None) -> None:
+    """Keep RobotJointList metadata aligned with connected numbered sockets."""
+    fn = _NODE_REGISTRY.get("RobotJointList")
+    inputs = [str(port) for port in list(meta.get("inputs") or []) if str(port).startswith("joint_")]
+    if edges is not None:
+        inputs = sorted({
+            str(edge.get("to_port"))
+            for edge in edges
+            if edge.get("to") == meta.get("id") and str(edge.get("to_port", "")).startswith("joint_")
+        }, key=_joint_port_sort_key)
+    input_types = dict(meta.get("input_types", {}))
+    meta["inputs"] = inputs
+    meta["input_types"] = {port: input_types.get(port, "Dict") for port in inputs}
+    meta["outputs"] = getattr(fn, "_bn_outputs", ["joints", "count", "report"])
+    meta["output_types"] = getattr(fn, "_bn_output_types", {"joints": "List", "count": "Int", "report": "Text"})
+    meta["input_defaults"] = {}
+
+
 def _default_visual_agent_loop_subgraph() -> dict:
     node_meta = {
         "loop_in": {
@@ -879,6 +904,8 @@ def _sync_dynamic_node_meta(meta: dict, edges: list[dict] | None = None) -> bool
         _sync_subgraph_node_ports(meta)
     elif meta.get("type") in _TOOLBOX_NODE_TYPES:
         _sync_toolbox_ports(meta, edges)
+    elif meta.get("type") in _JOINT_LIST_NODE_TYPES:
+        _sync_joint_list_ports(meta, edges)
     changed = before != _meta_fingerprint(meta)
 
     node_id = meta.get("id")
@@ -1095,8 +1122,8 @@ def update_ports(node_id: str, req: UpdatePortsReq):
     if node_id not in _session.node_meta:
         raise HTTPException(404, "Node not found")
     meta = _session.node_meta[node_id]
-    if meta["type"] not in _TOOLBOX_NODE_TYPES:
-        raise HTTPException(400, "Only ToolBox supports editable root ports")
+    if meta["type"] not in _NUMBERED_INPUT_NODE_TYPES:
+        raise HTTPException(400, "This node does not support editable root ports")
 
     if req.inputs is not None:
         meta["inputs"] = req.inputs
@@ -1111,7 +1138,10 @@ def update_ports(node_id: str, req: UpdatePortsReq):
     if req.multi_input_ports is not None:
         meta["multi_input_ports"] = req.multi_input_ports
 
-    _sync_toolbox_ports(meta)
+    if meta["type"] in _TOOLBOX_NODE_TYPES:
+        _sync_toolbox_ports(meta)
+    else:
+        _sync_joint_list_ports(meta)
     _session.graph._mark_dirty(node_id)
     _save()
     return meta
@@ -1139,6 +1169,12 @@ def connect(req: ConnectReq):
             meta["inputs"] = [*inputs, req.to_port]
             meta["input_types"] = {**meta.get("input_types", {}), req.to_port: "Fn"}
         _sync_toolbox_ports(meta)
+    elif meta and meta.get("type") in _JOINT_LIST_NODE_TYPES and req.to_port.startswith("joint_"):
+        inputs = list(meta.get("inputs", []))
+        if req.to_port not in inputs:
+            meta["inputs"] = [*inputs, req.to_port]
+            meta["input_types"] = {**meta.get("input_types", {}), req.to_port: "Dict"}
+        _sync_joint_list_ports(meta)
     _save()
     return {"ok": True}
 
@@ -1153,6 +1189,8 @@ def disconnect(from_id: str, from_port: str, to_id: str, to_port: str):
     meta = _session.node_meta.get(to_id)
     if meta and meta.get("type") in _TOOLBOX_NODE_TYPES:
         _sync_toolbox_ports(meta, _session.graph._edges)
+    elif meta and meta.get("type") in _JOINT_LIST_NODE_TYPES:
+        _sync_joint_list_ports(meta, _session.graph._edges)
     _save()
     return {"ok": True}
 

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -331,9 +331,18 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const updateNodeInternals = useUpdateNodeInternals()
   const color       = headerColor(data.type)
   const isToolBox   = data.type === 'ToolBox'
+  const isRobotJointList = data.type === 'RobotJointList'
   const isManualMove = data.type === 'ROS2ManualMove' || data.type === 'ROS2TeachMode'
   const isRobotCalibration = data.type === 'RobotCalibrationRecorder'
-  const visibleInputs = data.inputs ?? []
+  const visibleInputs = isRobotJointList
+    ? (data.inputs ?? []).filter(port => edges.some(edge => edge.target === id && edge.targetHandle === port))
+    : (data.inputs ?? [])
+  const usedJointNumbers = new Set(visibleInputs.map(port => {
+    const value = Number(port.split('_').pop())
+    return Number.isFinite(value) ? value : 0
+  }))
+  let nextJointNumber = 1
+  while (usedJointNumbers.has(nextJointNumber)) nextJointNumber += 1
   const inputsKey = visibleInputs.join('|')
   const outputsKey = (data.outputs ?? []).join('|')
   // Explicit OutputImage nodes always render their image. Dashboard producers
@@ -972,7 +981,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
 
       {/* ports */}
       <div style={{ flex: 1, padding: '6px 0', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-        {isToolBox && (
+        {(isToolBox || isRobotJointList) && (
           <div style={{
             position: 'relative',
             display: 'flex',
@@ -988,12 +997,12 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
                 background: 'var(--node)',
                 width: 11,
                 height: 11,
-                border: `2px dashed ${TOOLBOX_NEW_HANDLE_COLOR}`,
+                border: `2px dashed ${isRobotJointList ? portColor('Dict') : TOOLBOX_NEW_HANDLE_COLOR}`,
                 borderRadius: '50%',
               }}
             />
-            <span style={{ fontSize: 9, color: TOOLBOX_NEW_HANDLE_COLOR, fontFamily: 'var(--font-ui)', userSelect: 'none' }}>
-              ← drag to create
+            <span style={{ fontSize: 9, color: isRobotJointList ? portColor('Dict') : TOOLBOX_NEW_HANDLE_COLOR, fontFamily: 'var(--font-ui)', userSelect: 'none' }}>
+              {isRobotJointList ? `joint_${nextJointNumber} · connect to add` : '← drag to create'}
             </span>
           </div>
         )}
@@ -1019,7 +1028,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
                 name={inp}
                 type={type}
                 dir="input"
-                onRemove={isToolBox ? () => removeToolSlot(inp) : undefined}
+                onRemove={(isToolBox || isRobotJointList) ? () => removeToolSlot(inp) : undefined}
               />
               {showImageInput && (
                 <NodeImageInput

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -317,6 +317,21 @@ function sortToolInputs(inputs: string[]): string[] {
   return [...inputs].sort((a, b) => toolInputIndex(a) - toolInputIndex(b) || a.localeCompare(b))
 }
 
+function nextJointInputName(inputs: string[]): string {
+  let i = 1
+  while (inputs.includes(`joint_${i}`)) i++
+  return `joint_${i}`
+}
+
+function sortJointInputs(inputs: string[]): string[] {
+  return [...inputs].sort((a, b) => {
+    const ai = Number(a.split('_').pop())
+    const bi = Number(b.split('_').pop())
+    return (Number.isFinite(ai) ? ai : Number.MAX_SAFE_INTEGER)
+      - (Number.isFinite(bi) ? bi : Number.MAX_SAFE_INTEGER) || a.localeCompare(b)
+  })
+}
+
 function cloneDeep<T>(value: T): T {
   if (value === undefined || value === null) return value
   return JSON.parse(JSON.stringify(value)) as T
@@ -868,10 +883,16 @@ function pruneDisconnectedDynamicPorts(
   removedEdges: Edge[] = [],
 ): { nodes: Node<NodeData>[]; changedIds: Set<string> } {
   const connectedToolPorts = new Map<string, Set<string>>()
+  const connectedJointPorts = new Map<string, Set<string>>()
   edges.forEach(edge => {
-    if (!edge.targetHandle?.startsWith('tool_')) return
-    if (!connectedToolPorts.has(edge.target)) connectedToolPorts.set(edge.target, new Set())
-    connectedToolPorts.get(edge.target)!.add(edge.targetHandle)
+    if (edge.targetHandle?.startsWith('tool_')) {
+      if (!connectedToolPorts.has(edge.target)) connectedToolPorts.set(edge.target, new Set())
+      connectedToolPorts.get(edge.target)!.add(edge.targetHandle)
+    }
+    if (edge.targetHandle?.startsWith('joint_')) {
+      if (!connectedJointPorts.has(edge.target)) connectedJointPorts.set(edge.target, new Set())
+      connectedJointPorts.get(edge.target)!.add(edge.targetHandle)
+    }
   })
 
   const removedInputs = new Map<string, Set<string>>()
@@ -914,6 +935,21 @@ function pruneDisconnectedDynamicPorts(
           input_types: inputTypes,
           input_defaults: {},
         },
+      }
+    }
+
+    if (node.data.type === 'RobotJointList') {
+      const connected = sortJointInputs(Array.from(connectedJointPorts.get(node.id) ?? []))
+      if (
+        connected.length === (node.data.inputs ?? []).length
+        && connected.every((port, i) => port === node.data.inputs[i])
+      ) return node
+      changedIds.add(node.id)
+      const inputTypes: Record<string, string> = {}
+      connected.forEach(port => { inputTypes[port] = 'Dict' })
+      return {
+        ...node,
+        data: { ...node.data, inputs: connected, input_types: inputTypes, input_defaults: {} },
       }
     }
 
@@ -1029,14 +1065,15 @@ function pruneDisconnectedDynamicPorts(
 function ensureConnectedToolBoxSlots(nodes: Node<NodeData>[], edges: Edge[]): Node<NodeData>[] {
   const connectedPorts = new Map<string, Set<string>>()
   edges.forEach(edge => {
-    if (!edge.targetHandle?.startsWith('tool_')) return
+    if (!edge.targetHandle?.startsWith('tool_') && !edge.targetHandle?.startsWith('joint_')) return
     if (!connectedPorts.has(edge.target)) connectedPorts.set(edge.target, new Set())
     connectedPorts.get(edge.target)!.add(edge.targetHandle)
   })
 
   return nodes.map(node => {
-    if (node.data.type !== 'ToolBox') return node
-    const connected = sortToolInputs(Array.from(connectedPorts.get(node.id) ?? []))
+    if (node.data.type !== 'ToolBox' && node.data.type !== 'RobotJointList') return node
+    const isJointList = node.data.type === 'RobotJointList'
+    const connected = (isJointList ? sortJointInputs : sortToolInputs)(Array.from(connectedPorts.get(node.id) ?? []))
     if (
       connected.length === (node.data.inputs ?? []).length
       && connected.every((port, i) => port === node.data.inputs[i])
@@ -1045,7 +1082,7 @@ function ensureConnectedToolBoxSlots(nodes: Node<NodeData>[], edges: Edge[]): No
     }
 
     const inputTypes: Record<string, string> = {}
-    connected.forEach(port => { inputTypes[port] = 'Fn' })
+    connected.forEach(port => { inputTypes[port] = isJointList ? 'Dict' : 'Fn' })
     return {
       ...node,
       data: {
@@ -2086,11 +2123,13 @@ export const useStore = create<Store>((set, get) => ({
       conn = { ...conn, targetHandle: portName }
     }
 
-    // __new__ target handle on ToolBox: connect to the first empty tool slot,
-    // creating a new tool_N input when all visible slots are already used.
-    if (conn.targetHandle === '__new__' && tgtNode?.data?.type === 'ToolBox') {
+    // Numbered collectors expose one synthetic socket and turn it into a
+    // persistent tool_N or joint_N port when connected.
+    if (conn.targetHandle === '__new__' && (tgtNode?.data?.type === 'ToolBox' || tgtNode?.data?.type === 'RobotJointList')) {
+      const isJointList = tgtNode.data.type === 'RobotJointList'
+      const expectedType = isJointList ? 'Dict' : 'Fn'
       const fromType = srcNode?.data?.output_types?.[conn.sourceHandle!] ?? 'Any'
-      if (!portsCompatible(fromType, 'Fn')) return
+      if (!portsCompatible(fromType, expectedType)) return
       const existing: string[] = tgtNode.data.inputs ?? []
       const occupied = new Set(
         edges
@@ -2099,15 +2138,15 @@ export const useStore = create<Store>((set, get) => ({
       )
       let portName = existing.find(p => !occupied.has(p))
       if (!portName) {
-        const newPortName = nextToolInputName(existing)
+        const newPortName = isJointList ? nextJointInputName(existing) : nextToolInputName(existing)
         nodes = nodes.map(n =>
           n.id === conn.target
             ? {
                 ...n,
                 data: {
                   ...n.data,
-                  inputs: sortToolInputs([...existing, newPortName]),
-                  input_types: { ...(n.data.input_types ?? {}), [newPortName]: 'Fn' },
+                  inputs: (isJointList ? sortJointInputs : sortToolInputs)([...existing, newPortName]),
+                  input_types: { ...(n.data.input_types ?? {}), [newPortName]: expectedType },
                 },
               }
             : n
@@ -2119,11 +2158,12 @@ export const useStore = create<Store>((set, get) => ({
     }
 
     if (
-      tgtNode?.data?.type === 'ToolBox'
-      && conn.targetHandle?.startsWith('tool_')
+      (tgtNode?.data?.type === 'ToolBox' || tgtNode?.data?.type === 'RobotJointList')
+      && (conn.targetHandle?.startsWith('tool_') || conn.targetHandle?.startsWith('joint_'))
       && !(tgtNode.data.inputs ?? []).includes(conn.targetHandle)
     ) {
-      const nextInputs = sortToolInputs([...(tgtNode.data.inputs ?? []), conn.targetHandle])
+      const isJointList = tgtNode.data.type === 'RobotJointList'
+      const nextInputs = (isJointList ? sortJointInputs : sortToolInputs)([...(tgtNode.data.inputs ?? []), conn.targetHandle])
       nodes = nodes.map(n =>
         n.id === conn.target
           ? {
@@ -2131,7 +2171,7 @@ export const useStore = create<Store>((set, get) => ({
               data: {
                 ...n.data,
                 inputs: nextInputs,
-                input_types: { ...(n.data.input_types ?? {}), [conn.targetHandle!]: 'Fn' },
+                input_types: { ...(n.data.input_types ?? {}), [conn.targetHandle!]: isJointList ? 'Dict' : 'Fn' },
               },
             }
           : n
@@ -2218,9 +2258,11 @@ export const useStore = create<Store>((set, get) => ({
     let srcNode = nodes.find(n => n.id === conn.source)
     let tgtNode = nodes.find(n => n.id === conn.target)
 
-    if (conn.targetHandle === '__new__' && tgtNode?.data?.type === 'ToolBox') {
+    if (conn.targetHandle === '__new__' && (tgtNode?.data?.type === 'ToolBox' || tgtNode?.data?.type === 'RobotJointList')) {
+      const isJointList = tgtNode.data.type === 'RobotJointList'
+      const expectedType = isJointList ? 'Dict' : 'Fn'
       const fromType = srcNode?.data?.output_types?.[conn.sourceHandle] ?? 'Any'
-      if (!portsCompatible(fromType, 'Fn')) return
+      if (!portsCompatible(fromType, expectedType)) return
       const existing: string[] = tgtNode.data.inputs ?? []
       const occupied = new Set(
         edges
@@ -2229,15 +2271,15 @@ export const useStore = create<Store>((set, get) => ({
       )
       let portName = existing.find(p => !occupied.has(p))
       if (!portName) {
-        const newPortName = nextToolInputName(existing)
+        const newPortName = isJointList ? nextJointInputName(existing) : nextToolInputName(existing)
         nodes = nodes.map(n =>
           n.id === conn.target
             ? {
                 ...n,
                 data: {
                   ...n.data,
-                  inputs: [...existing, newPortName],
-                  input_types: { ...(n.data.input_types ?? {}), [newPortName]: 'Fn' },
+                  inputs: (isJointList ? sortJointInputs : sortToolInputs)([...existing, newPortName]),
+                  input_types: { ...(n.data.input_types ?? {}), [newPortName]: expectedType },
                 },
               }
             : n

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -67,6 +67,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "RobotDriverDescriptor",
             "RobotDriverLauncher",
             "RobotDriverPreset",
+            "Robot",
             "RobotJointDefinition",
             "RobotJointList",
             "RobotDefinition",

--- a/skills/blacknode-workflow/SKILL.md
+++ b/skills/blacknode-workflow/SKILL.md
@@ -130,6 +130,9 @@ or type error, inspect `get_node_schema` and fix the graph instead of guessing.
 
 ## Robot Profile and Calibration Semantics
 
+- Use the generic `Robot` selector in new workflows. Built-in and saved profiles
+  appear in its dropdown; `RobotDriverPreset` and `RobotProfileLoad` are hidden
+  compatibility names for existing graphs.
 - Build custom robots with `RobotJointDefinition` → `RobotJointList` →
   `RobotDefinition` → `RobotProfileSave`. Prefer duplicating a built-in profile
   with `RobotProfileDuplicate` when it is a close mechanical starting point.
@@ -144,9 +147,13 @@ or type error, inspect `get_node_schema` and fix the graph instead of guessing.
   Recording observes hand-guided extrema; it never commands motion. Capture an
   explicit home pose, observe every configured joint, and keep a positive
   safety margin inside the physical extrema before saving.
-- Feed discovery hardware identity into `RobotProfileLoad` and
+- Feed discovery hardware identity into `Robot` and
   `RobotCalibrationRecorder` so the matching device calibration is selected.
   Never replace a missing hardware identity with a generic shared calibration.
+- USB VID/PID values come from discovery and may filter adapter models; they are
+  not random user-assigned IDs. The USB serial or device path identifies the
+  physical assembly for calibration. Leave manual identity overrides blank in
+  ordinary workflows.
 - Base-profile limits are provisional until the physical assembly is calibrated.
   Do not discover limits by driving an armed joint into a hard stop.
 

--- a/tests/test_editor_robot_joint_ports.py
+++ b/tests/test_editor_robot_joint_ports.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITOR_SERVER_DIR = ROOT / "editor-server"
+if str(EDITOR_SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(EDITOR_SERVER_DIR))
+
+import server  # noqa: E402
+
+
+def test_joint_list_dynamic_ports_follow_connected_edges():
+    meta = {
+        "id": "joints",
+        "type": "RobotJointList",
+        "inputs": ["joint_1", "joint_2", "joint_16"],
+        "input_types": {"joint_1": "Dict", "joint_2": "Dict", "joint_16": "Dict"},
+        "outputs": ["joints", "count", "report"],
+        "output_types": {"joints": "List", "count": "Int", "report": "Text"},
+        "input_defaults": {},
+    }
+    edges = [
+        {"from": "b", "from_port": "joint", "to": "joints", "to_port": "joint_25"},
+        {"from": "a", "from_port": "joint", "to": "joints", "to_port": "joint_2"},
+    ]
+
+    server._sync_joint_list_ports(meta, edges)
+
+    assert meta["inputs"] == ["joint_2", "joint_25"]
+    assert meta["input_types"] == {"joint_2": "Dict", "joint_25": "Dict"}
+    assert meta["input_defaults"] == {}


### PR DESCRIPTION
## What changed
- add the generic `Robot` node to the package catalog and workflow rules
- make `RobotJointList` a dynamic numbered-input collector with no 16-joint UI ceiling
- persist and prune dynamic joint sockets across connect, reconnect, disconnect, save, and reload
- hide disconnected joint sockets and always present the next available joint handle
- ignore editor-server robot runtime data

## Why
The custom robot builder should use one ordinary Robot selector and scale to complex robots without exposing legacy preset/load naming or a fixed bank of joint inputs.

## Validation
- `python -m pytest -q` (546 passed, 8 skipped, 45 subtests)
- `npm run build` in `editor/`
- `python -m pytest -q tests/test_editor_robot_joint_ports.py tests/test_agent_skill.py`
- `git diff --check`