### PR TITLE
Document Blacknode agent workflows

### DIFF
--- a/.agents/skills/blacknode-development/SKILL.md
+++ b/.agents/skills/blacknode-development/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: blacknode-development
+description: >
+  Develop, extend, test, or debug Blacknode itself and its reusable extension
+  ecosystem. Use when changing the Python or Rust runtime, MCP server, editor,
+  package manager, exporters, node contracts, managed services, creating a
+  reusable core/custom/community node, authoring an extension package, or
+  modifying blacknode-cuda, blacknode-vision, blacknode-ros2, or
+  blacknode-robot. Use blacknode-workflow when the requested result is only a
+  workflow graph built from existing capabilities.
+---
+
+# Blacknode Development
+
+Develop the smallest reusable layer that owns the requested capability, protect
+saved-workflow compatibility, and prove the result through both focused tests
+and a representative workflow when applicable.
+
+## Start Here
+
+1. Read the nearest `AGENTS.md`; package repositories have scoped guidance.
+2. Inspect the current implementation, tests, and public documentation before
+   choosing a layer.
+3. Check Git status in the exact worktree being changed. `packages/*` are
+   independent repositories, not tracked children of the core repository.
+4. Decide whether the capability belongs in core, an extension package, a
+   user-local custom node, or a workflow-local `PythonFn`.
+5. Implement the narrowest coherent change, add tests, and update public docs.
+6. Build a small workflow/template when it materially proves discovery, ports,
+   runtime behavior, or package resolution.
+
+## Choose the Ownership Layer
+
+| Need | Put it here |
+|---|---|
+| Graph types, execution, validation, registry, CLI, MCP, exporters | `python/blacknode/` |
+| Browser/editor behavior or UI | `editor/` |
+| Editor HTTP API, runtime services, replay | `editor-server/` |
+| Portable Rust graph/runtime/CLI behavior | `crates/` |
+| Broad, dependency-light node | `python/blacknode/nodes/` |
+| Hardware, GPU, ROS, vision, or large optional dependency | extension package |
+| User-owned local reusable behavior | `custom-nodes/` |
+| One graph's small adapter | `PythonFn` in the workflow |
+
+Do not duplicate a domain implementation in core and a package. Keep the core
+contract generic and place transport- or hardware-specific implementations
+behind package nodes and runtime adapters.
+
+## Develop a Node
+
+1. Inspect `python/blacknode/node.py`, nearby nodes, and node tests.
+2. Define stable, typed inputs and outputs with the existing `@node` contract.
+3. Keep import-time behavior cheap and deterministic. Guard optional heavy
+   dependencies and return actionable structured errors at runtime.
+4. Separate one-shot cooking from persistent services. A stream/controller node
+   starts or updates one managed service; it does not create a polling cook.
+5. Add discovery/registration tests and behavior tests.
+6. Exercise the node in a minimal validated workflow or package template.
+7. Document configuration, outputs, dependencies, and lifecycle behavior.
+
+Preserve old node names needed by saved workflows as compatibility aliases.
+Use current generic names in new templates and docs.
+
+## Author an Extension Package
+
+Use `blacknode-cuda` as the smallest reference package. Read
+`docs/packages.md` and `docs/custom-nodes.md` before authoring.
+
+Required shape:
+
+```text
+blacknode-example/
+  blacknode-package.toml
+  nodes/
+    __init__.py
+  tests/
+  templates/          # optional
+  requirements.txt    # optional
+  README.md
+  AGENTS.md
+```
+
+- Declare `name`, `version`, `description`, and `requires-blacknode`.
+- Declare import names under `dependencies.imports`, pip requirements under
+  `dependencies.pip`, and Docker images when required.
+- Keep package loading functional when optional runtime dependencies are absent;
+  surface dependency warnings and actionable setup commands.
+- Add `metadata.required_packages` to templates that use package nodes.
+- Keep each package independently testable, versioned, documented, and
+  publishable from its own Git repository.
+- Add scoped `AGENTS.md` safety and test instructions. Create a package-specific
+  skill only when users need a distinct, substantial operational workflow that
+  cannot be routed clearly through `blacknode-workflow`.
+
+## Cross-Layer Contracts
+
+When changing node schemas, runtime events, managed services, or package APIs,
+trace all consumers:
+
+```text
+node/package -> registry and schema -> editor-server/MCP -> editor -> template
+             -> tests and documentation
+```
+
+Update each affected layer in the same change. Do not persist editor-only fields
+such as `cookResult`, `cookError`, `cooking`, or `cookPort` in workflow JSON.
+
+## Hardware and Managed-Service Safety
+
+- Keep robot motion disarmed until explicitly authorized.
+- Never bypass calibrated limits, freshness checks, or emergency shutdown.
+- Treat worker heartbeat and source-data freshness as separate signals.
+- Preserve idempotent control behavior across retries.
+- Make stop paths explicit and testable. Robot shutdown may release torque.
+- Do not use physical hard stops to discover joint limits.
+
+Read the target package's `AGENTS.md` before modifying CUDA, vision, ROS 2, or
+robot code.
+
+## Verification Matrix
+
+| Change | Minimum verification |
+|---|---|
+| Python runtime, nodes, MCP, packages, templates | focused test plus `python -m unittest discover -s tests` |
+| Editor | relevant tests plus `npm run build` in `editor/` |
+| Rust | focused crate test plus `cargo test` |
+| Extension package | package test command from its `AGENTS.md` |
+| Workflow-facing capability | validate and run a representative graph |
+
+Run broader checks when a shared schema or runtime contract changes. Report
+checks that could not run because hardware, credentials, Docker, ROS, or CUDA
+were unavailable; do not claim those paths were verified.
+
+## Documentation
+
+Update the closest public contract alongside code:
+
+- `docs/agent-guide.md` for agent routing and workflow behavior.
+- `docs/packages.md` for package format and lifecycle.
+- `docs/custom-nodes.md` for node authoring.
+- `CONTRIBUTING.md` for contributor setup and verification.
+- The affected package README for package-specific behavior.
+
+Keep `skills/` and `.agents/skills/` synchronized when editing a shipped skill.

