### PR TITLE
Add live calibration pause and status controls

### DIFF
--- a/.agents/skills/blacknode-workflow/SKILL.md
+++ b/.agents/skills/blacknode-workflow/SKILL.md
@@ -147,6 +147,9 @@ or type error, inspect `get_node_schema` and fix the graph instead of guessing.
   Recording observes hand-guided extrema; it never commands motion. Capture an
   explicit home pose, observe every configured joint, and keep a positive
   safety margin inside the physical extrema before saving.
+- Calibration recording may be paused without discarding samples. Keep current
+  pose and downstream Output values live while paused, but do not expand the
+  observed extrema until recording resumes.
 - Feed discovery hardware identity into `Robot` and
   `RobotCalibrationRecorder` so the matching device calibration is selected.
   Never replace a missing hardware identity with a generic shared calibration.

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -327,7 +327,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const [streamStopPending, setStreamStopPending] = useState(false)
   const [rosRunStopPending, setRosRunStopPending] = useState(false)
   const [manualMovePending, setManualMovePending] = useState<null | 'release' | 'monitor' | 'hold'>(null)
-  const [calibrationPending, setCalibrationPending] = useState<null | 'start' | 'capture_home' | 'finish' | 'cancel'>(null)
+  const [calibrationPending, setCalibrationPending] = useState<null | 'start' | 'pause' | 'capture_home' | 'finish' | 'cancel'>(null)
   const updateNodeInternals = useUpdateNodeInternals()
   const color       = headerColor(data.type)
   const isToolBox   = data.type === 'ToolBox'
@@ -387,10 +387,13 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     && holdSelected
     && data.portResults?.torque_enabled === false
   const calibrationActive = isRobotCalibration && data.portResults?.active === true
+  const calibrationState = isRobotCalibration ? String(data.portResults?.state ?? 'idle') : 'idle'
+  const calibrationPaused = calibrationState === 'paused'
+  const calibrationDataReady = isRobotCalibration && data.portResults?.data_ready === true
   const calibrationSamples = isRobotCalibration && typeof data.portResults?.samples === 'number'
     ? data.portResults.samples
     : 0
-  const calibrationSaved = isRobotCalibration && data.portResults?.saved === true
+  const calibrationSaved = isRobotCalibration && (data.portResults?.saved === true || calibrationState === 'saved')
   const genericNodeLive = data.live_capable === true && data.portResults?.live === true && !manualMoveLive && !streamActive
   const snapshotResult = data.live_capable === true
     && !streamActive
@@ -522,7 +525,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     }
   }
 
