### PR TITLE
Invalidate stale robot profile results

### DIFF
--- a/docs/so-arm101-five-minute-demo.md
+++ b/docs/so-arm101-five-minute-demo.md
@@ -27,11 +27,15 @@ otherwise it prepares the local rosbridge service automatically.
 4. Confirm the generic `Robot` dropdown is set to `so_arm101`. Its hardware
    input is already connected to USB discovery, so a saved device calibration
    is selected automatically.
+   If you select a different saved profile, Blacknode clears the old dashboard;
+   press **Run** to safely replace the running driver and apply that profile.
 5. Keep `ROS2SetJoint.armed` set to `false`.
 6. Press **Run**.
 7. Inspect **Robot Connection Dashboard**. USB, driver, ROS 2, and live state
    should all show ready. The joint table shows live positions, home references,
    safe ranges, and whether they came from saved calibration or profile defaults.
+   `PROFILE DEFAULTS` means calibration was not saved for the displayed profile
+   and hardware ID; it does not mean a recording session completed successfully.
 8. Clear the workspace. Set `joint` to `shoulder_pan`, choose a small target
    close to the current value, and only then set `armed=true`.
 9. Cook the final output once. Confirm the motion dashboard shows the before,

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -1112,6 +1112,22 @@ def update_param(node_id: str, req: UpdateParamReq):
     meta["params"][req.key] = req.value
     _session.graph._nodes[node_id]["params"][req.key] = req.value
     _session.graph._mark_dirty(node_id)
+    # A changed input invalidates every visible result derived from it. The
+    # graph cache was already dirtied above; clear persisted node status too so
+    # the editor never continues presenting an old dashboard as current.
+    invalidated = {node_id}
+    pending = [node_id]
+    while pending:
+        current = pending.pop()
+        for edge in _session.graph._edges:
+            target = str(edge.get("to") or "")
+            if edge.get("from") == current and target and target not in invalidated:
+                invalidated.add(target)
+                pending.append(target)
+    for invalidated_id in invalidated:
+        invalidated_meta = _session.node_meta.get(invalidated_id)
+        if invalidated_meta is not None:
+            _clear_runtime_status(invalidated_meta)
     _push_live_node_param_update(meta, req.key, req.value, old_params)
     _save()
     return meta

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -380,6 +380,18 @@ function clearReplayData(data: NodeData): NodeData {
   return rest
 }
 
+function clearCookResults(data: NodeData): NodeData {
+  const {
+    cookResult: _cookResult,
+    cookError: _cookError,
+    cooking: _cooking,
+    cookPort: _cookPort,
+    portResults: _portResults,
+    ...rest
+  } = clearReplayData(data)
+  return rest
+}
+
 function clearRuntimeNodeData(data: NodeData): NodeData {
   const base = { ...data, cooking: false, cookError: undefined }
   if (
@@ -2629,6 +2641,20 @@ export const useStore = create<Store>((set, get) => ({
   updateParam: async (id, key, value) => {
     const node = get().nodes.find(n => n.id === id)
     if (!node || node.data.params?.[key] === value) return
+    const profileChanged = node.data.type === 'Robot' && key === 'profile_id'
+    const invalidated = new Set<string>([id])
+    if (profileChanged) {
+      const pending = [id]
+      while (pending.length > 0) {
+        const source = pending.pop()!
+        get().edges.forEach(edge => {
+          if (edge.source === source && !invalidated.has(edge.target)) {
+            invalidated.add(edge.target)
+            pending.push(edge.target)
+          }
+        })
+      }
+    }
     set(s => pushUndoSnapshot(s))
     // Apply the local param optimistically before awaiting the backend PATCH
     // (rather than after) so displayed state always reflects the latest
@@ -2636,12 +2662,27 @@ export const useStore = create<Store>((set, get) => ({
     // can be in flight at once (e.g. rapid edits), and network responses
     // aren't guaranteed to resolve in call order.
     set(s => ({
-      nodes: s.nodes.map(n =>
-        n.id === id ? { ...n, data: { ...n.data, params: { ...n.data.params, [key]: value } } } : n
-      ),
+      nodes: s.nodes.map(n => {
+        if (n.id === id) {
+          const data = { ...n.data, params: { ...n.data.params, [key]: value } }
+          return { ...n, data: profileChanged ? clearCookResults(data) : data }
+        }
+        return profileChanged && invalidated.has(n.id)
+          ? { ...n, data: clearCookResults(n.data) }
+          : n
+      }),
       ...markActiveTabDirty(s),
     }))
     await api.updateParam(id, key, value)
+    if (profileChanged) {
+      window.dispatchEvent(new CustomEvent('blacknode:notice', {
+        detail: {
+          kind: 'info',
+          title: 'Robot profile changed',
+          message: 'Previous dashboard values were cleared. Press Run to safely restart the driver with this profile and refresh all downstream nodes.',
+        },
+      }))
+    }
   },
 
   cookNode: async (id, port = 'output', graphTargets, runMode = 'once') => {


### PR DESCRIPTION
## What changed
- clear a Robot node and all downstream runtime results when its profile changes
- show an explicit notice to press Run before the selected profile is applied
- clear persisted server-side cook status for all invalidated descendants
- document safe profile switching and calibration provenance

## Why
Changing profile_id left the previous dashboard visible, making stale limits appear current. Automatically running the full physical-control graph from a dropdown change would be unsafe, so the editor now invalidates immediately and requires an explicit Run.

## Validation
- editor production build passed
- full Python suite: 552 passed, 8 skipped, 45 subtests passed