### PR TITLE
Add workspace package onboarding

### DIFF
--- a/.agents/skills/blacknode-workflow/SKILL.md
+++ b/.agents/skills/blacknode-workflow/SKILL.md
@@ -66,7 +66,7 @@ Visual editor:
 On Windows:
 
 ```powershell
-start.bat
+.\start.bat
 ```
 
 CLI checks:

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ CLAUDE.md
 .claude/
 .local-notes/
 .local-logs/
+/.blacknode/
 docs/todays-goal.md
 docs/public-preview-checklist.md
 docs/future-ideas.md

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Windows:
 ```powershell
 git clone https://github.com/temiroff/Blacknode.git
 cd Blacknode
-start.bat
+.\start.bat
 ```
 
 macOS/Linux:
@@ -76,6 +76,13 @@ chmod +x start.sh
 
 Python 3.11+ and Node.js 20.19+ or 22.12+ are required. A warm start normally
 takes less than a minute; first-run time depends on network and package caches.
+
+On the first launch of a Blacknode workspace, the editor opens **Packages** with
+a one-time welcome message. Install the official packages needed for robotics,
+ROS 2, vision, CUDA, datasets, and training workflows, or continue directly
+with the core graph. The acknowledgement is stored locally in
+`.blacknode/onboarding.json`, and the Packages tab remains available in the
+left sidebar.
 
 Continue with the [Beginner Walkthrough](docs/walkthrough.md).
 

--- a/docs/framework-export.md
+++ b/docs/framework-export.md
@@ -6,7 +6,7 @@ outside the editor.
 
 ## Editor
 
-1. Start Blacknode with `start.bat` on Windows or `./start.sh` on macOS/Linux.
+1. Start Blacknode with `.\start.bat` on Windows or `./start.sh` on macOS/Linux.
 2. Open or build a workflow that ends in an `Output` or `OutputImage` node.
 3. Press `Export` in the top bar.
 4. Choose `Plain Python`, `Python Class`, `LangGraph`, `CrewAI`, `AutoGen`, `OpenAI Swarm`, or `NVIDIA Agent Stack`.

--- a/docs/nvidia-mission-control.md
+++ b/docs/nvidia-mission-control.md
@@ -78,7 +78,7 @@ Expected result:
 ### 2. Open the visual workflow
 
 ```powershell
-start.bat
+.\start.bat
 ```
 
 Then open the **Templates** tab and load **NVIDIA Video Intelligence Mission

--- a/docs/nvidia-nim-demo.md
+++ b/docs/nvidia-nim-demo.md
@@ -25,7 +25,7 @@ https://github.com/user-attachments/assets/9debbc72-68d7-4717-9a44-433ae65fd4d2
 For the Windows one-command path:
 
 ```bat
-start.bat
+.\start.bat
 ```
 
 For a manual two-terminal path:

--- a/docs/nvidia-visual-rag.md
+++ b/docs/nvidia-visual-rag.md
@@ -53,7 +53,7 @@ $env:NVIDIA_API_KEY="nvapi-..."
 Open the editor:
 
 ```powershell
-start.bat
+.\start.bat
 ```
 
 Alternatively, select any NVIDIA node and enter the key once in the

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -96,6 +96,13 @@ If auto-update is disabled but you still want startup to fetch remote state, set
 Official packages are listed in the editor's Packages tab even when they are not
 installed. Press **Install** on an available package to clone it from the built-in
 Git URL without pasting a repository URL manually.
+
+On a Blacknode workspace's first editor session, the editor opens this tab
+behind a one-time welcome message. The message directs robotics users to install
+the official packages their workflows require and lets core-graph users
+continue immediately. After either choice, Blacknode records the acknowledgement
+in `.blacknode/onboarding.json` inside the repository and does not show the
+message again for that workspace.
 ## Official robotics and vision packages
 
 The robotics packages are separate repos but can live under `packages/` during

--- a/docs/python-roundtrip.md
+++ b/docs/python-roundtrip.md
@@ -90,7 +90,7 @@ Invoke-RestMethod `
 
 Live sync lets a Python script push run events back into the editor.
 
-1. Start Blacknode with `start.bat`.
+1. Start Blacknode with `.\start.bat`.
 2. Export a workflow to Python.
 3. Run the script with `BLACKNODE_SYNC_URL` pointing at the editor backend.
 

--- a/docs/quickstart-mcp.md
+++ b/docs/quickstart-mcp.md
@@ -16,7 +16,7 @@ The no-API-key smoke test works without model credentials.
 From the repository root on Windows:
 
 ```bat