-  const runCalibrationAction = async (action: 'start' | 'capture_home' | 'finish' | 'cancel') => {
+  const runCalibrationAction = async (action: 'start' | 'pause' | 'capture_home' | 'finish' | 'cancel') => {
     if (calibrationPending) return
     if (action === 'start' && !window.confirm(
       'Support the robot and release motor torque before calibration. Calibration records hand-moved positions and never commands motion. Continue?'
@@ -930,45 +933,53 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       {isRobotCalibration && (
         <div style={{
           margin: '7px 9px 3px', padding: 8, borderRadius: 7,
-          border: `1px solid ${calibrationActive ? 'var(--warn)' : calibrationSaved ? 'var(--ok)' : 'var(--line)'}`,
+          border: `1px solid ${calibrationActive ? 'var(--warn)' : calibrationPaused ? 'var(--accent)' : calibrationSaved ? 'var(--ok)' : 'var(--line)'}`,
           background: calibrationActive ? 'rgba(245,158,11,.08)' : 'rgba(255,255,255,.02)',
         }}>
           <div style={{
-            marginBottom: 7, color: calibrationActive ? 'var(--warn)' : calibrationSaved ? 'var(--ok)' : 'var(--tx2)',
+            marginBottom: 7, color: calibrationActive ? 'var(--warn)' : calibrationPaused ? 'var(--accent)' : calibrationSaved ? 'var(--ok)' : 'var(--tx2)',
             fontFamily: 'var(--font-ui)', fontSize: 10, fontWeight: 800,
           }}>
-            {calibrationActive ? `● RECORDING · ${calibrationSamples} samples` : calibrationSaved ? '✓ CALIBRATION SAVED' : '○ CALIBRATION IDLE'}
+            {calibrationActive ? `● RECORDING LIVE · ${calibrationSamples} samples` : calibrationPaused ? `Ⅱ RECORDING PAUSED · ${calibrationSamples} samples` : calibrationSaved ? '✓ CALIBRATION SAVED' : '○ CALIBRATION IDLE'}
           </div>
           <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
             <button
-              disabled={Boolean(calibrationPending)}
+              disabled={Boolean(calibrationPending) || calibrationActive}
               title="Start recording observed positions. Torque must already be released."
               onClick={e => { e.stopPropagation(); void runCalibrationAction('start') }}
-              style={driverBtn('var(--warn)', Boolean(calibrationPending))}
+              style={driverBtn('var(--warn)', Boolean(calibrationPending) || calibrationActive)}
             >
-              {calibrationPending === 'start' ? 'Starting…' : 'Start recording'}
+              {calibrationPending === 'start' ? 'Starting…' : calibrationPaused ? 'Resume recording' : 'Start recording'}
             </button>
             <button
               disabled={Boolean(calibrationPending) || !calibrationActive}
+              title="Pause range recording without discarding samples; live pose continues"
+              onClick={e => { e.stopPropagation(); void runCalibrationAction('pause') }}
+              style={driverBtn('var(--accent)', Boolean(calibrationPending) || !calibrationActive)}
+            >
+              {calibrationPending === 'pause' ? 'Stopping…' : 'Stop recording'}
+            </button>
+            <button
+              disabled={Boolean(calibrationPending) || !calibrationDataReady}
               title="Capture the current released pose as the neutral Home pose"
               onClick={e => { e.stopPropagation(); void runCalibrationAction('capture_home') }}
-              style={driverBtn('var(--accent)', Boolean(calibrationPending) || !calibrationActive)}
+              style={driverBtn('var(--accent)', Boolean(calibrationPending) || !calibrationDataReady)}
             >
               {calibrationPending === 'capture_home' ? 'Capturing…' : 'Capture Home'}
             </button>
             <button
-              disabled={Boolean(calibrationPending) || !calibrationActive}
+              disabled={Boolean(calibrationPending) || !calibrationDataReady}
               title="Review and save observed and safe ranges for this hardware serial"
               onClick={e => { e.stopPropagation(); void runCalibrationAction('finish') }}
-              style={driverBtn('var(--ok)', Boolean(calibrationPending) || !calibrationActive)}
+              style={driverBtn('var(--ok)', Boolean(calibrationPending) || !calibrationDataReady)}
             >
               {calibrationPending === 'finish' ? 'Saving…' : 'Save calibration'}
             </button>
             <button
-              disabled={Boolean(calibrationPending) || !calibrationActive}
+              disabled={Boolean(calibrationPending) || (!calibrationActive && !calibrationPaused)}
               title="Discard this unsaved calibration session"
               onClick={e => { e.stopPropagation(); void runCalibrationAction('cancel') }}
-              style={driverBtn('var(--err)', Boolean(calibrationPending) || !calibrationActive)}
+              style={driverBtn('var(--err)', Boolean(calibrationPending) || (!calibrationActive && !calibrationPaused))}
             >
               Cancel
             </button>

--- a/skills/blacknode-workflow/SKILL.md
+++ b/skills/blacknode-workflow/SKILL.md
@@ -147,6 +147,9 @@ or type error, inspect `get_node_schema` and fix the graph instead of guessing.
   Recording observes hand-guided extrema; it never commands motion. Capture an
   explicit home pose, observe every configured joint, and keep a positive
   safety margin inside the physical extrema before saving.
+- Calibration recording may be paused without discarding samples. Keep current
+  pose and downstream Output values live while paused, but do not expand the
+  observed extrema until recording resumes.
 - Feed discovery hardware identity into `Robot` and
   `RobotCalibrationRecorder` so the matching device calibration is selected.
   Never replace a missing hardware identity with a generic shared calibration.


### PR DESCRIPTION
## What changed
- add explicit Start/Resume, Stop recording, Capture Home, Save, and Cancel calibration controls
- distinguish recording, paused, saved, and idle UI states
- permit capture/save after recording is paused
- document that pause retains live pose while freezing extrema

## Root cause
RobotCalibrationRecorder was live-capable but did not emit a live output, and the editor had no pause state. The node therefore appeared as a snapshot even while runtime samples increased, and its connected Output stayed on the original idle result.

## Validation
- `python -m pytest -q` (547 passed, 8 skipped, 45 subtests)
- `npm run build` in `editor/`
- `python -m pytest -q tests/test_agent_skill.py`
- `git diff --check`