--- a/.agents/skills/blacknode-development/agents/openai.yaml
+++ b/.agents/skills/blacknode-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blacknode Development"
+  short_description: "Develop Blacknode core, nodes, and packages"
+  default_prompt: "Use $blacknode-development to add a tested capability to Blacknode."

--- a/.agents/skills/blacknode-workflow/SKILL.md
+++ b/.agents/skills/blacknode-workflow/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: blacknode-workflow
 description: >
-  Use this skill when the task asks an agent to create, edit, validate, run,
-  export, debug, visualize, extend, or open Blacknode workflows. Trigger phrases
-  include Blacknode, visual workflow, node graph, MCP workflow builder, run
-  replay, NVIDIA NIM workflow, workflow JSON, custom node, open in editor, and
-  framework export.
+  Create, edit, validate, run, debug, visualize, import, export, or open typed
+  Blacknode workflows using core nodes and extension packages. Use for requests
+  involving Blacknode workflow JSON, node graphs, MCP workflow building,
+  templates, editor runs, replay, NVIDIA NIM workflows, package-backed nodes,
+  or framework exports. Use blacknode-development instead when the requested
+  result is a change to Blacknode itself or a new reusable node/package.
 ---
 
 # Blacknode Workflow
@@ -13,7 +14,7 @@ description: >
 Blacknode is the visual workflow layer for agent harnesses. Use it when a chat
 or coding agent needs a typed node graph instead of raw JSON or ad hoc scripts.
 
-## When to Use
+## Scope
 
 Use this skill for:
 
@@ -22,11 +23,25 @@ Use this skill for:
 - Opening a workflow in the running visual editor.
 - Running a workflow or template and inspecting the structured event log.
 - Exporting or importing a workflow with Python round-trip, LangGraph, CrewAI, AutoGen, Swarm, or NVIDIA Agent Stack.
-- Creating persistent custom nodes and community node packs.
 - Creating NVIDIA NIM, local NIM, RAG, tool-agent, or research-pipeline demos.
+- Discovering or installing the extension package required by a workflow.
 
