### PR TITLE
Support leader-follower runtime controls

### DIFF
--- a/docs/so-arm101-leader-follower.md
+++ b/docs/so-arm101-leader-follower.md
@@ -1,0 +1,32 @@
+# SO-ARM101 Leader–Follower Control
+
+Use **SO-ARM101 Leader Follower** to move one released leader arm by hand and
+stream its calibrated joint coordinates into a separate follower arm.
+
+## Prepare both arms
+
+1. Record the two USB serial values shown by `RobotUSBDiscovery`; never identify
+   the pair by COM-port order alone.
+2. Select or create the logical profile for each arm. Matching arms may use the
+   same profile because calibration is stored separately per USB serial.
+3. Calibrate each physical arm and successfully save both calibrations.
+4. Open **SO-ARM101 Leader Follower**. Set `leader_usb.port_filter` and
+   `follower_usb.port_filter` to their distinct USB serials.
+5. Select each profile and keep the supplied `/leader` and `/follower` prefixes.
+
+## Start safely
+
+1. Support the leader arm and clear the follower workspace.
+2. Keep `ROS2LeaderFollower.armed=false` and press **Go live**.
+3. Confirm leader torque is released and the dashboard shows live leader, safe
+   target, and follower values. Moving the leader must not move the follower.
+4. Set `armed=true`. The live controller applies this immediately while limits,
+   bounded steps, deadband, and stale-message suppression remain active.
+5. Set `armed=false` or press **Stop all** before touching the follower.
+
+Matching joint names map automatically. Otherwise set `joint_map` as
+`{ "leader_joint": "follower_joint" }`. `scale` and `offset_deg` are keyed by
+leader joint; a scale of `-1` mirrors direction.
+
+The initial controller uses rosbridge for persistent dual-arm streams. Both
+profiles share the rosbridge host and port but must keep distinct topic prefixes.

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -469,6 +469,19 @@ _CV2_STREAM_LIVE_CONFIG_KEYS = {
 
 
 def _push_live_node_param_update(meta: dict[str, Any], key: str, value: Any, old_params: dict[str, Any]) -> None:
+    if meta.get("type") == "ROS2LeaderFollower":
+        update_fn = _runtime_callable("ros2_live", _RUNTIME_MODULES["ros2_live"], "update_leader_follower_config")
+        if update_fn is None:
+            return
+        run_id = str(old_params.get("run_id") or meta.get("params", {}).get("run_id") or "leader_follower").strip() or "leader_follower"
+        try:
+            result = update_fn(run_id, {key: value})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[blacknode] live leader-follower update failed for {run_id}.{key}: {type(exc).__name__}: {exc}")
+            return
+        if not result.get("ok", True) and "not running" not in str(result.get("report") or ""):
+            print(f"[blacknode] live leader-follower update failed for {run_id}.{key}: {result.get('error') or result.get('report')}")
+        return
     if meta.get("type") != "CV2ColorObjectStream" or key not in _CV2_STREAM_LIVE_CONFIG_KEYS:
         return
     runtime = _runtime_module(_RUNTIME_MODULES["vision"])
@@ -1128,6 +1141,14 @@ def update_param(node_id: str, req: UpdateParamReq):
         invalidated_meta = _session.node_meta.get(invalidated_id)
         if invalidated_meta is not None:
             _clear_runtime_status(invalidated_meta)
+            if invalidated_meta.get("type") == "ROS2LeaderFollower" and invalidated_id != node_id:
+                disarm_fn = _runtime_callable("ros2_live", _RUNTIME_MODULES["ros2_live"], "update_leader_follower_config")
+                if disarm_fn is not None:
+                    run_id = str(invalidated_meta.get("params", {}).get("run_id") or "leader_follower").strip() or "leader_follower"
+                    try:
+                        disarm_fn(run_id, {"armed": False})
+                    except Exception as exc:  # noqa: BLE001
+                        print(f"[blacknode] could not disarm invalidated leader-follower '{run_id}': {type(exc).__name__}: {exc}")
     _push_live_node_param_update(meta, req.key, req.value, old_params)
     _save()
     return meta

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1016,7 +1016,7 @@ export default function App() {
   )).length
   const managedRunCount = nodes.filter(n => n.data.type === 'ROS2Run' && n.data.portResults?.running === true).length
   const controllerCount = nodes.filter(n => (
-    n.data.type === 'ROS2ContinuousFollowDetectionJoint' && n.data.portResults?.running === true
+    (n.data.type === 'ROS2ContinuousFollowDetectionJoint' || n.data.type === 'ROS2LeaderFollower') && n.data.portResults?.running === true
   )).length
   const manualMoveCount = nodes.filter(n => n.data.type === 'ROS2ManualMove' && n.data.portResults?.live === true).length
   const liveDashboardCount = nodes.filter(n => n.data.type === 'ROS2MotionDashboard' && n.data.portResults?.live === true).length

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -446,7 +446,7 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
       },
     }
   }
-  if (data.type === 'ROS2ContinuousFollowDetectionJoint') {
+  if (data.type === 'ROS2ContinuousFollowDetectionJoint' || data.type === 'ROS2LeaderFollower') {
     return {
       ...base,
       portResults: {
@@ -2976,6 +2976,7 @@ export const useStore = create<Store>((set, get) => ({
           n.data.type === 'VisionReasoningStream' ||
           n.data.type === 'CUDAImageFilterStream' ||
           n.data.type === 'ROS2ContinuousFollowDetectionJoint' ||
+          n.data.type === 'ROS2LeaderFollower' ||
           n.data.type === 'ROS2ManualMove' ||
           n.data.type === 'ROS2TeachMode' ||
           n.data.type === 'ROS2MotionDashboard' ||


### PR DESCRIPTION
## What changed
- push live ROS2LeaderFollower parameter changes into the running controller
- immediately disarm an active controller when an upstream profile is invalidated
- include leader-follower controllers in editor live and Stop-all state
- add a complete dual-arm setup and safety guide

## Why
Arming and disarming must affect a live controller immediately, while profile or hardware changes must never leave an old command stream armed.

## Validation
- editor production build passed
- full Python suite: 555 passed, 8 skipped, 45 subtests passed