-start.bat
+.\start.bat
 ```
 
 From the repository root on macOS/Linux:
@@ -26,7 +26,7 @@ chmod +x start.sh
 ./start.sh
 ```
 
-These launchers install local dependencies if needed, start the FastAPI backend at `http://127.0.0.1:7777`, restart an old Blacknode editor on port 3000 if needed, start the Vite editor at `http://localhost:3000`, and open the browser. On Windows, `start.bat` keeps one launcher window open and writes service logs to `.local-logs/`.
+These launchers install local dependencies if needed, start the FastAPI backend at `http://127.0.0.1:7777`, restart an old Blacknode editor on port 3000 if needed, start the Vite editor at `http://localhost:3000`, and open the browser. On Windows, `.\start.bat` keeps one launcher window open and writes service logs to `.local-logs/`.
 
 If you see `Stopping existing visual editor on port 3000...`, the launcher
 found an old Blacknode Vite server and restarted it so the editor stays on

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -39,7 +39,7 @@ visual editor, and opens the browser. Later starts reuse the installed files.
 Windows:
 
 ```bat
-start.bat
+.\start.bat
 ```
 
 macOS/Linux:
@@ -58,6 +58,13 @@ What this does:
 
 First-run time depends on network speed and whether pip/npm packages are already
 cached. Later starts normally complete in less than one minute.
+
+On the first launch of this Blacknode workspace, a welcome message opens the
+**Packages** tab. Use it to install the official packages needed by robotics,
+ROS 2, vision, CUDA, dataset, and training templates. Choose **Continue with
+core graph** when you want to begin with built-in nodes. Blacknode records the
+choice in `.blacknode/onboarding.json`; Packages stays available in the left
+sidebar.
 
 ## 3. Check the Local Setup
 
@@ -148,7 +155,7 @@ Expected result:
 - If an old Blacknode editor is already on port `3000`, the launcher restarts
   it and keeps the same URL.
 
-If you stopped the launcher, run `start.bat` or `./start.sh` again.
+If you stopped the launcher, run `.\start.bat` or `./start.sh` again.
 
 If the browser does not open, open this manually:
 
@@ -320,7 +327,7 @@ Windows:
 
 ```powershell
 $env:NVIDIA_API_KEY="your-key"
-start.bat
+.\start.bat
 ```
 
 macOS/Linux:
@@ -587,7 +594,7 @@ blacknode = "blacknode.cli:main"
 Run the launcher again:
 
 ```powershell
-start.bat
+.\start.bat
 ```
 
 or:

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -208,6 +208,9 @@ class SetApiKeyReq(BaseModel):
     provider: str
     key: str
 
+class SetOnboardingReq(BaseModel):
+    package_welcome_seen: bool = True
+
 class SaveWorkflowReq(BaseModel):
     name: str
     previous_slug: str | None = None
@@ -580,6 +583,39 @@ class AddCustomModelReq(BaseModel):
 
 
 _load_custom_models()
+
+# ── Workspace onboarding persistence ─────────────────────────────────────────
+
+_ONBOARDING_PATH = Path(__file__).resolve().parents[1] / ".blacknode" / "onboarding.json"
+_onboarding_state: dict[str, bool] = {"package_welcome_seen": False}
+
+
+def _load_onboarding_state() -> None:
+    global _onboarding_state
+    if not _ONBOARDING_PATH.exists():
+        _onboarding_state = {"package_welcome_seen": False}
+        return
+    try:
+        payload = json.loads(_ONBOARDING_PATH.read_text(encoding="utf-8"))
+        _onboarding_state = {
+            "package_welcome_seen": bool(payload.get("package_welcome_seen", False)),
+        }
+    except Exception as e:
+        _onboarding_state = {"package_welcome_seen": False}
+        print(f"[blacknode] Could not load onboarding state: {e}")
+
+
+def _save_onboarding_state() -> None:
+    try:
+        _ONBOARDING_PATH.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = _ONBOARDING_PATH.with_suffix(".json.tmp")
+        temp_path.write_text(json.dumps(_onboarding_state, indent=2) + "\n", encoding="utf-8")
+        temp_path.replace(_ONBOARDING_PATH)
+    except Exception as e:
+        print(f"[blacknode] Could not save onboarding state: {e}")
+
+
+_load_onboarding_state()
 
 
 def _toolbox_port_sort_key(port: str) -> tuple[int, str]:
@@ -2885,6 +2921,18 @@ def set_api_key(req: SetApiKeyReq):
         "restarted": restarted,
         "credential": _api_key_status().get(req.provider),
     }
+
+
+@app.get("/settings/onboarding")
+def get_onboarding_state():
+    return dict(_onboarding_state)
+
+
+@app.post("/settings/onboarding")
+def set_onboarding_state(req: SetOnboardingReq):
+    _onboarding_state["package_welcome_seen"] = req.package_welcome_seen
+    _save_onboarding_state()
+    return {"ok": True, **_onboarding_state}
 
 
 # ── Driver status bridge ──────────────────────────────────────────────────

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -385,6 +385,9 @@ export const api = {
   getApiKeyStatus:  () => req<Record<string, ApiKeyStatus>>('GET', '/settings/api-key-status'),
   setApiKey:        (provider: string, key: string) =>
     req<{ ok: boolean; restarted?: string | null; credential?: ApiKeyStatus }>('POST', '/settings/api-key', { provider, key }),
+  getOnboarding:    () => req<{ package_welcome_seen: boolean }>('GET', '/settings/onboarding'),
+  setOnboarding:    (packageWelcomeSeen: boolean) =>
+    req<{ ok: boolean; package_welcome_seen: boolean }>('POST', '/settings/onboarding', { package_welcome_seen: packageWelcomeSeen }),
   getCustomModels:  () => req<string[]>('GET', '/settings/custom-models'),
   addCustomModel:   (value: string) => req('POST', '/settings/custom-models', { value }),
   removeCustomModel:(value: string) => req('DELETE', `/settings/custom-models?value=${encodeURIComponent(value)}`),

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
+import { api } from '../api'
 import { useStore } from '../store'
 import { CATEGORIES } from '../categories'
 import { isPythonToolPreset, resolvePythonToolPreset } from '../pythonToolPresets'
@@ -19,6 +20,16 @@ const RAIL_W = 78
 const PANEL_DEFAULT_W = 240
 const PANEL_MIN_W = 188
 const PANEL_MAX_W = 520
+const welcomeButtonStyle: React.CSSProperties = {
+  border: '1px solid var(--line2)',
+  borderRadius: 6,
+  background: 'transparent',
+  color: 'var(--tx2)',
+  cursor: 'pointer',
+  fontFamily: 'var(--font-ui)',
+  fontSize: 12,
+  padding: '7px 12px',
+}
 
 const ICON_NODES = (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
@@ -90,6 +101,7 @@ const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
 export default function NodePalette() {
   const { nodeTypes, nodeDefs, addNode, loadNodeTypes, learnedNodeHighlight } = useStore()
   const [activeTab, setActiveTab] = useState<Tab | null>('nodes')
+  const [showPackageWelcome, setShowPackageWelcome] = useState(false)
   const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_W)
   const [openGroups, setOpenGroups] = useState<Set<string>>(() => new Set())
   const dragRef = useRef<{ startX: number; startW: number } | null>(null)
@@ -97,6 +109,24 @@ export default function NodePalette() {
   useEffect(() => {
     if (activeTab === 'nodes') loadNodeTypes()
   }, [activeTab, loadNodeTypes])
+
+  useEffect(() => {
+    let active = true
+    api.getOnboarding()
+      .then(state => {
+        if (active && !state.package_welcome_seen) {
+          setActiveTab('packages')
+          setShowPackageWelcome(true)
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setActiveTab('packages')
+          setShowPackageWelcome(true)
+        }
+      })
+    return () => { active = false }
+  }, [])
 
   useEffect(() => {
     if (!learnedNodeHighlight) return
@@ -161,6 +191,17 @@ export default function NodePalette() {
     })
   }
 
+  const finishPackageWelcome = async (tab: Tab) => {
+    try {
+      await api.setOnboarding(true)
+    } catch {
+      // Keep the editor usable; an unavailable server will cause the prompt
+      // to return on the next launch instead of losing the acknowledgement.
+    }
+    setShowPackageWelcome(false)
+    setActiveTab(tab)
+  }
+
   const renderGroupHeader = (group: string, color: string, count: number) => {
     const open = openGroups.has(group)
     return (
@@ -210,6 +251,63 @@ export default function NodePalette() {
 
   return (
     <div style={{ display: 'flex', flexShrink: 0, height: '100%' }}>
+
+      {showPackageWelcome && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="package-welcome-title"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 1000,
+            background: 'rgba(4, 8, 18, 0.72)',
+            display: 'grid',
+            placeItems: 'center',
+            padding: 24,
+          }}
+        >
+          <div style={{
+            width: 'min(520px, calc(100vw - 48px))',
+            background: 'var(--panel)',
+            border: '1px solid var(--line2)',
+            borderRadius: 12,
+            boxShadow: '0 24px 80px rgba(0,0,0,.5)',
+            padding: 24,
+            color: 'var(--tx1)',
+            fontFamily: 'var(--font-ui)',
+          }}>
+            <div style={{ color: 'var(--accent)', fontSize: 11, fontWeight: 800, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+              Welcome to Blacknode
+            </div>
+            <h1 id="package-welcome-title" style={{ margin: '8px 0 10px', fontSize: 22, lineHeight: 1.2 }}>
+              Prepare your robotics workspace
+            </h1>
+            <p style={{ margin: 0, color: 'var(--tx2)', fontSize: 13, lineHeight: 1.6 }}>
+              Start in Packages and install the official Blacknode capabilities for robot hardware, ROS 2, vision, CUDA, datasets, and training. Package-backed templates need their listed packages before they can run.
+            </p>
+            <p style={{ margin: '10px 0 0', color: 'var(--tx3)', fontSize: 12, lineHeight: 1.5 }}>
+              Core graph workflows are ready immediately. You can return to Packages at any time from the left sidebar.
+            </p>
+            <div style={{ marginTop: 20, display: 'flex', gap: 10, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+              <button
+                type="button"
+                onClick={() => finishPackageWelcome('nodes')}
+                style={welcomeButtonStyle}
+              >
+                Continue with core graph
+              </button>
+              <button
+                type="button"
+                onClick={() => finishPackageWelcome('packages')}
+                style={{ ...welcomeButtonStyle, padding: '7px 14px', color: '#fff', background: 'var(--accent)', borderColor: 'var(--accent)', fontWeight: 700 }}
+              >
+                Explore essential packages
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* ── Icon rail ── */}
       <div style={{

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -118,6 +118,17 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "LeRobotV3Export",
         ],
     },
+    "blacknode-training": {
+        "name": "blacknode-training",
+        "git_url": "https://github.com/temiroff/blacknode-training.git",
+        "description": "Offline robot-policy dataset checks, managed PyTorch training, checkpoints, metrics, and prediction previews.",
+        "node_types": [
+            "TrainingDatasetCheck",
+            "ACTTraining",
+            "ACTCheckpointInspect",
+            "ACTPolicyPreview",
+        ],
+    },
 }
 
 _NODE_PACKAGE_INDEX: dict[str, dict[str, str]] = {

--- a/skills/blacknode-workflow/SKILL.md
+++ b/skills/blacknode-workflow/SKILL.md
@@ -66,7 +66,7 @@ Visual editor:
 On Windows:
 
 ```powershell
-start.bat
+.\start.bat
 ```
 
 CLI checks:

--- a/start.ps1
+++ b/start.ps1
@@ -184,7 +184,7 @@ function Write-PortBusyError {
         Write-Host ""
         Write-Host "  Listening process id(s): $(@($ProcessIds) -join ', ')"
     }
-    Write-Host "  Close that app or free port $Port, then run start.bat again."
+    Write-Host "  Close that app or free port $Port, then run .\start.bat again."
 }
 
 function Invoke-NativeProbe {

--- a/tests/test_editor_onboarding_state.py
+++ b/tests/test_editor_onboarding_state.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITOR_SERVER_DIR = ROOT / "editor-server"
+
+if str(EDITOR_SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(EDITOR_SERVER_DIR))
+
+import server  # noqa: E402
+
+
+def test_onboarding_is_workspace_local_and_persistent(tmp_path: Path):
+    state_path = tmp_path / ".blacknode" / "onboarding.json"
+    state = {"package_welcome_seen": False}
+
+    with (
+        patch.object(server, "_ONBOARDING_PATH", state_path),
+        patch.object(server, "_onboarding_state", state),
+    ):
+        client = TestClient(server.app)
+        first = client.get("/settings/onboarding")
+        saved = client.post("/settings/onboarding", json={"package_welcome_seen": True})
+
+        assert first.status_code == 200
+        assert first.json() == {"package_welcome_seen": False}
+        assert saved.status_code == 200
+        assert saved.json() == {"ok": True, "package_welcome_seen": True}
+        assert json.loads(state_path.read_text(encoding="utf-8")) == {
+            "package_welcome_seen": True,
+        }
+
+
+def test_missing_workspace_state_shows_welcome(tmp_path: Path):
+    with patch.object(server, "_ONBOARDING_PATH", tmp_path / "missing.json"):
+        server._load_onboarding_state()
+        assert server._onboarding_state == {"package_welcome_seen": False}

--- a/tests/test_editor_package_welcome.py
+++ b/tests/test_editor_package_welcome.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_first_editor_visit_opens_packages_with_one_time_welcome():
+    source = (ROOT / "editor" / "src" / "components" / "NodePalette.tsx").read_text(encoding="utf-8")
+
+    assert "api.getOnboarding()" in source
+    assert "!state.package_welcome_seen" in source
+    assert "setActiveTab('packages')" in source
+    assert "await api.setOnboarding(true)" in source
+    assert "localStorage" not in source
+    assert "Prepare your robotics workspace" in source
+    assert "Explore essential packages" in source
+    assert "Continue with core graph" in source

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 
@@ -23,3 +24,19 @@ def test_core_launchers_do_not_install_optional_cuda_dependencies():
 
     assert "pip install cupy" not in powershell.lower()
     assert "pip_install cupy" not in shell.lower()
+
+
+def test_windows_markdown_launch_commands_are_powershell_explicit():
+    markdown_files = [ROOT / "README.md", *ROOT.joinpath("docs").rglob("*.md")]
+    markdown_files.extend([
+        ROOT / "skills" / "blacknode-workflow" / "SKILL.md",
+        ROOT / ".agents" / "skills" / "blacknode-workflow" / "SKILL.md",
+    ])
+
+    ambiguous = []
+    for path in markdown_files:
+        text = path.read_text(encoding="utf-8")
+        if re.search(r"(?<!\.\\)start\.bat", text):
+            ambiguous.append(str(path.relative_to(ROOT)))
+
+    assert ambiguous == []

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -49,6 +49,10 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["Camera"]["package"] == "blacknode-vision"
     assert payload["nodes"]["CameraStream"]["package"] == "blacknode-vision"
     assert payload["nodes"]["CV2CameraStream"]["package"] == "blacknode-vision"
+    assert payload["nodes"]["ACTTraining"] == {
+        "package": "blacknode-training",
+        "git_url": "https://github.com/temiroff/blacknode-training.git",
+    }
 
 
 def test_resolver_finds_nested_nodes_and_indexed_package():


### PR DESCRIPTION
## What changed

- add a one-time first-workspace welcome dialog that opens the Packages tab
- persist acknowledgement in `.blacknode/onboarding.json` through the editor server instead of browser storage
- acknowledge onboarding only after an explicit user action
- add `blacknode-training` to the official package catalog
- use explicit `.\start.bat` commands throughout Windows documentation and launcher guidance
- document the workspace onboarding behavior
- add backend, editor-contract, catalog, and documentation regression tests

## Why

A fresh Blacknode clone should guide users to official packages before package-backed robotics workflows. Browser storage made the experience inconsistent across clones and browser profiles, and an unpublished test clone could not exercise the new flow. Workspace-local persistence makes first-run behavior deterministic and keeps the acknowledgement out of Git.

## Validation

- `python -m pytest -q`: 595 passed, 16 skipped, 45 subtests passed
- `PYTHONPATH=python python -m unittest discover -s tests`: 312 passed, 8 skipped
- `npm run build`: passed
- focused onboarding and package-index tests: passed
- `git diff --check`: passed