-Use the ordinary answer path for prose-only questions. Use this skill when the
-workflow artifact, editor state, run trace, custom node, or framework export matters.
+If no existing node expresses a reusable capability, stop graph construction
+and use `blacknode-development`. After implementing and testing the capability,
+return here to integrate it into a validated workflow.
+
+## Package-Aware Planning
+
+1. Inspect `list_nodes` and `list_templates` before assuming a node is missing.
+2. Prefer installed core or package nodes over one-off code.
+3. If a template reports missing nodes, use its `metadata.required_packages`
+   and the package index to identify the package.
+4. Ask before installing third-party package code. An indexed official package
+   may be installed when package installation is part of the user's request.
+5. Run `blacknode packages list` after installation and resolve declared
+   dependency warnings before cooking affected nodes.
+6. Use `PythonFn` only for workflow-local adapters. Use
+   `blacknode-development` for reusable nodes or packages.
 
 ## Available Surfaces
 

--- a/.agents/skills/blacknode-workflow/agents/openai.yaml
+++ b/.agents/skills/blacknode-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blacknode Workflow"
+  short_description: "Build and run typed Blacknode workflows"
+  default_prompt: "Use $blacknode-workflow to build and validate a typed Blacknode workflow."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Blacknode Agent Instructions
+
+These instructions apply to the Blacknode core repository. Extension packages
+under `packages/` are separate Git repositories and carry their own `AGENTS.md`.
+
+## Route the task
+
+- Use `.agents/skills/blacknode-workflow/SKILL.md` when the requested result is
+  a workflow graph, template, editor run, replay, validation, or export.
+- Use `.agents/skills/blacknode-development/SKILL.md` when changing Blacknode,
+  adding a reusable node, modifying the editor/runtime/MCP API, or creating an
+  extension package.
+- When a workflow exposes a missing reusable capability, switch to the
+  development skill, implement and test it, then return to the workflow skill
+  to integrate and validate the graph.
+
+## Repository map
+
+| Area | Responsibility |
+|---|---|
+| `python/blacknode/` | Python graph model, runtime, nodes, CLI, packages, exporters, and MCP |
+| `editor-server/` | FastAPI editor backend, runtime services, sessions, and run replay |
+| `editor/` | React/TypeScript visual editor |
+| `crates/` | Rust types, core, runtime, Python bindings, and CLI |
+| `templates/` | Tracked reusable workflow graphs |
+| `tests/` | Core Python and integration tests |
+| `packages/` | Independently versioned extension-package checkouts |
+
+## Change rules
+
+- Inspect the live node schema or the node decorator contract before adding or
+  connecting ports. Do not invent port names or persisted runtime fields.
+- Keep core broadly useful. Put hardware stacks, large optional dependencies,
+  and domain-specific integrations in extension packages.
+- Preserve compatibility for saved workflow node names unless a migration is
+  included. New workflows should use the current generic names.
+- Keep templates portable: declare `kind`, `schema_version`, an explicit
+  entrypoint, complete port metadata, and any `metadata.required_packages`.
+- Never commit API keys, run logs, local workflows, editor state, caches, robot
+  calibration data, or generated scratch exports.
+- Treat camera, CUDA, ROS, and robot streams as managed services. Do not turn a
+  one-shot cook into a polling loop.
+- Keep physical motion disarmed by default. Retain stale-data, joint-limit, and
+  shutdown safeguards in every transport path.
+
+## Verification
+
+Run the smallest relevant checks first, then the wider suite when shared
+contracts changed:
+
+```powershell
+python -m unittest discover -s tests
+cd editor
+npm run build
+cd ..
+cargo test
+```
+
+Package changes must also run the package's own tests from that package
+worktree. See `CONTRIBUTING.md` and `docs/agent-guide.md` for the public guide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,52 @@ npm install
 npm run dev
 ```
 
+Install the root project with development dependencies when changing the Python
+runtime, nodes, packages, CLI, or MCP server:
+
+```bash
+python -m pip install -e ".[dev,mcp]"
+```
+
+## Working with coding agents
+
+Read [`AGENTS.md`](AGENTS.md) before making repository changes.
+
+- Use the shipped `blacknode-workflow` skill to create, validate, run, inspect,
+  and export workflows using existing nodes and packages.
+- Use `blacknode-development` to modify core, editor, MCP, reusable nodes, or
+  extension packages.
+- Treat every folder under `packages/` as a separate Git repository. Read its
+  own `AGENTS.md`, check its status independently, and do not include package
+  changes in a core-repository commit.
+- If workflow construction reveals a missing reusable capability, implement and
+  test it through the development path, then validate it in a workflow.
+
+See the [Agent Guide](docs/agent-guide.md) for routing and the
+[Extension Packages guide](docs/packages.md) for package authoring.
+
+## Verification
+
+Run checks appropriate to the changed areas:
+
+```bash
+python -m unittest discover -s tests
+cd editor && npm run build
+cargo test
+```
+
+Run package tests from the core root with `python -m pytest
+packages/<package>/tests`, or follow the package's `AGENTS.md`. Hardware,
+network, provider, CUDA, camera, Docker, and ROS paths may skip locally; state
+clearly which paths were not exercised.
+
 ## Pull request guidelines
 
 - One logical change per PR.
 - Keep commit messages concise: subject line + optional body paragraph.
 - If you add a new node type, include a short description in the PR body.
+- Update the nearest public documentation and add a representative validated
+  workflow/template when it materially proves the capability.
 - Run `npm run build` in `editor/` before submitting to catch TypeScript errors.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -192,8 +192,10 @@ See [Blacknode and NVIDIA AI-Q](docs/aiq-integration.md) and
 | [Learned Nodes Test Plan](docs/learned-nodes-test-plan.md) | Step-by-step commands for validating Docker, MCP, editor refresh, consent, and the camera demo dry run. |
 | [Learned Nodes Internals](docs/learned-nodes-internals.md) | Registry wiring, manifest schema, execution wrapper, and SSE events. |
 | [Learned Nodes Sandbox](docs/learned-nodes-sandbox.md) | Docker image, runtime limits, configuration, and troubleshooting. |
-| [Agent Guide](docs/agent-guide.md) | How agents should create and modify Blacknode workflows. |
-| [Blacknode Skill](.agents/skills/blacknode-workflow/SKILL.md) | Agent skill instructions for workflow creation, validation, running, and export. |
+| [Agent Guide](docs/agent-guide.md) | How agents route workflow construction, reusable development, and package work. |
+| [Repository Agent Instructions](AGENTS.md) | Always-on repository map, invariants, safety rules, and verification commands. |
+| [Blacknode Workflow Skill](.agents/skills/blacknode-workflow/SKILL.md) | Build, validate, run, inspect, and export graphs using core and package nodes. |
+| [Blacknode Development Skill](.agents/skills/blacknode-development/SKILL.md) | Extend core, editor, MCP, reusable nodes, and extension packages. |
 
 ## Demos
 
@@ -226,6 +228,8 @@ See [Blacknode and NVIDIA AI-Q](docs/aiq-integration.md) and
 | `packages/` | Extension packages — separate git repos cloned in place (e.g. `blacknode-cuda`). |
 | `workflows/` | Local saved workflows, ignored by git. |
 | `docs/` | Walkthroughs, integration guides, workflow schema, and example assets. |
+| `AGENTS.md` | Repository-wide coding-agent routing and development rules. |
+| `skills/` | Canonical distributable Blacknode workflow and development skills. |
 | `docker-compose.yml` | Self-hosted editor, backend, and streamable HTTP MCP stack. |
 | `crates/` | Rust crates and no-server CLI. |
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -1,6 +1,45 @@
 # Blacknode Agent Guide
 
-This guide is for AI agents and contributors that need to inspect, create, validate, run, export, or share Blacknode workflows.
+This guide is for AI agents and contributors using or developing Blacknode. It
+defines the handoff between workflow construction and reusable platform or
+package development.
+
+## Choose the Agent Path
+
+Blacknode ships two complementary skills:
+
+| Goal | Skill | Result |
+|---|---|---|
+| Build with existing nodes and packages | `blacknode-workflow` | A validated graph, editor run, replay, or export |
+| Add or change reusable capability | `blacknode-development` | Tested core, editor, MCP, node, or extension-package changes |
+
+Repository instructions in [`AGENTS.md`](../AGENTS.md) orient coding agents
+before either skill is used. Each official extension package also carries its
+own scoped `AGENTS.md`, because packages are independent repositories with
+different dependencies, tests, and safety constraints.
+
+Do not create one general-purpose agent per package. The workflow skill should
+discover and use installed package nodes. The development skill should route
+code changes into the correct package and then follow that package's
+`AGENTS.md`. A package-specific skill is useful only when the package exposes a
+large standalone user workflow that cannot be routed clearly through these two
+skills.
+
+### Missing capability handoff
+
+When building a workflow:
+
+1. Inspect `list_nodes`, `get_node_schema`, and `list_templates`.
+2. Resolve missing official nodes through `metadata.required_packages` and the
+   package index.
+3. Use `PythonFn` only for a small adapter owned by that one graph.
+4. If a reusable capability is genuinely missing, switch to
+   `blacknode-development` and add a core, custom, community, or package node.
+5. Test the new capability, then return to `blacknode-workflow` to build,
+   validate, and run the final graph.
+
+The canonical skill sources live in `skills/`; `.agents/skills/` is the
+repository-discoverable mirror. Keep both copies synchronized.
 
 ## Current Contract
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -180,6 +180,7 @@ package code automatically.
 ```
 blacknode-ros2/
   blacknode-package.toml   # manifest (required)
