### PR TITLE
Show live STREAMING state for StreamPublisher node

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ takes less than a minute; first-run time depends on network and package caches.
 On the first launch of a Blacknode workspace, the editor opens **Packages** with
 a one-time welcome message. Install the official packages needed for robotics,
 ROS 2, vision, CUDA, datasets, and training workflows, or continue directly
-with the core graph. The acknowledgement is stored locally in
+with the core templates. The acknowledgement is stored locally in
 `.blacknode/onboarding.json`, and the Packages tab remains available in the
-left sidebar.
+left sidebar. After onboarding, normal editor sessions start in **Templates**;
+the full Nodes palette remains available when building a graph manually.
 
 Continue with the [Beginner Walkthrough](docs/walkthrough.md).
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -35,7 +35,9 @@ blacknode packages setup blacknode-ros2
 ```
 
 `start.ps1` and `start.sh` automatically install missing declared Python
-dependencies for installed packages before starting the server. Set
+dependencies for installed packages before starting the server. The launchers
+stream package names, dependency resolution, downloads, and pip installation
+output while this step runs. Set
 `BLACKNODE_PACKAGE_AUTO_SETUP=0` to disable that behavior. Automatic startup
 setup does not pull Docker images or run package setup scripts; use the command
 above when those additional prerequisites are required.
@@ -96,6 +98,11 @@ If auto-update is disabled but you still want startup to fetch remote state, set
 Official packages are listed in the editor's Packages tab even when they are not
 installed. Press **Install** on an available package to clone it from the built-in
 Git URL without pasting a repository URL manually.
+
+The editor's **Templates** tab groups starter workflows by Core or their source
+package category. Every group starts collapsed, its templates inherit the
+category color, and the search field filters across category names, template
+names, slugs, and descriptions.
 
 On a Blacknode workspace's first editor session, the editor opens this tab
 behind a one-time welcome message. The message directs robotics users to install

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -168,7 +168,7 @@ http://localhost:3000
 In the browser:
 
 1. Look at the left sidebar.
-2. Click the **Templates** tab.
+2. Use the **Templates** tab, which is open by default after onboarding.
 3. Click **Text Pipeline**.
 4. Click the **Output** node on the canvas.
 5. In the right **Properties** panel, click **Cook**.
@@ -178,6 +178,10 @@ Expected result:
 - The Output node shows `Hello World`.
 - A small run status appears while the graph cooks once.
 - The run is saved in the **Runs** tab.
+
+An Output node connected to a typed image or video port opens at the same large
+dashboard size used by robot monitoring nodes. Live camera frames and video
+controls stay inside the node.
 
 ## 7. Build the Same Workflow by Hand
 

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
@@ -167,6 +167,17 @@ class ConnectReq(BaseModel):
 class UpdateParamReq(BaseModel):
     key: str
     value: Any
+
+class NodeControlReq(BaseModel):
+    action: str
+
+class PickDirectoryReq(BaseModel):
+    initial_path: str = ""
+
+class DatasetTrimReq(BaseModel):
+    token: str
+    frame_index: int
+    side: str
 
 class UpdatePortsReq(BaseModel):
     inputs: list[str] | None = None
@@ -1232,6 +1243,57 @@ def update_param(node_id: str, req: UpdateParamReq):
     _push_live_node_param_update(meta, req.key, req.value, old_params)
     _save()
     return meta
+
+
+@app.post("/nodes/{node_id}/control")
+def control_node(node_id: str, req: NodeControlReq):
+    meta = _session.node_meta.get(node_id)
+    if meta is None:
+        raise HTTPException(404, "Node not found")
+    if meta.get("type") != "EpisodeRecorder":
+        raise HTTPException(400, "This node does not expose direct controls")
+    control_fn = _runtime_callable("dataset", _RUNTIME_MODULES["dataset"], "control_configured_recorder")
+    if control_fn is None:
+        raise HTTPException(503, "blacknode-dataset recorder runtime is not loaded")
+    run_id = str(meta.get("params", {}).get("run_id") or "episode_recorder").strip() or "episode_recorder"
+    try:
+        outputs = dict(control_fn(run_id, req.action))
+    except ValueError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    return {"ok": True, "node_id": node_id, "outputs": outputs}
+
+
+def _pick_directory(initial_path: str = "") -> str:
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+    except Exception as exc:  # pragma: no cover - depends on the local Python GUI build
+        raise RuntimeError(f"native folder picker is unavailable: {exc}") from exc
+    initial = Path(str(initial_path or "")).expanduser()
+    if not initial.is_dir():
+        initial = Path.home()
+    root = tk.Tk()
+    try:
+        root.withdraw()
+        root.attributes("-topmost", True)
+        root.update()
+        return str(filedialog.askdirectory(
+            parent=root,
+            title="Choose a folder that will contain Blacknode datasets",
+            initialdir=str(initial),
+            mustexist=True,
+        ) or "")
+    finally:
+        root.destroy()
+
+
+@app.post("/filesystem/pick-directory")
+def pick_directory(req: PickDirectoryReq):
+    try:
+        selected = _pick_directory(req.initial_path)
+    except RuntimeError as exc:
+        raise HTTPException(503, str(exc)) from exc
+    return {"selected": selected, "cancelled": not bool(selected)}
 
 
 @app.patch("/nodes/{node_id}/ports")
@@ -2311,6 +2373,43 @@ def ollama_models(endpoint_url: str = "http://127.0.0.1:11434"):
 @app.get("/runtime/status")
 def runtime_status():
     return _runtime_status()
+
+
+@app.get("/api/dataset/media/{token}")
+@app.get("/dataset/media/{token}")
+def dataset_media(token: str):
+    resolve_fn = _runtime_callable("dataset", _RUNTIME_MODULES["dataset"], "replay_media_path")
+    path = resolve_fn(token) if resolve_fn is not None else None
+    if path is None:
+        raise HTTPException(404, "Replay media not found")
+    return FileResponse(path, media_type="video/mp4")
+
+
+@app.get("/api/dataset/frame/{token}")
+@app.get("/dataset/frame/{token}")
+def dataset_frame(token: str, index: int = 0):
+    frame_fn = _runtime_callable("dataset", _RUNTIME_MODULES["dataset"], "replay_frame")
+    try:
+        frame = frame_fn(token, index) if frame_fn is not None else None
+    except (RuntimeError, ValueError) as exc:
+        raise HTTPException(409, str(exc)) from exc
+    if frame is None:
+        raise HTTPException(404, "Replay frame not found")
+    return frame
+
+
+@app.post("/api/dataset/trim")
+@app.post("/dataset/trim")
+def dataset_trim(req: DatasetTrimReq):
+    trim_fn = _runtime_callable("dataset", _RUNTIME_MODULES["dataset"], "trim_replay_episode")
+    if trim_fn is None:
+        raise HTTPException(503, "blacknode-dataset trim runtime is not loaded")
+    try:
+        return dict(trim_fn(req.token, req.frame_index, req.side))
+    except ValueError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(500, str(exc)) from exc
 
 
 @app.post("/runtime/stop")
@@ -3530,6 +3629,21 @@ def _template_dirs() -> list[str]:
     return [_TEMPLATES_DIR, *package_template_dirs()]
 
 
+def _template_sources() -> list[tuple[str, str, str]]:
+    """Return template directories with stable editor grouping metadata."""
+    sources = [(_TEMPLATES_DIR, "Core", "#6366f1")]
+    for info in installed_packages():
+        if not info.ok or not info.templates_dir:
+            continue
+        if info.categories:
+            group, color = next(iter(info.categories.items()))
+        else:
+            group = info.name.removeprefix("blacknode-").replace("-", " ").title()
+            color = "#6366f1"
+        sources.append((info.templates_dir, group, color))
+    return sources
+
+
 def _template_path(slug: str) -> str:
     if not re.fullmatch(r"[a-zA-Z0-9_-]{1,60}", slug):
         raise HTTPException(400, "Invalid template slug")
@@ -3549,7 +3663,13 @@ def _read_workflow_file(path: str) -> dict[str, Any]:
     return data
 
 
-def _workflow_summary(slug: str, data: dict[str, Any]) -> dict[str, Any]:
+def _workflow_summary(
+    slug: str,
+    data: dict[str, Any],
+    *,
+    group: str = "Core",
+    group_color: str = "#6366f1",
+) -> dict[str, Any]:
     metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
     return {
         "slug": slug,
@@ -3558,6 +3678,8 @@ def _workflow_summary(slug: str, data: dict[str, Any]) -> dict[str, Any]:
         "description": metadata.get("description", ""),
         "color": metadata.get("color", "#6366f1"),
         "node_count": len(data.get("node_meta", {}) or {}),
+        "group": group,
+        "group_color": group_color,
     }
 
 
@@ -3722,7 +3844,7 @@ def list_workflows():
 def list_templates():
     result = []
     seen: set[str] = set()
-    for templates_dir in _template_dirs():
+    for templates_dir, group, group_color in _template_sources():
         if not os.path.isdir(templates_dir):
             continue
         for fname in sorted(os.listdir(templates_dir)):
@@ -3733,7 +3855,12 @@ def list_templates():
                 continue
             try:
                 data = _read_workflow_file(os.path.join(templates_dir, fname))
-                result.append(_workflow_summary(slug, data))
+                result.append(_workflow_summary(
+                    slug,
+                    data,
+                    group=group,
+                    group_color=group_color,
+                ))
                 seen.add(slug)
             except Exception:
                 pass

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -17,6 +17,8 @@ export interface TemplateMeta {
   name: string
   description: string
   color: string
+  group: string
+  group_color: string
   saved_at: string
   node_count: number
 }
@@ -342,6 +344,14 @@ export const api = {
   removeNode: (id: string)                  => req('DELETE', `/nodes/${id}`),
   updateParam:(id: string, key: string, value: unknown) =>
     req('PATCH', `/nodes/${id}/params`, { key, value }),
+  controlNode:(id: string, action: string) =>
+    req<{ ok: boolean; node_id: string; outputs: Record<string, unknown> }>('POST', `/nodes/${id}/control`, { action }),
+  pickDirectory:(initialPath = '') =>
+    req<{ selected: string; cancelled: boolean }>('POST', '/filesystem/pick-directory', { initial_path: initialPath }),
+  datasetFrame:(token: string, index: number) =>
+    req<Record<string, unknown>>('GET', `/dataset/frame/${encodeURIComponent(token)}?index=${Math.max(0, Math.floor(index))}`),
+  trimDatasetEpisode:(token: string, frameIndex: number, side: 'before' | 'after') =>
+    req<Record<string, unknown>>('POST', '/dataset/trim', { token, frame_index: Math.max(0, Math.floor(frameIndex)), side }, 120000),
   updatePorts:(id: string, patch: Partial<Pick<BnNodeMeta, 'inputs' | 'outputs' | 'input_types' | 'output_types' | 'input_defaults' | 'multi_input_ports'>>) =>
     req<BnNodeMeta>('PATCH', `/nodes/${id}/ports`, patch),
   updatePortVisibility:(id: string, patch: Pick<BnNodeMeta, 'promoted_inputs' | 'promoted_outputs'>) =>

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -9,6 +9,7 @@ import { isWireOnlyInput } from '../inputControls'
 import { copyTextToClipboard } from '../clipboard'
 import { portDisplayHint, portDisplayName } from '../portLabels'
 import NodeFrame from './NodeFrame'
+import DatasetBrowserPanel from './DatasetBrowserPanel'
 import type { NodeCookState } from '../types'
 
 const TOOLBOX_NEW_HANDLE_COLOR = '#ef444488'
@@ -26,6 +27,7 @@ const LIVE_STREAM_NODE_TYPES = new Set([
   'CV2ColorObjectStream',
   'VisionReasoningStream',
   'CUDAImageFilterStream',
+  'StreamPublisher',
 ])
 
 function driverBtn(color: string, disabled = false): React.CSSProperties {
@@ -424,6 +426,8 @@ function NodeImageInput({
 function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const cookNode    = useStore(s => s.cookNode)
   const updateParam = useStore(s => s.updateParam)
+  const controlNode = useStore(s => s.controlNode)
+  const pickDirectory = useStore(s => s.pickDirectory)
   const resizeNode  = useStore(s => s.resizeNode)
   const disconnectEdge = useStore(s => s.disconnectEdge)
   const edges       = useStore(s => s.edges)
@@ -442,6 +446,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const [manualMovePending, setManualMovePending] = useState<null | 'release' | 'monitor' | 'hold'>(null)
   const [calibrationPending, setCalibrationPending] = useState<null | 'start' | 'pause' | 'capture_home' | 'finish' | 'cancel'>(null)
   const [episodePending, setEpisodePending] = useState<null | 'start' | 'pause' | 'resume' | 'save' | 'stop' | 'discard'>(null)
+  const [datasetFolderPending, setDatasetFolderPending] = useState(false)
   const dashboardAutoFitDone = useRef(false)
   const updateNodeInternals = useUpdateNodeInternals()
   const color       = headerColor(data.type)
@@ -452,6 +457,8 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const isManualMove = data.type === 'ROS2ManualMove' || data.type === 'ROS2TeachMode'
   const isRobotCalibration = data.type === 'RobotCalibrationRecorder'
   const isEpisodeRecorder = data.type === 'EpisodeRecorder'
+  const isDatasetCreate = data.type === 'DatasetCreate'
+  const isDatasetBrowser = data.type === 'DatasetBrowser'
   const availableInputs = isRobotJointList
     ? (data.inputs ?? []).filter(port => edges.some(edge => edge.target === id && edge.targetHandle === port))
     : isVariadic
@@ -552,10 +559,29 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const episodeLastError = isEpisodeRecorder && data.portResults?.status && typeof data.portResults.status === 'object'
     ? String((data.portResults.status as Record<string, unknown>).last_error ?? '')
     : ''
+  const episodeRecoverable = isEpisodeRecorder && data.portResults?.status && typeof data.portResults.status === 'object'
+    ? (data.portResults.status as Record<string, unknown>).recoverable === true
+    : false
+  const episodeStoragePath = isEpisodeRecorder && data.portResults?.status && typeof data.portResults.status === 'object'
+    ? String(
+        (data.portResults.status as Record<string, unknown>).saved_path
+        ?? (data.portResults.status as Record<string, unknown>).work_path
+        ?? (data.portResults.status as Record<string, unknown>).dataset_path
+        ?? (data.portResults.dataset && typeof data.portResults.dataset === 'object'
+          ? (data.portResults.dataset as Record<string, unknown>).path
+          : '')
+        ?? ''
+      )
+    : ''
   const episodeInputsReady = isEpisodeRecorder
     && edges.some(edge => edge.target === id && edge.targetHandle === 'dataset')
     && edges.some(edge => edge.target === id && edge.targetHandle === 'robot_stream')
     && edges.some(edge => edge.target === id && (edge.targetHandle === 'camera_stream' || edge.targetHandle === 'camera_streams'))
+  const datasetRoot = isDatasetCreate ? String(data.params?.root ?? '').trim() : ''
+  const datasetId = isDatasetCreate ? String(data.params?.dataset_id ?? 'dataset').trim() || 'dataset' : ''
+  const datasetResolvedPath = isDatasetCreate && typeof data.portResults?.path === 'string'
+    ? data.portResults.path
+    : ''
   const hasLiveOutput = data.live_capable === true && (data.outputs ?? []).includes('live')
   const liveStateReport = hasLiveOutput ? String(data.portResults?.report ?? '').trim() : ''
   const liveServiceRunning = hasLiveOutput && data.portResults?.running === true
@@ -726,14 +752,32 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     )) return
     setEpisodePending(action)
     try {
-      await updateParam(id, 'action', action)
-      await cookNode(id, 'dashboard', undefined, 'live')
-    } finally {
       try {
-        await updateParam(id, 'action', 'status')
-      } finally {
-        setEpisodePending(null)
+        await controlNode(id, action)
+      } catch (error) {
+        // A fresh graph has no resolved recorder handles yet. Record may cook
+        // once to configure them; every subsequent control is runtime-only.
+        if (action !== 'start') throw error
+        await updateParam(id, 'action', action)
+        try {
+          await cookNode(id, 'dashboard', undefined, 'live')
+        } finally {
+          await updateParam(id, 'action', 'status')
+        }
       }
+    } finally {
+      setEpisodePending(null)
+    }
+  }
+
+  const chooseDatasetFolder = async () => {
+    if (datasetFolderPending) return
+    setDatasetFolderPending(true)
+    try {
+      const selected = await pickDirectory(String(data.params?.root ?? ''))
+      if (selected) await updateParam(id, 'root', selected)
+    } finally {
+      setDatasetFolderPending(false)
     }
   }
 
@@ -1266,6 +1310,46 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
         </div>
       )}
 
+      {isDatasetBrowser && <DatasetBrowserPanel id={id} data={data} />}
+
+      {isDatasetCreate && (
+        <div style={{
+          margin: '7px 9px 3px', padding: 8, borderRadius: 7,
+          border: '1px solid var(--line)', background: 'rgba(255,255,255,.02)',
+        }}>
+          <div style={{ color: 'var(--tx2)', fontFamily: 'var(--font-ui)', fontSize: 10, fontWeight: 800 }}>
+            DATASET STORAGE
+          </div>
+          <div title={datasetRoot || '~/.blacknode/datasets'} style={{ marginTop: 5, color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 9, lineHeight: 1.35, wordBreak: 'break-all' }}>
+            Root: {datasetRoot || '~/.blacknode/datasets (default)'}
+          </div>
+          <div style={{ marginTop: 2, color: 'var(--tx3)', fontFamily: 'var(--font-ui)', fontSize: 9 }}>
+            Blacknode stores this dataset in a “{datasetId}” subfolder.
+          </div>
+          {datasetResolvedPath && (
+            <div title={datasetResolvedPath} style={{ marginTop: 3, color: 'var(--ok)', fontFamily: 'var(--font-mono)', fontSize: 9, lineHeight: 1.35, wordBreak: 'break-all' }}>
+              Current: {datasetResolvedPath}
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: 6, marginTop: 7, flexWrap: 'wrap' }}>
+            <button
+              disabled={datasetFolderPending}
+              onClick={e => { e.stopPropagation(); void chooseDatasetFolder() }}
+              style={driverBtn('var(--accent)', datasetFolderPending)}
+            >
+              {datasetFolderPending ? 'Choosing…' : 'Choose folder…'}
+            </button>
+            <button
+              disabled={datasetFolderPending || !datasetRoot}
+              onClick={e => { e.stopPropagation(); void updateParam(id, 'root', '') }}
+              style={driverBtn('var(--tx2)', datasetFolderPending || !datasetRoot)}
+            >
+              Use default
+            </button>
+          </div>
+        </div>
+      )}
+
       {isEpisodeRecorder && (
         <div style={{
           margin: '7px 9px 3px', padding: 8, borderRadius: 7,
@@ -1281,7 +1365,9 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
               ? `● RECORDING · ${episodeFrameCount} FRAMES · ${episodeDuration.toFixed(1)}s`
               : episodePaused
                 ? `Ⅱ PAUSED · ${episodeFrameCount} FRAMES · ${episodeDuration.toFixed(1)}s`
-                : '○ READY FOR A NEW EPISODE'}
+                : episodeRecoverable
+                  ? `↻ RECOVERABLE · ${episodeFrameCount} FRAMES · ${episodeDuration.toFixed(1)}s`
+                  : '○ READY FOR A NEW EPISODE'}
             {episodeDroppedFrames > 0 ? ` · ${episodeDroppedFrames} DROPPED` : ''}
           </div>
           {episodeLastError && (
@@ -1289,12 +1375,17 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
               {episodeLastError}
             </div>
           )}
+          {episodeStoragePath && (
+            <div title={episodeStoragePath} style={{ margin: '-2px 0 7px', color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 9, lineHeight: 1.35, wordBreak: 'break-all' }}>
+              Saving to: {episodeStoragePath}
+            </div>
+          )}
           <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
             <button
-              disabled={Boolean(episodePending) || episodeRunning || !episodeInputsReady}
-              title={episodeInputsReady ? 'Start a new synchronized robot and camera episode' : 'Connect dataset, robot stream, and at least one camera stream first'}
+              disabled={Boolean(episodePending) || episodeRunning || episodeRecoverable || !episodeInputsReady}
+              title={episodeRecoverable ? 'Save or discard the recoverable episode first' : episodeInputsReady ? 'Start a new synchronized robot and camera episode' : 'Connect dataset, robot stream, and at least one camera stream first'}
               onClick={e => { e.stopPropagation(); void runEpisodeAction('start') }}
-              style={driverBtn('var(--err)', Boolean(episodePending) || episodeRunning || !episodeInputsReady)}
+              style={driverBtn('var(--err)', Boolean(episodePending) || episodeRunning || episodeRecoverable || !episodeInputsReady)}
             >
               {episodePending === 'start' ? 'Starting…' : '● Record'}
             </button>
@@ -1315,10 +1406,10 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
               {episodePending === 'resume' ? 'Resuming…' : '▶ Resume'}
             </button>
             <button
-              disabled={Boolean(episodePending) || !episodeRunning}
+              disabled={Boolean(episodePending) || (!episodeRunning && (!episodeRecoverable || episodeFrameCount === 0))}
               title="Finalize and save this episode to the dataset"
               onClick={e => { e.stopPropagation(); void runEpisodeAction('save') }}
-              style={driverBtn('var(--ok)', Boolean(episodePending) || !episodeRunning)}
+              style={driverBtn('var(--ok)', Boolean(episodePending) || (!episodeRunning && (!episodeRecoverable || episodeFrameCount === 0)))}
             >
               {episodePending === 'save' ? 'Saving…' : '✓ Save episode'}
             </button>
@@ -1331,10 +1422,10 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
               {episodePending === 'stop' ? 'Stopping…' : '■ Stop'}
             </button>
             <button
-              disabled={Boolean(episodePending) || !episodeRunning}
+              disabled={Boolean(episodePending) || (!episodeRunning && !episodeRecoverable)}
               title="Permanently discard this incomplete episode"
               onClick={e => { e.stopPropagation(); void runEpisodeAction('discard') }}
-              style={driverBtn('var(--err)', Boolean(episodePending) || !episodeRunning)}
+              style={driverBtn('var(--err)', Boolean(episodePending) || (!episodeRunning && !episodeRecoverable))}
             >
               {episodePending === 'discard' ? 'Discarding…' : 'Discard'}
             </button>

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -442,6 +442,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const driverNotInstalled = driverName ? drivers[driverName]?.packages_installed === false : false
   const [driverPending, setDriverPending] = useState<null | 'start' | 'stop'>(null)
   const [streamStopPending, setStreamStopPending] = useState(false)
+  const [streamStartPending, setStreamStartPending] = useState(false)
   const [rosRunStopPending, setRosRunStopPending] = useState(false)
   const [manualMovePending, setManualMovePending] = useState<null | 'release' | 'monitor' | 'hold'>(null)
   const [calibrationPending, setCalibrationPending] = useState<null | 'start' | 'pause' | 'capture_home' | 'finish' | 'cancel'>(null)
@@ -593,8 +594,12 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     .replace(/^(blocked|failed|error)\s*:\s*/i, '')
     .trim()
   const genericNodeLive = data.live_capable === true && data.portResults?.live === true && !manualMoveLive && !streamActive
+  // StreamPublisher gets its own Go live / Stop controls, so it should never fall
+  // back to the generic "snapshot" badge — that badge is what read as "broken".
+  const streamStartable = data.type === 'StreamPublisher' && !streamActive
   const snapshotResult = data.live_capable === true
     && !streamActive
+    && !streamStartable
     && !manualMoveLive
     && !genericNodeLive
     && !liveBlocked
@@ -675,6 +680,16 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       await stopDriver(driverName!)
     } finally {
       setDriverPending(null)
+    }
+  }
+
+  const onStartStream = async () => {
+    setStreamStartPending(true)
+    try {
+      await updateParam(id, 'action', 'start')
+      await cookNode(id, 'dashboard')
+    } finally {
+      setStreamStartPending(false)
     }
   }
 
@@ -974,6 +989,28 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
           <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {liveBlocked ? 'BLOCKED' : 'LIVE • WAITING'}
             {liveStateReason ? ` • ${liveStateReason}` : liveWaiting ? ' • waiting for source data' : ''}
+          </span>
+        </div>
+      )}
+
+      {streamStartable && (
+        <div className="nodrag" onMouseDown={e => e.stopPropagation()}
+          style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 10px 2px' }}>
+          <button
+            disabled={streamStartPending}
+            onClick={e => { e.stopPropagation(); void onStartStream() }}
+            style={{
+              padding: '4px 10px', borderRadius: 5, border: '1px solid var(--ok)',
+              background: 'rgba(34,197,94,.18)',
+              color: streamStartPending ? 'var(--tx3)' : 'var(--tx1)',
+              cursor: streamStartPending ? 'default' : 'pointer',
+              fontFamily: 'var(--font-ui)', fontSize: 10, fontWeight: 700, letterSpacing: 0,
+            }}
+          >
+            {streamStartPending ? 'Starting…' : 'Go live'}
+          </button>
+          <span style={{ color: 'var(--tx3)', fontFamily: 'var(--font-ui)', fontSize: 9 }}>
+            starts the WebSocket stream (action=start)
           </span>
         </div>
       )}

--- a/editor/src/components/DatasetBrowserPanel.tsx
+++ b/editor/src/components/DatasetBrowserPanel.tsx
@@ -1,0 +1,301 @@
+import { useEffect, useRef, useState } from 'react'
+import { api } from '../api'
+import { useStore } from '../store'
+
+type AnyRecord = Record<string, any>
+
+const panel: React.CSSProperties = {
+  margin: '7px 9px 3px', padding: 10, borderRadius: 8,
+  border: '1px solid var(--line)', background: 'rgba(255,255,255,.02)',
+  fontFamily: 'var(--font-ui)',
+}
+
+const button = (disabled = false): React.CSSProperties => ({
+  border: '1px solid var(--line)', borderRadius: 5, padding: '4px 9px',
+  background: disabled ? 'rgba(255,255,255,.03)' : 'rgba(139,92,246,.18)',
+  color: disabled ? 'var(--tx3)' : 'var(--tx1)', cursor: disabled ? 'default' : 'pointer',
+  fontSize: 10, fontWeight: 700,
+})
+
+const selectStyle: React.CSSProperties = {
+  minWidth: 150, maxWidth: 260, padding: '4px 6px', borderRadius: 5,
+  border: '1px solid var(--line)', background: 'var(--bg2)', color: 'var(--tx1)', fontSize: 10,
+  colorScheme: 'dark',
+}
+
+const optionStyle: React.CSSProperties = { background: '#0f172a', color: '#e2e8f0' }
+
+export default function DatasetBrowserPanel({ id, data }: {
+  id: string
+  data: { params?: Record<string, unknown>; portResults?: Record<string, unknown> }
+}) {
+  const updateParam = useStore(s => s.updateParam)
+  const cookNode = useStore(s => s.cookNode)
+  const pickDirectory = useStore(s => s.pickDirectory)
+  const [pending, setPending] = useState(false)
+  const [frame, setFrame] = useState<AnyRecord | null>(null)
+  const [playing, setPlaying] = useState(false)
+  const [playbackRate, setPlaybackRate] = useState(1)
+  const [loop, setLoop] = useState(false)
+  const [angleUnit, setAngleUnit] = useState<'radians' | 'degrees'>('radians')
+  const [trimPending, setTrimPending] = useState<'before' | 'after' | null>(null)
+  const [trimMessage, setTrimMessage] = useState('')
+  const lastFrame = useRef(-1)
+  const videoRef = useRef<HTMLVideoElement | null>(null)
+
+  const catalog = data.portResults?.catalog && typeof data.portResults.catalog === 'object'
+    ? data.portResults.catalog as AnyRecord : {}
+  const datasets = Array.isArray(catalog.datasets) ? catalog.datasets as AnyRecord[] : []
+  const selectedDataset = catalog.selected_dataset && typeof catalog.selected_dataset === 'object'
+    ? catalog.selected_dataset as AnyRecord : {}
+  const episodes = Array.isArray(selectedDataset.episodes) ? selectedDataset.episodes as AnyRecord[] : []
+  const episode = catalog.selected_episode && typeof catalog.selected_episode === 'object'
+    ? catalog.selected_episode as AnyRecord : {}
+  const cameras = Array.isArray(episode.cameras) ? episode.cameras.map(String) : []
+  const rawVideo = typeof catalog.video === 'string' ? catalog.video : ''
+  const video = rawVideo.startsWith('/dataset/') ? `/api${rawVideo}` : rawVideo
+  const token = typeof catalog.replay_token === 'string' ? catalog.replay_token : ''
+  const fps = Number(episode.fps ?? 0)
+  const totalFrames = Number(episode.frames ?? 0)
+
+  useEffect(() => {
+    setFrame(null)
+    setPlaying(false)
+    lastFrame.current = -1
+  }, [token])
+
+  const refresh = async (patch: Record<string, unknown> = {}) => {
+    if (pending) return
+    setPending(true)
+    try {
+      const effectivePatch = Object.keys(patch).length > 0 ? patch : { refresh_key: Date.now() }
+      for (const [key, value] of Object.entries(effectivePatch)) await updateParam(id, key, value)
+      await cookNode(id, 'catalog')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const chooseRoot = async () => {
+    if (pending) return
+    const selected = await pickDirectory(String(data.params?.root ?? ''))
+    if (selected) await refresh({ root: selected, dataset_id: '', episode_index: 0, camera: '' })
+  }
+
+  const updateReplayFrame = async (time: number) => {
+    if (!token || !fps) return
+    const index = Math.min(Math.max(0, totalFrames - 1), Math.max(0, Math.floor(time * fps)))
+    if (index === lastFrame.current) return
+    lastFrame.current = index
+    try {
+      setFrame(await api.datasetFrame(token, index))
+    } catch {
+      // Playback remains usable even if one metadata request races a selection change.
+    }
+  }
+
+  const jointNames = frame && Array.isArray(frame.joint_names) ? frame.joint_names.map(String) : []
+  const leader = (frame?.leader ?? {}) as AnyRecord
+  const observation = (frame?.observation ?? {}) as AnyRecord
+  const action = (frame?.action ?? {}) as AnyRecord
+  const storedUnits = String(episode.units ?? 'radians').toLowerCase()
+  const displayAngle = (value: unknown) => {
+    const numeric = Number(value ?? 0)
+    if (angleUnit === 'degrees' && storedUnits.startsWith('rad')) return numeric * 180 / Math.PI
+    if (angleUnit === 'radians' && storedUnits.startsWith('deg')) return numeric * Math.PI / 180
+    return numeric
+  }
+
+  const toggleReplay = async () => {
+    const player = videoRef.current
+    if (!player) return
+    if (player.paused) await player.play()
+    else player.pause()
+  }
+
+  const restartReplay = async () => {
+    const player = videoRef.current
+    if (!player) return
+    player.currentTime = 0
+    await updateReplayFrame(0)
+    await player.play()
+  }
+
+  const stepFrame = async (direction: -1 | 1) => {
+    const player = videoRef.current
+    if (!player || !fps) return
+    player.pause()
+    player.currentTime = Math.max(0, Math.min(player.duration || Number.POSITIVE_INFINITY, player.currentTime + direction / fps))
+    await updateReplayFrame(player.currentTime)
+  }
+
+  const trimEpisode = async (side: 'before' | 'after') => {
+    const player = videoRef.current
+    if (!token || !player || trimPending) return
+    player.pause()
+    const index = Math.min(
+      Math.max(0, totalFrames - 1),
+      Math.max(0, Math.floor(player.currentTime * fps)),
+    )
+    const removeCount = side === 'before' ? index : Math.max(0, totalFrames - index - 1)
+    if (removeCount <= 0) return
+    const label = side === 'before' ? `before frame ${index}` : `after frame ${index}`
+    if (!window.confirm(
+      `Permanently remove ${removeCount} frame(s) ${label} from episode ${episode.episode_index}?\n\n` +
+      'The selected frame is kept. Every camera video and the synchronized robot data will be trimmed together.'
+    )) return
+    setTrimPending(side)
+    setTrimMessage('')
+    try {
+      const result = await api.trimDatasetEpisode(token, index, side)
+      setTrimMessage(`Trimmed ${Number(result.removed_frames ?? removeCount)} frame(s); ${Number(result.frames ?? 0)} remain.`)
+      await refresh({ refresh_key: Date.now() })
+    } catch (error) {
+      setTrimMessage(error instanceof Error ? error.message : String(error))
+    } finally {
+      setTrimPending(null)
+    }
+  }
+
+  return (
+    <div className="nodrag" style={panel}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}>
+        <strong style={{ color: 'var(--tx1)', fontSize: 11 }}>DATASET BROWSER</strong>
+        <button disabled={pending} style={button(pending)} onClick={() => void chooseRoot()}>
+          Choose root…
+        </button>
+        <button disabled={pending} style={button(pending)} onClick={() => void refresh()}>
+          {pending ? 'Loading…' : 'Refresh'}
+        </button>
+        <span style={{ color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 9, wordBreak: 'break-all' }}>
+          {String(catalog.root ?? data.params?.root ?? '~/.blacknode/datasets')}
+        </span>
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 9, flexWrap: 'wrap' }}>
+        <label style={{ color: 'var(--tx3)', fontSize: 9 }}>
+          Dataset<br />
+          <select value={String(selectedDataset.dataset_id ?? '')} style={selectStyle}
+            onChange={event => void refresh({ dataset_id: event.target.value, episode_index: 0, camera: '' })}>
+            {datasets.length === 0 && <option style={optionStyle} value="">No datasets found</option>}
+            {datasets.map(item => <option style={optionStyle} key={String(item.path)} value={String(item.dataset_id)}>{String(item.dataset_id)}</option>)}
+          </select>
+        </label>
+        <label style={{ color: 'var(--tx3)', fontSize: 9 }}>
+          Episode<br />
+          <select value={String(episode.episode_index ?? 0)} style={selectStyle}
+            onChange={event => void refresh({ episode_index: Number(event.target.value), camera: '' })}>
+            {episodes.length === 0 && <option style={optionStyle} value="0">No saved episodes</option>}
+            {episodes.map(item => <option style={optionStyle} key={String(item.episode_index)} value={String(item.episode_index)}>
+              #{item.episode_index} · {Number(item.duration_seconds ?? 0).toFixed(1)}s · {item.frames} frames
+            </option>)}
+          </select>
+        </label>
+        <label style={{ color: 'var(--tx3)', fontSize: 9 }}>
+          Camera<br />
+          <select value={String(episode.camera ?? '')} style={selectStyle}
+            onChange={event => void refresh({ camera: event.target.value })}>
+            {cameras.length === 0 && <option style={optionStyle} value="">No camera video</option>}
+            {cameras.map(name => <option style={optionStyle} key={name} value={name}>{name}</option>)}
+          </select>
+        </label>
+      </div>
+
+      {video ? (
+        <>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 10, flexWrap: 'wrap', padding: 7, borderRadius: 6, background: 'rgba(139,92,246,.09)', border: '1px solid rgba(139,92,246,.3)' }}>
+          <button style={{ ...button(false), minWidth: 76, background: playing ? 'rgba(245,158,11,.2)' : 'rgba(34,197,94,.2)' }} onClick={() => void toggleReplay()}>
+            {playing ? 'Ⅱ Pause' : '▶ Replay'}
+          </button>
+          <button style={button(false)} onClick={() => void restartReplay()}>↺ Restart</button>
+          <button style={button(false)} onClick={() => void stepFrame(-1)}>‹ Frame</button>
+          <button style={button(false)} onClick={() => void stepFrame(1)}>Frame ›</button>
+          <label style={{ color: 'var(--tx3)', fontSize: 9 }}>
+            Speed&nbsp;
+            <select value={playbackRate} style={{ ...selectStyle, minWidth: 66, width: 66 }} onChange={event => {
+              const rate = Number(event.target.value)
+              setPlaybackRate(rate)
+              if (videoRef.current) videoRef.current.playbackRate = rate
+            }}>
+              {[0.25, 0.5, 1, 1.5, 2].map(rate => <option style={optionStyle} key={rate} value={rate}>{rate}×</option>)}
+            </select>
+          </label>
+          <label style={{ color: 'var(--tx2)', fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
+            <input type="checkbox" checked={loop} onChange={event => setLoop(event.target.checked)} /> Loop
+          </label>
+          <span style={{ display: 'flex', gap: 2, padding: 2, border: '1px solid var(--line)', borderRadius: 5 }}>
+            <button style={{ ...button(angleUnit !== 'radians'), padding: '2px 7px', background: angleUnit === 'radians' ? 'rgba(139,92,246,.3)' : 'transparent' }} onClick={() => setAngleUnit('radians')}>rad</button>
+            <button style={{ ...button(angleUnit !== 'degrees'), padding: '2px 7px', background: angleUnit === 'degrees' ? 'rgba(139,92,246,.3)' : 'transparent' }} onClick={() => setAngleUnit('degrees')}>deg</button>
+          </span>
+          <span style={{ display: 'flex', gap: 4, paddingLeft: 5, borderLeft: '1px solid var(--line)' }}>
+            <button disabled={Boolean(trimPending) || Number(frame?.frame_index ?? 0) <= 0}
+              title="Keep the selected frame and delete every earlier synchronized frame"
+              style={{ ...button(Boolean(trimPending) || Number(frame?.frame_index ?? 0) <= 0), borderColor: 'rgba(239,68,68,.45)' }}
+              onClick={() => void trimEpisode('before')}>
+              {trimPending === 'before' ? 'Cutting…' : '✂ Cut before'}
+            </button>
+            <button disabled={Boolean(trimPending) || Number(frame?.frame_index ?? 0) >= totalFrames - 1}
+              title="Keep the selected frame and delete every later synchronized frame"
+              style={{ ...button(Boolean(trimPending) || Number(frame?.frame_index ?? 0) >= totalFrames - 1), borderColor: 'rgba(239,68,68,.45)' }}
+              onClick={() => void trimEpisode('after')}>
+              {trimPending === 'after' ? 'Cutting…' : '✂ Cut after'}
+            </button>
+          </span>
+          <span style={{ marginLeft: 'auto', color: 'var(--tx3)', fontSize: 9 }}>Read-only replay · robot commands disabled</span>
+        </div>
+        {trimMessage && <div style={{ marginTop: 6, color: trimMessage.startsWith('Trimmed') ? 'var(--ok)' : 'var(--warn)', fontSize: 9, fontFamily: 'var(--font-mono)' }}>
+          {trimMessage}
+        </div>}
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(360px, 1.4fr) minmax(330px, 1fr)', gap: 10, marginTop: 8 }}>
+          <video ref={videoRef} key={video} src={video} controls playsInline preload="metadata" loop={loop}
+            onPlay={() => setPlaying(true)} onPause={() => setPlaying(false)} onEnded={() => setPlaying(false)}
+            onLoadedMetadata={event => void updateReplayFrame(event.currentTarget.currentTime)}
+            onTimeUpdate={event => void updateReplayFrame(event.currentTarget.currentTime)}
+            onSeeked={event => void updateReplayFrame(event.currentTarget.currentTime)}
+            style={{ width: '100%', maxHeight: 470, background: '#020617', borderRadius: 7, objectFit: 'contain' }} />
+          <div style={{ minWidth: 0 }}>
+            <div style={{ color: 'var(--tx2)', fontFamily: 'var(--font-mono)', fontSize: 10, lineHeight: 1.55 }}>
+              <div>episode {episode.episode_index ?? 0} · frame {frame?.frame_index ?? 0}/{Math.max(0, totalFrames - 1)}</div>
+              <div>{Number(frame?.timestamp ?? 0).toFixed(3)}s · {fps} fps · displaying {angleUnit}</div>
+              <div>sample #{frame?.sample_sequence ?? 0} · camera #{frame?.cameras?.[episode.camera]?.sequence ?? 0}</div>
+              <div>robot captured {frame?.captured_at_ns ?? 0}</div>
+              <div>camera captured {frame?.cameras?.[episode.camera]?.captured_at_ns ?? 0}</div>
+              <div>recorded {frame?.recorded_at_ns ?? 0}</div>
+            </div>
+            <div style={{ maxHeight: 355, overflow: 'auto', marginTop: 7, border: '1px solid var(--line)', borderRadius: 6 }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'var(--font-mono)', fontSize: 9 }}>
+                <thead><tr style={{ color: 'var(--tx3)', position: 'sticky', top: 0, background: 'var(--bg2)' }}>
+                  <th style={{ padding: 5, textAlign: 'left' }}>joint</th><th>leader</th><th>observed</th><th>action</th>
+                </tr></thead>
+                <tbody>{jointNames.map(name => <tr key={name} style={{ borderTop: '1px solid var(--line)', color: 'var(--tx2)' }}>
+                  <td style={{ padding: 5 }}>{name}</td>
+                  <td style={{ textAlign: 'right', padding: 5 }}>{displayAngle(leader[name]).toFixed(angleUnit === 'degrees' ? 2 : 4)}</td>
+                  <td style={{ textAlign: 'right', padding: 5 }}>{displayAngle(observation[name]).toFixed(angleUnit === 'degrees' ? 2 : 4)}</td>
+                  <td style={{ textAlign: 'right', padding: 5 }}>{displayAngle(action[name]).toFixed(angleUnit === 'degrees' ? 2 : 4)}</td>
+                </tr>)}</tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+        </>
+      ) : (
+        <div style={{ marginTop: 12, padding: 24, borderRadius: 7, background: '#020617', color: 'var(--tx3)', textAlign: 'center', fontSize: 11 }}>
+          {datasets.length ? 'Select a dataset containing a saved episode.' : 'Choose a dataset root, then press Refresh.'}
+        </div>
+      )}
+
+      {episode.episode_path && <div style={{ marginTop: 8, color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 8.5, lineHeight: 1.45, wordBreak: 'break-all' }}>
+        <div>Episode: {episode.episode_path}</div>
+        <div>Video: {episode.video_path}</div>
+        <div>Robot data: {episode.data_path}</div>
+        <div>Task: {episode.task || '—'} · saved {episode.saved_at || '—'}</div>
+      </div>}
+      {episode.episode_path && <details style={{ marginTop: 7, color: 'var(--tx3)', fontSize: 9 }}>
+        <summary style={{ cursor: 'pointer', color: 'var(--tx2)', fontWeight: 700 }}>All episode and current-frame metadata</summary>
+        <pre style={{ maxHeight: 260, overflow: 'auto', margin: '6px 0 0', padding: 7, borderRadius: 5, background: '#020617', color: 'var(--tx2)', fontFamily: 'var(--font-mono)', fontSize: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+          {JSON.stringify({ episode, frame }, null, 2)}
+        </pre>
+      </details>}
+    </div>
+  )
+}

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -100,7 +100,7 @@ const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
 
 export default function NodePalette() {
   const { nodeTypes, nodeDefs, addNode, loadNodeTypes, learnedNodeHighlight } = useStore()
-  const [activeTab, setActiveTab] = useState<Tab | null>('nodes')
+  const [activeTab, setActiveTab] = useState<Tab | null>('templates')
   const [showPackageWelcome, setShowPackageWelcome] = useState(false)
   const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_W)
   const [openGroups, setOpenGroups] = useState<Set<string>>(() => new Set())
@@ -292,10 +292,10 @@ export default function NodePalette() {
             <div style={{ marginTop: 20, display: 'flex', gap: 10, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
               <button
                 type="button"
-                onClick={() => finishPackageWelcome('nodes')}
+                onClick={() => finishPackageWelcome('templates')}
                 style={welcomeButtonStyle}
               >
-                Continue with core graph
+                Explore core templates
               </button>
               <button
                 type="button"

--- a/editor/src/components/OutputNode.tsx
+++ b/editor/src/components/OutputNode.tsx
@@ -19,7 +19,7 @@ const COLOR = '#8b5cf6'
 
 const isMediaSource = (value: unknown, dataPrefix: string): value is string =>
   typeof value === 'string'
-  && (value.startsWith(dataPrefix) || /^https?:\/\//i.test(value))
+  && (value.startsWith(dataPrefix) || value.startsWith('/') || /^https?:\/\//i.test(value))
 
 const imageSourceFrom = (value: unknown): string | null => {
   if (isMediaSource(value, 'data:image/')) return value
@@ -68,6 +68,9 @@ function OutputNode({ id, data, selected }: NodeProps<NodeData>) {
   const videoSource = !cookError && !replayError && sourceType === 'Video'
     && isMediaSource(displayValue, 'data:video/') ? displayValue : null
   const hasMedia = imageSource !== null || videoSource !== null
+  const hasVisualMediaInput = sourceType === 'Image' || sourceType === 'Video'
+  const mediaMinWidth = hasVisualMediaInput ? 860 : 240
+  const mediaMinHeight = hasVisualMediaInput ? 720 : 120
 
   return (
     <NodeFrame
@@ -79,15 +82,15 @@ function OutputNode({ id, data, selected }: NodeProps<NodeData>) {
       style={{
         width: '100%',
         height: '100%',
-        minWidth: 240,
-        minHeight: 120,
+        minWidth: mediaMinWidth,
+        minHeight: mediaMinHeight,
         display: 'flex',
         flexDirection: 'column',
       }}
     >
       <NodeResizer
-        minWidth={240}
-        minHeight={120}
+        minWidth={mediaMinWidth}
+        minHeight={mediaMinHeight}
         isVisible={selected}
         lineStyle={{ borderColor: COLOR }}
         handleStyle={{ background: COLOR, borderColor: COLOR, width: 8, height: 8, borderRadius: 2 }}
@@ -161,10 +164,9 @@ function OutputNode({ id, data, selected }: NodeProps<NodeData>) {
 
       {/* result area */}
       <div
-        className="nodrag nowheel bn-output-scroll"
+        className="nodrag bn-output-scroll"
         tabIndex={0}
         aria-label="Scrollable output value"
-        onWheel={e => e.stopPropagation()}
         style={{
         flex: '1 1 0',
         minWidth: 0,

--- a/editor/src/components/TemplateGallery.tsx
+++ b/editor/src/components/TemplateGallery.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   api,
   templateDependencyError,
@@ -16,6 +16,46 @@ export default function TemplateGallery() {
   const [installing, setInstalling] = useState<{ slug: string; packageName: string } | null>(null)
   const [missing, setMissing] = useState<Record<string, TemplateDependencyError>>({})
   const [error, setError] = useState<string | null>(null)
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set())
+  const [query, setQuery] = useState('')
+
+  const templateGroups = useMemo(() => {
+    const groups = new Map<string, { name: string; color: string; templates: TemplateMeta[] }>()
+    templates.forEach(template => {
+      const name = template.group || 'Core'
+      const current = groups.get(name)
+      if (current) current.templates.push(template)
+      else groups.set(name, {
+        name,
+        color: template.group_color || '#6366f1',
+        templates: [template],
+      })
+    })
+    return Array.from(groups.values())
+  }, [templates])
+
+  const filteredTemplateGroups = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    if (!needle) return templateGroups
+    return templateGroups
+      .map(group => ({
+        ...group,
+        templates: group.templates.filter(template =>
+          [template.name, template.description, template.slug, group.name]
+            .some(value => value.toLowerCase().includes(needle))
+        ),
+      }))
+      .filter(group => group.templates.length > 0)
+  }, [query, templateGroups])
+
+  const toggleGroup = (name: string) => {
+    setExpandedGroups(current => {
+      const next = new Set(current)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
 
   const refreshTemplates = async () => {
     try {
@@ -107,6 +147,26 @@ export default function TemplateGallery() {
         One-click starter graphs. Loads into the canvas.
       </div>
 
+      <input
+        type="search"
+        value={query}
+        onChange={event => setQuery(event.target.value)}
+        placeholder="Search templates or categories..."
+        aria-label="Search templates"
+        style={{
+          width: '100%',
+          minHeight: 38,
+          padding: '8px 10px',
+          color: 'var(--tx1)',
+          background: 'var(--lift)',
+          border: '1px solid var(--line2)',
+          borderRadius: 8,
+          outline: 'none',
+          fontFamily: 'var(--font-ui)',
+          fontSize: 12,
+        }}
+      />
+
       {error && (
         <div style={{
           color: 'var(--danger)',
@@ -126,7 +186,43 @@ export default function TemplateGallery() {
         </div>
       )}
 
-      {templates.map(template => {
+      {!error && templates.length > 0 && query.trim() && filteredTemplateGroups.length === 0 && (
+        <div style={{ color: 'var(--tx3)', fontSize: 12, padding: '8px 4px' }}>
+          No templates match “{query.trim()}”.
+        </div>
+      )}
+
+      {filteredTemplateGroups.map(group => {
+        const isExpanded = Boolean(query.trim()) || expandedGroups.has(group.name)
+        return (
+          <section key={group.name} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <button
+              type="button"
+              aria-expanded={isExpanded}
+              onClick={() => toggleGroup(group.name)}
+              style={{
+                width: '100%',
+                minHeight: 42,
+                padding: '8px 10px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 9,
+                background: 'var(--lift)',
+                border: '1px solid var(--line2)',
+                borderRadius: 8,
+                color: 'var(--tx1)',
+                cursor: 'pointer',
+                fontFamily: 'var(--font-ui)',
+                textAlign: 'left',
+              }}
+            >
+              <span style={{ color: group.color, fontSize: 12, width: 12 }}>
+                {isExpanded ? '▾' : '▸'}
+              </span>
+              <span style={{ flex: 1, fontSize: 12, fontWeight: 650 }}>{group.name}</span>
+              <span style={{ color: 'var(--tx3)', fontSize: 11 }}>{group.templates.length}</span>
+            </button>
+            {isExpanded && group.templates.map(template => {
         const isLoading = loading === template.slug
         const wasLoaded = loaded === template.slug
         const dependencyError = missing[template.slug]
@@ -137,25 +233,25 @@ export default function TemplateGallery() {
             key={template.slug}
             style={{
               background: 'var(--lift)',
-              border: `1px solid ${dependencyError ? 'var(--warn)' : wasLoaded ? template.color : 'var(--line2)'}`,
+              border: `1px solid ${dependencyError ? 'var(--warn)' : group.color}`,
               borderRadius: 8,
               padding: '10px 12px',
               cursor: isBusy ? 'default' : 'pointer',
               transition: 'border-color 0.2s',
             }}
             onMouseEnter={e => {
-              if (!isBusy && !dependencyError) (e.currentTarget as HTMLElement).style.borderColor = template.color
+              if (!isBusy && !dependencyError) (e.currentTarget as HTMLElement).style.borderColor = group.color
             }}
             onMouseLeave={e => {
               if (!wasLoaded) {
-                (e.currentTarget as HTMLElement).style.borderColor = dependencyError ? 'var(--warn)' : 'var(--line2)'
+                (e.currentTarget as HTMLElement).style.borderColor = dependencyError ? 'var(--warn)' : group.color
               }
             }}
             onClick={() => !isBusy && loadTemplate(template)}
           >
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginBottom: 4 }}>
               <span style={{
-                color: template.color,
+                color: group.color,
                 fontSize: 13,
                 fontWeight: 600,
                 overflow: 'hidden',
@@ -167,7 +263,7 @@ export default function TemplateGallery() {
               <span style={{
                 flex: '0 0 auto',
                 fontSize: 11,
-                color: dependencyError ? 'var(--warn)' : wasLoaded ? template.color : 'var(--tx3)',
+                color: dependencyError ? 'var(--warn)' : wasLoaded ? group.color : 'var(--tx3)',
                 fontFamily: 'var(--font-ui)',
               }}>
                 {isLoading
@@ -250,6 +346,9 @@ export default function TemplateGallery() {
               </div>
             )}
           </div>
+        )
+            })}
+          </section>
         )
       })}
     </div>

--- a/editor/src/portColors.ts
+++ b/editor/src/portColors.ts
@@ -10,6 +10,7 @@ export const PORT_COLORS: Record<string, string> = {
   Fn:        '#ef4444',  // red
   Model:     '#76b900',  // nvidia green
   Image:     '#fb7185',  // rose
+  Video:     '#f43f5e',  // deep rose
   Color:     '#e11d48',  // color picker value
   HSV:       '#0ea5e9',  // hue/saturation/value triplet
   Any:       '#6b7280',  // grey
@@ -28,6 +29,7 @@ const COMPAT: Record<string, Set<string>> = {
   Fn:        new Set(['Fn', 'Any']),
   Model:     new Set(['Model', 'Text', 'Any']),
   Image:     new Set(['Image', 'Any']),
+  Video:     new Set(['Video', 'Any']),
   Color:     new Set(['Color', 'Text', 'Any']),
   HSV:       new Set(['HSV', 'Text', 'Any']),
 }

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -13,6 +13,8 @@ import type { GraphRunTarget } from './graphRun'
 
 const MODEL_NODE_TYPES  = new Set(['Model'])
 const OUTPUT_NODE_TYPES = new Set(['Output'])
+const MEDIA_OUTPUT_NODE_SIZE = { width: 860, height: 720 } as const
+const MEDIA_OUTPUT_TYPES = new Set(['Image', 'Video'])
 const SUBGRAPH_NODE_TYPES = new Set(['Subnet', 'SubnetAsTool', 'VisualAgentLoop'])
 
 // In-flight cook stream, so a Stop button can abort a running/stuck cook.
@@ -180,6 +182,8 @@ interface Store {
     copyIdMap: Record<string, string> | null,
   ) => Promise<void>
   updateParam: (id: string, key: string, value: unknown) => Promise<void>
+  controlNode: (id: string, action: string) => Promise<void>
+  pickDirectory: (initialPath?: string) => Promise<string | null>
   updatePortVisibility: (id: string, promotedInputs?: string[], promotedOutputs?: string[]) => Promise<void>
   cookNode: (id: string, port?: string, graphTargets?: GraphRunTarget[], runMode?: 'once' | 'live') => Promise<void>
   stopCook: () => void
@@ -213,6 +217,7 @@ function makeReactNode(meta: BnNodeMeta): Node<NodeData> {
     ...(meta.type === 'Dict'   ? { style: { width: 260, height: 150 } } : {}),
     ...(meta.type === 'Output' ? { style: { width: 320, height: 200 } } : {}),
     ...(meta.type === 'OutputImage' ? { style: { width: 760, height: 620 } } : {}),
+    ...(meta.type === 'DatasetBrowser' ? { style: { width: 980, height: 860 } } : {}),
     ...(hasDashboardImage ? { style: { width: 860, height: 720 } } : {}),
     ...(meta.type === 'ROS2VisualDashboard' ? { style: { width: 840, height: 760 } } : {}),
     ...(meta.type === 'ROS2CompressedImageSnapshot' ? { style: { width: 700, height: 600 } } : {}),
@@ -221,6 +226,38 @@ function makeReactNode(meta: BnNodeMeta): Node<NodeData> {
     ...(meta.type === 'ROS2Run' ? { style: { width: 520, height: 360 } } : {}),
     ...(meta.type === 'ROS2MotionDashboard' ? { style: { width: 860, height: 720 } } : {}),
   }
+}
+
+function ensureMediaOutputNodeSizes(
+  nodes: Node<NodeData>[],
+  edges: Edge[],
+): Node<NodeData>[] {
+  const byId = new Map(nodes.map(node => [node.id, node]))
+  const mediaOutputIds = new Set<string>()
+  edges.forEach(edge => {
+    const target = byId.get(edge.target)
+    const source = byId.get(edge.source)
+    const sourceType = edge.sourceHandle
+      ? source?.data.output_types?.[edge.sourceHandle]
+      : undefined
+    if (target?.data.type === 'Output' && sourceType && MEDIA_OUTPUT_TYPES.has(sourceType)) {
+      mediaOutputIds.add(target.id)
+    }
+  })
+
+  return nodes.map(node => {
+    if (!mediaOutputIds.has(node.id)) return node
+    const styleWidth = typeof node.style?.width === 'number' ? node.style.width : 0
+    const styleHeight = typeof node.style?.height === 'number' ? node.style.height : 0
+    const width = Math.max(node.width ?? 0, styleWidth, MEDIA_OUTPUT_NODE_SIZE.width)
+    const height = Math.max(node.height ?? 0, styleHeight, MEDIA_OUTPUT_NODE_SIZE.height)
+    return {
+      ...node,
+      width,
+      height,
+      style: { ...(node.style ?? {}), width, height },
+    }
+  })
 }
 
 function parseGraph(bnNodes: BnNodeMeta[], bnEdges: any[]): { nodes: Node<NodeData>[]; edges: Edge[] } {
@@ -236,7 +273,7 @@ function parseGraph(bnNodes: BnNodeMeta[], bnEdges: any[]): { nodes: Node<NodeDa
       style: { stroke: portColor(fromType), strokeWidth: 1.5 },
     }
   })
-  return { nodes, edges }
+  return { nodes: ensureMediaOutputNodeSizes(nodes, edges), edges }
 }
 
 function propagateLiveTerminalValues(nodes: Node<NodeData>[], edges: Edge[]): Node<NodeData>[] {
@@ -1968,15 +2005,19 @@ export const useStore = create<Store>((set, get) => ({
       await api.connect(nextConn.source, nextConn.sourceHandle, nextConn.target, nextConn.targetHandle)
     }
 
-    set(s => ({
-      nodes: [...s.nodes, node],
-      edges: nextConn?.source && nextConn.target ? addEdge({
+    set(s => {
+      const nextEdges = nextConn?.source && nextConn.target ? addEdge({
         ...nextConn,
         id: nextEdgeId(),
         style: { stroke: portColor(edgeType), strokeWidth: 1.5 },
-      }, s.edges) : s.edges,
-      ...markActiveTabDirty(s),
-    }))
+      }, s.edges) : s.edges
+      const nextNodes = ensureMediaOutputNodeSizes([...s.nodes, node], nextEdges)
+      return {
+        nodes: nextNodes,
+        edges: nextEdges,
+        ...markActiveTabDirty(s),
+      }
+    })
   },
 
   removeNode: async (id) => {
@@ -2279,7 +2320,10 @@ export const useStore = create<Store>((set, get) => ({
       await api.connect(conn.source!, conn.sourceHandle!, conn.target!, conn.targetHandle!)
     }
 
-    const nextNodes = ensureConnectedToolBoxSlots(nodes, updatedEdges)
+    const nextNodes = ensureMediaOutputNodeSizes(
+      ensureConnectedToolBoxSlots(nodes, updatedEdges),
+      updatedEdges,
+    )
     set(s => ({ nodes: nextNodes, edges: updatedEdges, ...markActiveTabDirty(s) }))
   },
 
@@ -2377,7 +2421,8 @@ export const useStore = create<Store>((set, get) => ({
         style: { stroke: portColor(fromType), strokeWidth: 1.5 },
       }])
     const removedForPrune = [oldEdge, conflictingEdge].filter(Boolean) as Edge[]
-    const { nodes: nextNodes, changedIds: prunedDynamicNodes } = pruneDisconnectedDynamicPorts(nodes, nextEdges, removedForPrune)
+    const { nodes: prunedNodes, changedIds: prunedDynamicNodes } = pruneDisconnectedDynamicPorts(nodes, nextEdges, removedForPrune)
+    const nextNodes = ensureMediaOutputNodeSizes(prunedNodes, nextEdges)
 
     if (subnetStack.length > 0) {
       const frame = subnetStack[subnetStack.length - 1]
@@ -2741,6 +2786,24 @@ export const useStore = create<Store>((set, get) => ({
         },
       }))
     }
+  },
+
+  controlNode: async (id, action) => {
+    const result = await api.controlNode(id, action)
+    set(s => ({
+      nodes: propagateLiveTerminalValues(s.nodes.map(node => node.id === id ? {
+        ...node,
+        data: {
+          ...node.data,
+          portResults: { ...(node.data.portResults ?? {}), ...result.outputs },
+        },
+      } : node), s.edges),
+    }))
+  },
+
+  pickDirectory: async (initialPath = '') => {
+    const result = await api.pickDirectory(initialPath)
+    return result.cancelled || !result.selected ? null : result.selected
   },
 
   updatePortVisibility: async (id, promotedInputs, promotedOutputs) => {

--- a/python/blacknode/node.py
+++ b/python/blacknode/node.py
@@ -45,6 +45,7 @@ Fn = PortType("Fn")
 Model = PortType("Model")
 Number = PortType("Number")
 Image = PortType("Image")
+Video = PortType("Video")
 Any = PortType("Any")
 
 
@@ -173,7 +174,7 @@ def _parse_default(raw: str) -> object:
 
 
 _COMPACT_PORT_THRESHOLD = 8
-_DATA_INPUT_TYPES = {"Any", "Dict", "Embedding", "Fn", "Image", "List"}
+_DATA_INPUT_TYPES = {"Any", "Dict", "Embedding", "Fn", "Image", "Video", "List"}
 _STATUS_OUTPUTS = {
     "active", "armed", "command_ok", "connected", "count", "data_ready",
     "device", "driver_running", "dropped_frames", "error", "found", "joint_count",

--- a/start.ps1
+++ b/start.ps1
@@ -355,12 +355,14 @@ function Invoke-PackageHealthCheck {
 
         if ($env:BLACKNODE_PACKAGE_AUTO_SETUP -ne "0") {
             Write-Step "Installing missing extension package dependencies..."
-            $SetupResult = Invoke-PythonCapture -Arguments @("-m", "blacknode.cli", "packages", "setup", "--missing")
-            $SetupOutput = $SetupResult.Output
-            $SetupExitCode = $SetupResult.ExitCode
-            if ($SetupOutput) { $SetupOutput | ForEach-Object { Write-Host "    $_" } }
+            Write-Host "  Dependency download and installation output will appear below."
+            $SetupArguments = @("-m", "blacknode.cli", "packages", "setup", "--missing")
+            & $Python @SetupArguments
+            $SetupExitCode = $LASTEXITCODE
             if ($SetupExitCode -ne 0) {
                 Write-Host "  Warning: automatic package dependency setup failed; startup will continue." -ForegroundColor Yellow
+            } else {
+                Write-Step "Extension package dependency setup complete."
             }
         }
 

--- a/start.sh
+++ b/start.sh
@@ -311,11 +311,11 @@ check_package_dependencies() {
 
   if [[ "${BLACKNODE_PACKAGE_AUTO_SETUP:-1}" == "1" ]]; then
     echo "  Installing missing extension package dependencies..."
-    if ! output="$(PYTHONPATH="$ROOT_DIR/python" "$PYTHON_BIN" -m blacknode.cli packages setup --missing 2>&1)"; then
-      printf '%s\n' "$output" | sed 's/^/    /'
+    echo "  Dependency download and installation output will appear below."
+    if ! PYTHONPATH="$ROOT_DIR/python" "$PYTHON_BIN" -m blacknode.cli packages setup --missing; then
       echo "  Warning: automatic package dependency setup failed; startup will continue."
-    elif [[ -n "$output" ]]; then
-      printf '%s\n' "$output" | sed 's/^/    /'
+    else
+      echo "  Extension package dependency setup complete."
     fi
   fi
 

--- a/tests/test_editor_media_output.py
+++ b/tests/test_editor_media_output.py
@@ -6,6 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_generic_output_renders_typed_images_and_video_instead_of_urls() -> None:
     source = (ROOT / "editor" / "src" / "components" / "OutputNode.tsx").read_text(encoding="utf-8")
+    store = (ROOT / "editor" / "src" / "store.ts").read_text(encoding="utf-8")
 
     assert "sourceType === 'Image'" in source
     assert "sourceType === 'Video'" in source
@@ -13,6 +14,12 @@ def test_generic_output_renders_typed_images_and_video_instead_of_urls() -> None
     assert "<video" in source
     assert "data:image/" in source
     assert "data:video/" in source
+    assert "sourceType === 'Image' || sourceType === 'Video'" in source
+    assert "hasVisualMediaInput ? 860 : 240" in source
+    assert "hasVisualMediaInput ? 720 : 120" in source
+    assert "MEDIA_OUTPUT_NODE_SIZE = { width: 860, height: 720 }" in store
+    assert "MEDIA_OUTPUT_TYPES = new Set(['Image', 'Video'])" in store
+    assert "ensureMediaOutputNodeSizes(nodes, edges)" in store
 
 
 def test_generic_output_converts_legacy_raw_svg_images_to_data_urls() -> None:
@@ -64,3 +71,21 @@ def test_live_nodes_distinguish_blocked_waiting_and_snapshot_states() -> None:
     assert "&& !liveWaiting" in black_node
     assert "blockedControllerCount" in app
     assert "waitingControllerCount" in app
+
+
+def test_dataset_replay_switches_units_and_keeps_canvas_wheel_zoom() -> None:
+    browser = (ROOT / "editor" / "src" / "components" / "DatasetBrowserPanel.tsx").read_text(encoding="utf-8")
+    output = (ROOT / "editor" / "src" / "components" / "OutputNode.tsx").read_text(encoding="utf-8")
+    api = (ROOT / "editor" / "src" / "api.ts").read_text(encoding="utf-8")
+
+    assert "setAngleUnit('radians')" in browser
+    assert "setAngleUnit('degrees')" in browser
+    assert "numeric * 180 / Math.PI" in browser
+    assert "numeric * Math.PI / 180" in browser
+    assert 'className="nodrag"' in browser
+    assert 'className="nodrag nowheel"' not in browser
+    assert 'className="nodrag nowheel bn-output-scroll"' not in output
+    assert "✂ Cut before" in browser
+    assert "✂ Cut after" in browser
+    assert "The selected frame is kept" in browser
+    assert "trimDatasetEpisode" in api

--- a/tests/test_editor_package_welcome.py
+++ b/tests/test_editor_package_welcome.py
@@ -14,4 +14,6 @@ def test_first_editor_visit_opens_packages_with_one_time_welcome():
     assert "localStorage" not in source
     assert "Prepare your robotics workspace" in source
     assert "Explore essential packages" in source
-    assert "Continue with core graph" in source
+    assert "Explore core templates" in source
+    assert "useState<Tab | null>('templates')" in source
+    assert "finishPackageWelcome('templates')" in source

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -173,6 +174,86 @@ class EditorRuntimeTests(unittest.TestCase):
         self.assertEqual(response.json(), runtime_result)
         stop_cook.assert_called_once()
         fresh_cook.assert_called_once()
+
+    def test_episode_recorder_control_does_not_cook_graph(self):
+        server._session.node_meta["recorder-control-test"] = {
+            "id": "recorder-control-test", "type": "EpisodeRecorder",
+            "params": {"run_id": "episode-test"},
+        }
+        control = lambda run_id, action: {"running": False, "frame_count": 12, "report": f"{run_id}:{action}"}
+        try:
+            with (
+                patch.object(server, "_runtime_callable", return_value=control),
+                patch.object(server, "_prepare_cook") as prepare_cook,
+            ):
+                response = TestClient(server.app).post(
+                    "/nodes/recorder-control-test/control", json={"action": "save"},
+                )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["outputs"]["frame_count"], 12)
+            prepare_cook.assert_not_called()
+        finally:
+            server._session.node_meta.pop("recorder-control-test", None)
+
+    def test_dataset_media_endpoint_serves_only_runtime_registered_video(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            video = Path(tmp) / "episode.mp4"
+            video.write_bytes(b"synthetic-mp4")
+            with patch.object(server, "_runtime_callable", return_value=lambda token: video if token == "known" else None):
+                client = TestClient(server.app)
+                response = client.get("/dataset/media/known")
+                api_response = client.get("/api/dataset/media/known")
+                missing = client.get("/dataset/media/unknown")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"synthetic-mp4")
+        self.assertEqual(api_response.content, b"synthetic-mp4")
+        self.assertEqual(missing.status_code, 404)
+
+    def test_directory_picker_endpoint_returns_native_selection(self):
+        with patch.object(server, "_pick_directory", return_value=r"E:\RobotData") as picker:
+            response = TestClient(server.app).post(
+                "/filesystem/pick-directory", json={"initial_path": r"C:\Users\robot"},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"selected": r"E:\RobotData", "cancelled": False})
+        picker.assert_called_once_with(r"C:\Users\robot")
+
+    def test_dataset_frame_endpoint_returns_synchronized_robot_values(self):
+        frame = {
+            "frame_index": 12,
+            "timestamp": 0.4,
+            "leader": {"joint": 0.1},
+            "observation": {"joint": 0.09},
+            "action": {"joint": 0.1},
+        }
+        with patch.object(server, "_runtime_callable", return_value=lambda token, index: frame if (token, index) == ("known", 12) else None):
+            client = TestClient(server.app)
+            response = client.get("/dataset/frame/known?index=12")
+            missing = client.get("/dataset/frame/unknown?index=12")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), frame)
+        self.assertEqual(missing.status_code, 404)
+
+    def test_dataset_trim_endpoint_forwards_confirmed_frame_and_side(self):
+        def trim(token, frame_index, side):
+            if token != "known":
+                raise ValueError("replay selection expired")
+            return {"ok": True, "frames": 8, "removed_frames": 4,
+                    "frame_index": frame_index, "side": side}
+
+        with patch.object(server, "_runtime_callable", return_value=trim):
+            client = TestClient(server.app)
+            response = client.post(
+                "/dataset/trim", json={"token": "known", "frame_index": 4, "side": "before"},
+            )
+            expired = client.post(
+                "/dataset/trim", json={"token": "expired", "frame_index": 4, "side": "after"},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["removed_frames"], 4)
+        self.assertEqual(response.json()["frame_index"], 4)
+        self.assertEqual(response.json()["side"], "before")
+        self.assertEqual(expired.status_code, 409)
 
 
 if __name__ == "__main__":

--- a/tests/test_editor_template_groups.py
+++ b/tests/test_editor_template_groups.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_template_gallery_groups_are_collapsed_by_default():
+    source = (
+        ROOT / "editor" / "src" / "components" / "TemplateGallery.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "useState<Set<string>>(() => new Set())" in source
+    assert "template.group || 'Core'" in source
+    assert "aria-expanded={isExpanded}" in source
+    assert "isExpanded && group.templates.map" in source
+
+
+def test_template_gallery_searches_and_uses_group_colors():
+    source = (
+        ROOT / "editor" / "src" / "components" / "TemplateGallery.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert 'placeholder="Search templates or categories..."' in source
+    assert "const filteredTemplateGroups = useMemo" in source
+    assert "Boolean(query.trim()) || expandedGroups.has(group.name)" in source
+    assert "border: `1px solid ${dependencyError ? 'var(--warn)' : group.color}`" in source
+    assert "color: group.color" in source

--- a/tests/test_editor_template_packages.py
+++ b/tests/test_editor_template_packages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -73,3 +74,35 @@ def test_template_load_returns_installable_missing_package(tmp_path):
         "installed": False,
         "load_error": "",
     }]
+
+
+def test_template_list_groups_core_and_package_templates(tmp_path: Path):
+    core_dir = tmp_path / "core"
+    robot_dir = tmp_path / "robot" / "templates"
+    core_dir.mkdir()
+    robot_dir.mkdir(parents=True)
+    (core_dir / "text-pipeline.json").write_text(
+        json.dumps(_template("TextInput")), encoding="utf-8",
+    )
+    (robot_dir / "motion-test.json").write_text(
+        json.dumps(_template("Robot")), encoding="utf-8",
+    )
+    robot_package = SimpleNamespace(
+        name="blacknode-robot",
+        ok=True,
+        templates_dir=str(robot_dir),
+        categories={"Robot": "#14b8a6"},
+    )
+
+    with (
+        patch.object(server, "_TEMPLATES_DIR", str(core_dir)),
+        patch.object(server, "installed_packages", return_value=[robot_package]),
+    ):
+        response = TestClient(server.app).get("/templates")
+
+    assert response.status_code == 200
+    templates = {template["slug"]: template for template in response.json()}
+    assert templates["text-pipeline"]["group"] == "Core"
+    assert templates["text-pipeline"]["group_color"] == "#6366f1"
+    assert templates["motion-test"]["group"] == "Robot"
+    assert templates["motion-test"]["group_color"] == "#14b8a6"

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -26,6 +26,16 @@ def test_core_launchers_do_not_install_optional_cuda_dependencies():
     assert "pip_install cupy" not in shell.lower()
 
 
+def test_launchers_stream_extension_dependency_setup_output():
+    powershell = (ROOT / "start.ps1").read_text(encoding="utf-8")
+    shell = (ROOT / "start.sh").read_text(encoding="utf-8")
+
+    assert "& $Python @SetupArguments" in powershell
+    assert "Dependency download and installation output will appear below." in powershell
+    assert 'output="$(PYTHONPATH="$ROOT_DIR/python" "$PYTHON_BIN" -m blacknode.cli packages setup --missing' not in shell
+    assert 'PYTHONPATH="$ROOT_DIR/python" "$PYTHON_BIN" -m blacknode.cli packages setup --missing' in shell
+
+
 def test_windows_markdown_launch_commands_are_powershell_explicit():
     markdown_files = [ROOT / "README.md", *ROOT.joinpath("docs").rglob("*.md")]
     markdown_files.extend([


### PR DESCRIPTION
## What
Adds `StreamPublisher` to the editor's `LIVE_STREAM_NODE_TYPES` set in `BlackNode.tsx`. Once the node emits `streaming=true` with a `stream_url`, it now shows the **STREAMING** badge and a **Stop stream** button instead of the static `SNAPSHOT - NOT UPDATING / Go live` message. This was the cause of 'pressed go live and it says snapshot'.

## Heads up
This branch also **snapshots pre-existing in-progress editor/server/docs work** that was uncommitted in the working tree (BlackNode.tsx is entangled with uncommitted `store.ts`/`api.ts`/`portColors.ts`, so the fix can't be isolated into a buildable one-file PR). The reviewable change for this PR is the streaming live-UI fix; the rest is your existing WIP captured so the branch builds. Cherry-pick or merge as suits your workflow.

Pairs with blacknode-dataset generic streaming (StreamPublisher/TrajectorySmoother) already pushed.