+  AGENTS.md                # scoped coding-agent instructions (recommended)
   nodes/                   # Python modules using @node (required)
     __init__.py
     topics.py
@@ -196,6 +197,25 @@ modules get a stable import alias:
 ```python
 from blacknode.pkg.blacknode_ros2 import topics   # dashes become underscores
 ```
+
+### Agent guidance
+
+Every maintained package should include an `AGENTS.md` because it is an
+independent Git repository and may have domain-specific ownership, dependency,
+test, lifecycle, and safety rules. Keep that file concise and cover:
+
+- what belongs in the package and what belongs in core or a sibling package
+- optional dependency and no-hardware behavior
+- managed-service lifecycle and explicit shutdown, when applicable
+- exact focused test and template-validation commands
+- physical, credential, network, CUDA, camera, or ROS paths that must not be
+  claimed as tested without evidence
+
+Use the shared `blacknode-development` skill for package authoring and the
+package's `AGENTS.md` for its scoped implementation contract. Do not duplicate
+the same general authoring skill in every package. Create a package-specific
+skill only when its users need a distinct operational procedure beyond normal
+workflow construction.
 
 ## The manifest
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -24,3 +24,8 @@ robotics packages are split by responsibility: `blacknode-robot` is generic
 USB/driver setup, `blacknode-ros2` is ROS 2 transport/control, and
 `blacknode-vision` is camera/CV2/VLM perception. `blacknode-cuda` remains the
 smallest reference package to copy when writing your own.
+
+Maintained packages should include a scoped `AGENTS.md` with ownership,
+dependency, safety, and verification rules. Agents use the core
+`blacknode-development` skill for the shared authoring workflow, then follow the
+target package's `AGENTS.md`; packages do not need duplicated general skills.

--- a/skills/blacknode-development/SKILL.md
+++ b/skills/blacknode-development/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: blacknode-development
+description: >
+  Develop, extend, test, or debug Blacknode itself and its reusable extension
+  ecosystem. Use when changing the Python or Rust runtime, MCP server, editor,
+  package manager, exporters, node contracts, managed services, creating a
+  reusable core/custom/community node, authoring an extension package, or
+  modifying blacknode-cuda, blacknode-vision, blacknode-ros2, or
+  blacknode-robot. Use blacknode-workflow when the requested result is only a
+  workflow graph built from existing capabilities.
+---
+
+# Blacknode Development
+
+Develop the smallest reusable layer that owns the requested capability, protect
+saved-workflow compatibility, and prove the result through both focused tests
+and a representative workflow when applicable.
+
+## Start Here
+
+1. Read the nearest `AGENTS.md`; package repositories have scoped guidance.
+2. Inspect the current implementation, tests, and public documentation before
+   choosing a layer.
+3. Check Git status in the exact worktree being changed. `packages/*` are
+   independent repositories, not tracked children of the core repository.
+4. Decide whether the capability belongs in core, an extension package, a
+   user-local custom node, or a workflow-local `PythonFn`.
+5. Implement the narrowest coherent change, add tests, and update public docs.
+6. Build a small workflow/template when it materially proves discovery, ports,
+   runtime behavior, or package resolution.
+
+## Choose the Ownership Layer
+
+| Need | Put it here |
+|---|---|
+| Graph types, execution, validation, registry, CLI, MCP, exporters | `python/blacknode/` |
+| Browser/editor behavior or UI | `editor/` |
+| Editor HTTP API, runtime services, replay | `editor-server/` |
+| Portable Rust graph/runtime/CLI behavior | `crates/` |
+| Broad, dependency-light node | `python/blacknode/nodes/` |
+| Hardware, GPU, ROS, vision, or large optional dependency | extension package |
+| User-owned local reusable behavior | `custom-nodes/` |
+| One graph's small adapter | `PythonFn` in the workflow |
+
+Do not duplicate a domain implementation in core and a package. Keep the core
+contract generic and place transport- or hardware-specific implementations
+behind package nodes and runtime adapters.
+
+## Develop a Node
+
+1. Inspect `python/blacknode/node.py`, nearby nodes, and node tests.
+2. Define stable, typed inputs and outputs with the existing `@node` contract.
+3. Keep import-time behavior cheap and deterministic. Guard optional heavy
+   dependencies and return actionable structured errors at runtime.
+4. Separate one-shot cooking from persistent services. A stream/controller node
+   starts or updates one managed service; it does not create a polling cook.
+5. Add discovery/registration tests and behavior tests.
+6. Exercise the node in a minimal validated workflow or package template.
+7. Document configuration, outputs, dependencies, and lifecycle behavior.
+
+Preserve old node names needed by saved workflows as compatibility aliases.
+Use current generic names in new templates and docs.
+
+## Author an Extension Package
+
+Use `blacknode-cuda` as the smallest reference package. Read
+`docs/packages.md` and `docs/custom-nodes.md` before authoring.
+
+Required shape:
+
+```text
+blacknode-example/
+  blacknode-package.toml
+  nodes/
+    __init__.py
+  tests/
+  templates/          # optional
+  requirements.txt    # optional
+  README.md
+  AGENTS.md
+```
+
+- Declare `name`, `version`, `description`, and `requires-blacknode`.
+- Declare import names under `dependencies.imports`, pip requirements under
+  `dependencies.pip`, and Docker images when required.
+- Keep package loading functional when optional runtime dependencies are absent;
+  surface dependency warnings and actionable setup commands.
+- Add `metadata.required_packages` to templates that use package nodes.
+- Keep each package independently testable, versioned, documented, and
+  publishable from its own Git repository.
+- Add scoped `AGENTS.md` safety and test instructions. Create a package-specific
+  skill only when users need a distinct, substantial operational workflow that
+  cannot be routed clearly through `blacknode-workflow`.
+
+## Cross-Layer Contracts
+
+When changing node schemas, runtime events, managed services, or package APIs,
+trace all consumers:
+
+```text
+node/package -> registry and schema -> editor-server/MCP -> editor -> template
+             -> tests and documentation
+```
+
+Update each affected layer in the same change. Do not persist editor-only fields
+such as `cookResult`, `cookError`, `cooking`, or `cookPort` in workflow JSON.
+
+## Hardware and Managed-Service Safety
+
+- Keep robot motion disarmed until explicitly authorized.
+- Never bypass calibrated limits, freshness checks, or emergency shutdown.
+- Treat worker heartbeat and source-data freshness as separate signals.
+- Preserve idempotent control behavior across retries.
+- Make stop paths explicit and testable. Robot shutdown may release torque.
+- Do not use physical hard stops to discover joint limits.
+
+Read the target package's `AGENTS.md` before modifying CUDA, vision, ROS 2, or
+robot code.
+
+## Verification Matrix
+
+| Change | Minimum verification |
+|---|---|
+| Python runtime, nodes, MCP, packages, templates | focused test plus `python -m unittest discover -s tests` |
+| Editor | relevant tests plus `npm run build` in `editor/` |
+| Rust | focused crate test plus `cargo test` |
+| Extension package | package test command from its `AGENTS.md` |
+| Workflow-facing capability | validate and run a representative graph |
+
+Run broader checks when a shared schema or runtime contract changes. Report
+checks that could not run because hardware, credentials, Docker, ROS, or CUDA
+were unavailable; do not claim those paths were verified.
+
+## Documentation
+
+Update the closest public contract alongside code:
+
+- `docs/agent-guide.md` for agent routing and workflow behavior.
+- `docs/packages.md` for package format and lifecycle.
+- `docs/custom-nodes.md` for node authoring.
+- `CONTRIBUTING.md` for contributor setup and verification.
+- The affected package README for package-specific behavior.
+
+Keep `skills/` and `.agents/skills/` synchronized when editing a shipped skill.

--- a/skills/blacknode-development/agents/openai.yaml
+++ b/skills/blacknode-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blacknode Development"
+  short_description: "Develop Blacknode core, nodes, and packages"
+  default_prompt: "Use $blacknode-development to add a tested capability to Blacknode."

--- a/skills/blacknode-workflow/SKILL.md
+++ b/skills/blacknode-workflow/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: blacknode-workflow
 description: >
-  Use this skill when the task asks an agent to create, edit, validate, run,
-  export, debug, visualize, extend, or open Blacknode workflows. Trigger phrases
-  include Blacknode, visual workflow, node graph, MCP workflow builder, run
-  replay, NVIDIA NIM workflow, workflow JSON, custom node, open in editor, and
-  framework export.
+  Create, edit, validate, run, debug, visualize, import, export, or open typed
+  Blacknode workflows using core nodes and extension packages. Use for requests
+  involving Blacknode workflow JSON, node graphs, MCP workflow building,
+  templates, editor runs, replay, NVIDIA NIM workflows, package-backed nodes,
+  or framework exports. Use blacknode-development instead when the requested
+  result is a change to Blacknode itself or a new reusable node/package.
 ---
 
 # Blacknode Workflow
@@ -13,7 +14,7 @@ description: >
 Blacknode is the visual workflow layer for agent harnesses. Use it when a chat
 or coding agent needs a typed node graph instead of raw JSON or ad hoc scripts.
 
-## When to Use
+## Scope
 
 Use this skill for:
 
@@ -22,11 +23,25 @@ Use this skill for:
 - Opening a workflow in the running visual editor.
 - Running a workflow or template and inspecting the structured event log.
 - Exporting or importing a workflow with Python round-trip, LangGraph, CrewAI, AutoGen, Swarm, or NVIDIA Agent Stack.
-- Creating persistent custom nodes and community node packs.
 - Creating NVIDIA NIM, local NIM, RAG, tool-agent, or research-pipeline demos.
+- Discovering or installing the extension package required by a workflow.
 
-Use the ordinary answer path for prose-only questions. Use this skill when the
-workflow artifact, editor state, run trace, custom node, or framework export matters.
+If no existing node expresses a reusable capability, stop graph construction
+and use `blacknode-development`. After implementing and testing the capability,
+return here to integrate it into a validated workflow.
+
+## Package-Aware Planning
+
+1. Inspect `list_nodes` and `list_templates` before assuming a node is missing.
+2. Prefer installed core or package nodes over one-off code.
+3. If a template reports missing nodes, use its `metadata.required_packages`
+   and the package index to identify the package.
+4. Ask before installing third-party package code. An indexed official package
+   may be installed when package installation is part of the user's request.
+5. Run `blacknode packages list` after installation and resolve declared
+   dependency warnings before cooking affected nodes.
+6. Use `PythonFn` only for workflow-local adapters. Use
+   `blacknode-development` for reusable nodes or packages.
 
 ## Available Surfaces
 

--- a/skills/blacknode-workflow/agents/openai.yaml
+++ b/skills/blacknode-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blacknode Workflow"
+  short_description: "Build and run typed Blacknode workflows"
+  default_prompt: "Use $blacknode-workflow to build and validate a typed Blacknode workflow."


### PR DESCRIPTION
## What changed

- add repository-wide `AGENTS.md` routing and development rules
- split workflow construction from reusable Blacknode development into two validated skills
- add skill UI metadata and keep canonical and `.agents` copies synchronized
- document package-scoped agent guidance and contributor verification

## Why

Agents need a clear handoff between building graphs from existing nodes and changing core or package code when a reusable capability is missing.

## Impact

Workflow users get package-aware graph guidance, while contributors get explicit ownership, compatibility, safety, testing, and documentation rules.

## Checks

- validated all four skill locations with `quick_validate.py`
- confirmed canonical and `.agents` skill mirrors are byte-identical
- checked Markdown links and Git diffs
