### PR TITLE
Deploy workflows to paired devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Hardware drivers, cameras, buses, and the physical robot
 | Robot model | Robot profiles, capability contracts, calibration, discovery, and connection health | [`blacknode-robot`](https://github.com/temiroff/blacknode-robot) |
 | Integration | ROS 2 graph, topics, services, processes, native transport, and rosbridge | [`blacknode-ros2`](https://github.com/temiroff/blacknode-ros2) |
 | Hardware deployment | Runtime device contracts, capability inspection, safe device control, replaceable adapters, physical drivers, and firmware protocols | [`blacknode-hardware`](https://github.com/temiroff/blacknode-hardware), [`blacknode-drivers`](https://github.com/temiroff/blacknode-drivers) |
-| Learning and deployment | Episode recording, policy training, simulation, and accelerated compute | [`blacknode-dataset`](https://github.com/temiroff/blacknode-dataset), [`blacknode-training`](https://github.com/temiroff/blacknode-training), [`blacknode-isaac`](https://github.com/temiroff/blacknode-isaac), [`blacknode-cuda`](https://github.com/temiroff/blacknode-cuda) |
+| Learning and deployment | Episode recording, policy training, remote runtime, simulation, and accelerated compute | [`blacknode-dataset`](https://github.com/temiroff/blacknode-dataset), [`blacknode-training`](https://github.com/temiroff/blacknode-training), [`blacknode-runtime`](https://github.com/temiroff/blacknode-runtime), [`blacknode-isaac`](https://github.com/temiroff/blacknode-isaac), [`blacknode-cuda`](https://github.com/temiroff/blacknode-cuda) |
 
 The workflow depends on stable capabilities such as a camera, joint controller,
 mobile base, or navigation interface. Robot profiles select the concrete
@@ -104,6 +104,73 @@ replaceable adapters. Add
 [`blacknode-drivers`](https://github.com/temiroff/blacknode-drivers) for the
 physical bus, firmware, or device protocol used by the robot.
 
+### Pair a deployed device
+
+Start and verify the hardware service on the Raspberry Pi, then generate its
+pairing token:
+
+```bash
+./service.sh check --require-hardware
+./pair.sh
+```
+
+In the Blacknode editor, open **Devices**, select **Pair device**, and enter the
+Pi's service URL, such as `http://192.168.1.87:8765`. Paste the token printed by
+`pair.sh` and select **Pair and verify**. Blacknode checks the public service
+identity and then makes an authenticated status request before saving it.
+
+Device records are local to the editor installation at
+`.blacknode/devices.json`, which is excluded from Git. Pairing tokens remain in
+the editor backend: API responses, workflows, and deployment artifacts refer to
+the device ID and do not contain the token. Re-pair the same URL to replace a
+rotated token or update the device name.
+
+Plain HTTP protects access with the pairing token but does not encrypt network
+traffic. Use it only on a trusted local network; use HTTPS or a private VPN when
+the device is reachable through an untrusted network.
+
+### Deploy a workflow to a paired device
+
+Open **Deploy**, select a paired device under **Remote target**, and select
+**Validate deployment**. This preflight does not upload, start, arm, or move
+anything. It checks:
+
+- workflow structure and editor-side package resolution;
+- authenticated device-service access and physical hardware connection;
+- disarmed state;
+- declared `metadata.required_capabilities` against device capabilities;
+- calibration when a workflow declares the `joint_group` capability; and
+- availability of the target runtime manifest.
+
+Checks appear as pass, warning, failure, or pending. Install and start
+`blacknode-runtime` on the target to validate its Python version, Blacknode
+version, deployment features, required packages, and registered node types. If
+preflight reports an indexed extension package as **will install**, staging
+automatically clones it, installs its declared prerequisites, loads its nodes,
+and verifies the target manifest before uploading the workflow.
+
+When preflight reports **Ready**, choose:
+
+- **Stage** to export and upload the workflow without starting it.
+- **Stage & run** to upload it and explicitly start it on the device.
+
+Blacknode hashes the exact validated graph. If the canvas changes before
+staging, the upload is rejected; select **Validate** again so a different graph
+cannot be deployed accidentally.
+
+Remote deployments appear below the preflight report. Expand one to view its
+device log and use **Run**, **Stop**, **Stage update**, or **Rollback**.
+**Stage update** uploads the currently validated graph as another revision of
+that deployment. **Rollback** selects the previous revision without starting
+it; use **Run** after checking its state. A running deployment must be stopped
+before it can be updated or deleted. Every remote start rechecks that hardware
+is connected and disarmed.
+
+The editor sends runtime requests through its backend, using the pairing token
+stored in `.blacknode/devices.json`; the browser never receives that token.
+Existing **Save local** and **Run local** actions continue to operate on the
+editor computer.
+
 ## Core Platform
 
 - **Visual workflow editor:** compose and inspect typed node graphs.
@@ -121,6 +188,7 @@ physical bus, firmware, or device protocol used by the robot.
   [Datasets](docs/episode-datasets.md) ·
   [Policy training](docs/robot-policy-training.md)
 - Platform: [Packages](docs/packages.md) ·
+  [Device deployment](docs/deployment-architecture.md) ·
   [Workflow schema](docs/workflow-schema.md) ·
   [Custom nodes](docs/custom-nodes.md) ·
   [MCP](docs/quickstart-mcp.md) ·

--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -1,0 +1,212 @@
+# Modular Device Deployment
+
+Blacknode separates workflow deployment, communication transport, runtime
+execution, hardware control, and platform updates. Each layer has a stable
+contract and replaceable providers, allowing a device to use direct HTTP today
+and a broker, edge data fabric, container executor, or OTA platform later.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    E[Blacknode Editor] --> C[Deployment Coordinator]
+    C --> T[Deployment Transport]
+    T --> H[HTTP adapter]
+    T -. optional .-> Q[MQTT adapter]
+    T -. optional .-> Z[Zenoh adapter]
+    H --> S[Runtime Deployment Service]
+    Q -.-> S
+    Z -.-> S
+    S --> A[Artifact Store]
+    S --> X[Execution Backend]
+    S --> D[Hardware Service]
+
+    F[Platform Release Manager] --> U[Platform Update Provider]
+    U -. optional .-> M[Mender adapter]
+    M -. updates .-> P[OS, Blacknode, runtime, hardware, drivers]
+```
+
+Solid lines describe the current direct deployment path. Dotted lines are
+provider boundaries intended for optional integrations.
+
+The two update lifecycles remain separate:
+
+- **Workflow deployment** is frequent and interactive. It validates, stages,
+  starts, stops, logs, and rolls back a workflow artifact.
+- **Platform update** is infrequent and administrative. It updates the
+  operating system, Blacknode installation, runtime, hardware package, drivers,
+  and device configuration.
+
+An OTA provider may install a new runtime version, but it does not replace the
+runtime's workflow-aware deployment service.
+
+## Stable contracts
+
+### Deployment artifact
+
+Every transport carries the same logical artifact:
+
+| Field | Purpose |
+|---|---|
+| `schema_version` | Selects the artifact contract |
+| `name` | Human-readable deployment name |
+| `workflow_hash` | Binds the artifact to the exact validated graph |
+| `artifact_hash` | Identifies the exported executable content |
+| `entrypoint` | Declares what the runtime executes |
+| `required_capabilities` | Declares required device capabilities |
+| `required_packages` | Declares required target packages |
+| `package_requirements` | Declares package source and published version |
+| `content` | Executable workflow or a reference to immutable content |
+
+Large artifacts do not have to travel through the command transport. An MQTT
+or Zenoh command can carry a content-addressed HTTPS or object-store reference,
+while the same artifact manifest and hashes remain authoritative.
+
+### Deployment transport
+
+A transport adapter exposes these semantic operations regardless of protocol:
+
+| Operation | Meaning |
+|---|---|
+| `manifest` | Read runtime identity, versions, features, and package inventory |
+| `list` / `get` | Read desired and observed deployment state |
+| `stage` | Validate and store a revision without starting it |
+| `start` | Explicitly run the staged revision |
+| `stop` | Idempotently stop its complete process or service group |
+| `logs` | Read logs using a cursor or bounded tail |
+| `rollback` | Select a previous revision, without implicit motion |
+| `delete` | Remove a stopped deployment and its stored revisions |
+
+The current provider maps these operations to authenticated HTTP endpoints.
+Future providers must preserve the same request and response shapes rather than
+leaking protocol-specific topics, sessions, or query objects into the editor.
+
+Every mutating request will support:
+
+- a unique operation ID for idempotent retries;
+- device ID and deployment ID;
+- expected workflow and revision hashes;
+- creation and expiry timestamps;
+- explicit acknowledgement and structured errors; and
+- authenticated caller identity.
+
+### Runtime deployment service
+
+The runtime owns deployment state independently from its network adapter. Its
+service contract is responsible for:
+
+- synchronizing declared extension packages through a replaceable package
+  provider before artifact staging;
+- validating artifact size, schema, hash, and executable form;
+- preserving revisions;
+- separating stage from start;
+- supervising execution;
+- reporting observed state and bounded logs;
+- stopping complete process groups; and
+- selecting previous revisions.
+
+The current execution backend uses a supervised Python process. A systemd,
+container, or another executor can implement the same backend contract later.
+The current package provider uses the Blacknode package index and package
+manifests. Future image-based executors may resolve the same requirements into
+an immutable container or platform release instead.
+
+### Hardware service
+
+The hardware service remains the authority for physical state and commands.
+Transport and runtime providers never bypass:
+
+- explicit arming;
+- calibration and joint limits;
+- command freshness and expiry;
+- hardware identity;
+- emergency stop and shutdown behavior; or
+- capability availability.
+
+The deployment coordinator checks connectivity and disarmed state before a
+remote start. Hardware-facing commands still pass through the hardware
+service's own safety checks after a workflow starts.
+
+### Platform update provider
+
+A platform update provider reports inventory and manages releases of:
+
+- the operating system and kernel;
+- Blacknode core;
+- `blacknode-runtime`;
+- `blacknode-hardware`;
+- device drivers and optional packages; and
+- service definitions and non-secret configuration.
+
+Its lifecycle is distinct from workflow revisions:
+
+`available -> downloaded -> installed -> verified -> committed`
+
+A platform rollback restores a software or operating-system release. A
+workflow rollback only selects a previous workflow revision.
+
+## Provider roles
+
+| Provider | Intended role | Status |
+|---|---|---|
+| Direct HTTP | Local-network discovery, commands, state, and logs | Current |
+| MQTT 5 | Brokered commands, acknowledgements, status events, and offline fleet communication | Planned adapter |
+| Zenoh | Edge queries, pub/sub state, logs, and routed or peer-to-peer communication | Planned adapter |
+| Mender | Fleet inventory and OTA updates for device software and operating systems | Planned platform-update adapter |
+
+MQTT and Zenoh are deployment transports. Mender is a platform update
+provider. A device may use one from each category—for example, Zenoh for live
+deployment control and Mender for signed operating-system updates.
+
+Relevant provider specifications:
+
+- [MQTT 5.0 specification](https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html)
+- [Zenoh documentation](https://zenoh.io/docs/)
+- [Mender Update Modules](https://docs.mender.io/client-installation/use-an-updatemodule)
+- [Mender operating-system updates](https://docs.mender.io/operating-system-updates-yocto-project/overview)
+
+## Configuration and discovery
+
+Provider selection belongs to device configuration, not workflow graphs. A
+paired device record will eventually select providers using a shape such as:
+
+```json
+{
+  "device_id": "workshop-arm",
+  "deployment_transport": {
+    "provider": "http",
+    "endpoint": "http://192.168.1.87:8766"
+  },
+  "platform_updates": {
+    "provider": "none"
+  }
+}
+```
+
+Credentials are referenced by a local credential ID or operating-system secret
+store. They are never embedded in workflows, deployment artifacts, browser
+responses, logs, or provider-neutral configuration.
+
+The deployment plan sends package source and version from the editor. The
+runtime package provider is generic: it does not contain a list of perception,
+robot, training, or other extension packages. Publishing a new extension
+package or a newer package version therefore does not require a new runtime
+release. Package ownership can come from the official package index, explicit
+workflow metadata, or the editor's live package registry and Git origin.
+
+## Compatibility requirements
+
+Optional providers must satisfy one shared contract suite. Blacknode considers
+a provider compatible only when it demonstrates:
+
+- identical deployment state transitions;
+- idempotent retries and duplicate-command handling;
+- bounded payload and log behavior;
+- reconnect and timeout behavior;
+- authentication failures that do not expose credentials;
+- revision and workflow-hash enforcement;
+- explicit start, stop, and rollback behavior; and
+- unchanged hardware safety checks.
+
+The direct HTTP implementation remains the reference provider while additional
+adapters are developed.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -117,6 +117,7 @@ development:
 
 | Package | Role |
 |---|---|
+| `blacknode-runtime` | Authenticated remote deployment, target manifests, process supervision, logs, and rollback on Raspberry Pi, Jetson, and Linux targets. |
 | `blacknode-drivers` | Selectively enabled physical hardware drivers and firmware adapters; the first `feetech` component provides inert bus configuration, read-only probing, and torque-safe bus primitives. |
 | `blacknode-robot` | Generic USB robot discovery, serial permission help, driver descriptors, driver process launch, and the standard robot profile. |
 | `blacknode-controllers` | Joint-control, mobile-base, navigation, manipulation, policy, arbitration, and safety controllers with optional transport adapters. |

--- a/docs/python-roundtrip.md
+++ b/docs/python-roundtrip.md
@@ -48,7 +48,7 @@ looks for the local checkout, its `.venv` dependencies, and `BLACKNODE_HOME` if
 you need to point the script at a different Blacknode folder:
 
 ```bash
-BLACKNODE_HOME=/home/alex/PROJECTS/Blacknode python workflow.py
+BLACKNODE_HOME=/path/to/Blacknode python workflow.py
 ```
 
 If the graph starts live runtime helpers such as ROS 2 image streams, CV2

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -1,0 +1,394 @@
+"""Local registry and authenticated client for Blacknode hardware devices."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+_MAX_RESPONSE_BYTES = 1024 * 1024
+_ID_RE = re.compile(r"[^a-z0-9]+")
+
+
+class DeviceRegistryError(RuntimeError):
+    """A local registry or remote device request could not be completed."""
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_base_url(value: str) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        raise DeviceRegistryError("Device URL is required.")
+    parsed = urllib.parse.urlsplit(raw)
+    if parsed.scheme not in {"http", "https"}:
+        raise DeviceRegistryError("Device URL must start with http:// or https://.")
+    if not parsed.hostname:
+        raise DeviceRegistryError("Device URL must include a hostname or IP address.")
+    if parsed.username or parsed.password:
+        raise DeviceRegistryError("Device URL must not contain credentials.")
+    if parsed.query or parsed.fragment:
+        raise DeviceRegistryError("Device URL must not contain a query or fragment.")
+    if parsed.path not in {"", "/"}:
+        raise DeviceRegistryError("Enter the service base URL without an endpoint path.")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise DeviceRegistryError("Device URL contains an invalid port.") from exc
+    host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    authority = f"{host}:{port}" if port is not None else host
+    return urllib.parse.urlunsplit((parsed.scheme, authority, "", "", ""))
+
+
+def token_fingerprint(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
+
+
+def default_runtime_url(hardware_url: str) -> str:
+    parsed = urllib.parse.urlsplit(normalize_base_url(hardware_url))
+    host = f"[{parsed.hostname}]" if ":" in str(parsed.hostname) else parsed.hostname
+    return urllib.parse.urlunsplit((parsed.scheme, f"{host}:8766", "", "", ""))
+
+
+def _slug(value: str) -> str:
+    return _ID_RE.sub("-", value.strip().lower()).strip("-")[:48] or "device"
+
+
+class HardwareDeviceClient:
+    """Talk to one hardware service while keeping its bearer token server-side."""
+
+    def __init__(self, base_url: str, token: str, *, timeout: float = 5.0) -> None:
+        self.base_url = normalize_base_url(base_url)
+        self.token = str(token or "").strip()
+        self.timeout = timeout
+        if not self.token:
+            raise DeviceRegistryError("Pairing token is required.")
+
+    def health(self) -> dict[str, Any]:
+        return self._request("GET", "/health", authenticated=False)
+
+    def status(self) -> dict[str, Any]:
+        return self._request("GET", "/status")
+
+    def capabilities(self) -> dict[str, Any]:
+        return self._request("GET", "/capabilities")
+
+    def rpc(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", "/rpc", payload=payload)
+
+    def validate_pairing(self) -> dict[str, Any]:
+        health = self.health()
+        if health.get("service") != "blacknode-hardware":
+            raise DeviceRegistryError(
+                "The URL responded, but it is not a Blacknode Hardware service."
+            )
+        if not health.get("auth_required"):
+            raise DeviceRegistryError(
+                "Pairing authentication is not enabled on this device. "
+                "Run ./pair.sh on the device and restart its service."
+            )
+        status = self.status()
+        if not isinstance(status, dict) or not status.get("device_id"):
+            raise DeviceRegistryError("The device returned an invalid status response.")
+        return status
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        authenticated: bool = True,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        headers = {"Accept": "application/json"}
+        if authenticated:
+            headers["Authorization"] = f"Bearer {self.token}"
+        body = None
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            f"{self.base_url}{endpoint}",
+            data=body,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(
+                request,
+                timeout=self.timeout if timeout is None else timeout,
+            ) as response:
+                raw = response.read(_MAX_RESPONSE_BYTES + 1)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 401:
+                raise DeviceRegistryError(
+                    "Pairing token was rejected. Run ./pair.sh --show on the device "
+                    "and paste the current token."
+                ) from exc
+            detail = ""
+            try:
+                error_payload = json.loads(exc.read(_MAX_RESPONSE_BYTES).decode("utf-8"))
+                if isinstance(error_payload, dict):
+                    detail = str(
+                        error_payload.get("error")
+                        or error_payload.get("detail")
+                        or ""
+                    ).strip()
+            except (OSError, AttributeError, TypeError, UnicodeDecodeError, json.JSONDecodeError):
+                pass
+            raise DeviceRegistryError(
+                (
+                    f"Device request to {endpoint} failed with HTTP {exc.code}: {detail}"
+                    if detail
+                    else f"Device request to {endpoint} failed with HTTP {exc.code}."
+                )
+            ) from exc
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            reason = getattr(exc, "reason", exc)
+            raise DeviceRegistryError(
+                f"Could not reach {self.base_url}: {reason}. "
+                "Check the address, service, network, and firewall."
+            ) from exc
+        if len(raw) > _MAX_RESPONSE_BYTES:
+            raise DeviceRegistryError("Device response exceeded the 1 MB safety limit.")
+        try:
+            result = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise DeviceRegistryError(
+                f"Device returned invalid JSON from {endpoint}."
+            ) from exc
+        if not isinstance(result, dict):
+            raise DeviceRegistryError(
+                f"Device returned an invalid response from {endpoint}."
+            )
+        return result
+
+
+class RuntimeDeviceClient(HardwareDeviceClient):
+    """Authenticated client for the deployment runtime on a paired device."""
+
+    def manifest(self) -> dict[str, Any]:
+        return self._request("GET", "/manifest")
+
+    def list_deployments(self) -> dict[str, Any]:
+        return self._request("GET", "/deployments")
+
+    def stage_deployment(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", "/deployments", payload=payload)
+
+    def sync_packages(self, packages: list[dict[str, Any]]) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            "/packages/sync",
+            payload={"packages": packages},
+            timeout=600.0,
+        )
+
+    def get_deployment(self, deployment_id: str) -> dict[str, Any]:
+        return self._request("GET", self._deployment_endpoint(deployment_id))
+
+    def start_deployment(self, deployment_id: str) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"{self._deployment_endpoint(deployment_id)}/start",
+            payload={},
+        )
+
+    def stop_deployment(self, deployment_id: str) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"{self._deployment_endpoint(deployment_id)}/stop",
+            payload={},
+        )
+
+    def rollback_deployment(
+        self,
+        deployment_id: str,
+        *,
+        start: bool = False,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"{self._deployment_endpoint(deployment_id)}/rollback",
+            payload={"start": start},
+        )
+
+    def deployment_logs(self, deployment_id: str, *, limit: int = 20000) -> dict[str, Any]:
+        safe_limit = max(512, min(int(limit), 200000))
+        return self._request(
+            "GET",
+            f"{self._deployment_endpoint(deployment_id)}/logs?limit={safe_limit}",
+        )
+
+    def delete_deployment(self, deployment_id: str) -> dict[str, Any]:
+        return self._request("DELETE", self._deployment_endpoint(deployment_id))
+
+    @staticmethod
+    def _deployment_endpoint(deployment_id: str) -> str:
+        clean_id = str(deployment_id or "").strip()
+        if not clean_id:
+            raise DeviceRegistryError("Deployment ID is required.")
+        return f"/deployments/{urllib.parse.quote(clean_id, safe='')}"
+
+
+class DeviceRegistry:
+    """Persist paired devices locally and never expose their stored tokens."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self._lock = threading.RLock()
+
+    def list(self) -> list[dict[str, Any]]:
+        with self._lock:
+            records = self._load()
+            return [
+                self._public(record)
+                for record in sorted(
+                    records.values(),
+                    key=lambda item: (str(item.get("name", "")).lower(), item["id"]),
+                )
+            ]
+
+    def get_public(self, device_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            record = self._load().get(device_id)
+            return self._public(record) if record is not None else None
+
+    def client(self, device_id: str) -> HardwareDeviceClient:
+        with self._lock:
+            record = self._load().get(device_id)
+            if record is None:
+                raise KeyError(device_id)
+            return HardwareDeviceClient(record["base_url"], record["token"])
+
+    def runtime_client(self, device_id: str) -> RuntimeDeviceClient:
+        with self._lock:
+            record = self._load().get(device_id)
+            if record is None:
+                raise KeyError(device_id)
+            runtime_url = record.get("runtime_url") or default_runtime_url(record["base_url"])
+            return RuntimeDeviceClient(runtime_url, record["token"])
+
+    def pair(
+        self,
+        *,
+        name: str,
+        base_url: str,
+        token: str,
+        status: dict[str, Any],
+    ) -> dict[str, Any]:
+        clean_name = str(name or "").strip()
+        clean_url = normalize_base_url(base_url)
+        clean_token = str(token or "").strip()
+        if not clean_token:
+            raise DeviceRegistryError("Pairing token is required.")
+        remote_device_id = str(status.get("device_id") or "").strip()
+        if not remote_device_id:
+            raise DeviceRegistryError("The device status has no device_id.")
+        with self._lock:
+            records = self._load()
+            existing = next(
+                (item for item in records.values() if item.get("base_url") == clean_url),
+                None,
+            )
+            now = _iso_now()
+            if existing is not None:
+                device_id = existing["id"]
+                created_at = existing.get("created_at") or now
+            else:
+                base_id = _slug(remote_device_id or clean_name)
+                device_id = base_id
+                suffix = 2
+                while device_id in records:
+                    device_id = f"{base_id}-{suffix}"
+                    suffix += 1
+                created_at = now
+            record = {
+                "id": device_id,
+                "name": clean_name or remote_device_id,
+                "base_url": clean_url,
+                "runtime_url": (
+                    existing.get("runtime_url")
+                    if existing and existing.get("runtime_url")
+                    else default_runtime_url(clean_url)
+                ),
+                "token": clean_token,
+                "token_fingerprint": token_fingerprint(clean_token),
+                "remote_device_id": remote_device_id,
+                "created_at": created_at,
+                "updated_at": now,
+            }
+            records[device_id] = record
+            self._save(records)
+            return self._public(record)
+
+    def delete(self, device_id: str) -> bool:
+        with self._lock:
+            records = self._load()
+            if device_id not in records:
+                return False
+            del records[device_id]
+            self._save(records)
+            return True
+
+    def _load(self) -> dict[str, dict[str, Any]]:
+        if not self.path.exists():
+            return {}
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise DeviceRegistryError(
+                f"Could not read local device registry at {self.path}: {exc}"
+            ) from exc
+        devices = payload.get("devices", {}) if isinstance(payload, dict) else {}
+        if not isinstance(devices, dict):
+            raise DeviceRegistryError("Local device registry has an invalid format.")
+        return {
+            str(device_id): dict(record)
+            for device_id, record in devices.items()
+            if isinstance(record, dict)
+        }
+
+    def _save(self, records: dict[str, dict[str, Any]]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_name(f".{self.path.name}.{os.getpid()}.tmp")
+        payload = {"schema_version": 1, "devices": records}
+        try:
+            temporary.write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            try:
+                os.chmod(temporary, 0o600)
+            except OSError:
+                pass
+            os.replace(temporary, self.path)
+            try:
+                os.chmod(self.path, 0o600)
+            except OSError:
+                pass
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+
+    @staticmethod
+    def _public(record: dict[str, Any]) -> dict[str, Any]:
+        public = {
+            key: value
+            for key, value in record.items()
+            if key != "token"
+        }
+        public.setdefault("runtime_url", default_runtime_url(str(record["base_url"])))
+        return public

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -1,6 +1,6 @@
 """Blacknode editor backend — FastAPI server the React editor talks to."""
 from __future__ import annotations
-import uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex
+import uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex, hashlib
 import urllib.error, urllib.request
 from datetime import datetime
 from pathlib import Path
@@ -17,7 +17,7 @@ import blacknode.integrations  # noqa: F401  registers chat drivers (slack/teleg
 # frame-stream contract has to be filled here too.
 from blacknode import console as command_console
 from blacknode.node import fill_frame_stream as bn_fill_frame_stream
-from blacknode.deployments import DeploymentError, DeploymentStore
+from blacknode.deployments import DeploymentError, DeploymentStore, resolve_entrypoint
 from blacknode.discovery import discover_node_modules, load_node_file
 from blacknode.integrations import registry as driver_registry
 from blacknode.exporters import export_workflow as export_framework_workflow
@@ -26,7 +26,7 @@ from blacknode.learned import registry as learned_registry
 from blacknode.mcp import tools as mcp_tools
 from blacknode.node import _NODE_REGISTRY
 from blacknode.nodes import ai as ai_nodes
-from blacknode.package_index import package_index_payload, resolve_workflow_dependencies
+from blacknode.package_index import package_index_payload, resolve_workflow_dependencies, workflow_node_types
 from blacknode.packages import MANIFEST_NAME as BN_MANIFEST_NAME
 from blacknode.packages import component_dependency_plan as bn_component_dependency_plan
 from blacknode.packages import adapter_dependency_plan as bn_adapter_dependency_plan
@@ -43,9 +43,11 @@ from blacknode.packages import set_component_enabled as bn_set_component_enabled
 from blacknode.packages import set_adapter_enabled as bn_set_adapter_enabled
 from blacknode.packages import reset_component as bn_reset_component
 from blacknode.python_importer import import_workflow_python
+from blacknode.workflow import WorkflowRunError, export_workflow_python
 from blacknode.workflow import validate_graph as validate_bn_graph
 from blacknode.workflow import validate_workflow as validate_bn_workflow
 
+from device_registry import DeviceRegistry, DeviceRegistryError, HardwareDeviceClient
 from run_store import RunStore
 
 app = FastAPI(title="Blacknode Editor Server")
@@ -102,6 +104,8 @@ _run_store      = RunStore(_RUNS_DIR)
 # deployment outlives this server process and is not tied to it.
 _DEPLOYMENTS_DIR = Path(__file__).resolve().parents[1] / ".blacknode" / "deployments"
 _deployment_store = DeploymentStore(_DEPLOYMENTS_DIR)
+_DEVICES_PATH = Path(__file__).resolve().parents[1] / ".blacknode" / "devices.json"
+_device_registry = DeviceRegistry(_DEVICES_PATH)
 _save_timer: threading.Timer | None = None
 _SUBGRAPH_NODE_TYPES = {"Subnet", "SubnetAsTool", "VisualAgentLoop"}
 _TOOLBOX_NODE_TYPES = {"ToolBox"}
@@ -337,6 +341,30 @@ class DeployReq(BaseModel):
     workflow: dict[str, Any] | None = None
     target: str = "local-process"
     autostart: bool = True
+
+class PairDeviceReq(BaseModel):
+    name: str = ""
+    base_url: str
+    token: str
+
+class DeploymentPreflightReq(BaseModel):
+    # Omit to validate the graph currently open in the editor.
+    workflow: dict[str, Any] | None = None
+
+class RemoteDeployReq(BaseModel):
+    name: str = ""
+    workflow_hash: str
+    start: bool = False
+    deployment_id: str | None = None
+
+class RemoteRollbackReq(BaseModel):
+    start: bool = False
+
+class DeviceRpcReq(BaseModel):
+    jsonrpc: str = "2.0"
+    id: Any = None
+    method: str
+    params: dict[str, Any] = {}
 
 class SyncRunReq(BaseModel):
     node_id: str
@@ -2706,6 +2734,833 @@ def stop_runtime():
     _stop_active_cook()
     _begin_fresh_cook()
     return _stop_runtime_services()
+
+
+# ── Paired hardware devices ──────────────────────────────────────────────────
+
+def _paired_device_client(device_id: str) -> HardwareDeviceClient:
+    try:
+        return _device_registry.client(device_id)
+    except KeyError as exc:
+        raise HTTPException(404, "Device not found") from exc
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+
+
+@app.get("/devices")
+def list_devices():
+    try:
+        return {"devices": _device_registry.list()}
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+
+
+@app.post("/devices")
+def pair_device(req: PairDeviceReq):
+    try:
+        client = HardwareDeviceClient(req.base_url, req.token)
+        status = client.validate_pairing()
+        device = _device_registry.pair(
+            name=req.name,
+            base_url=client.base_url,
+            token=req.token,
+            status=status,
+        )
+    except DeviceRegistryError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    return {"device": device, "status": status}
+
+
+@app.get("/devices/{device_id}")
+def get_device(device_id: str):
+    try:
+        device = _device_registry.get_public(device_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    if device is None:
+        raise HTTPException(404, "Device not found")
+    return device
+
+
+@app.get("/devices/{device_id}/status")
+def get_device_status(device_id: str):
+    try:
+        return _paired_device_client(device_id).status()
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.get("/devices/{device_id}/capabilities")
+def get_device_capabilities(device_id: str):
+    try:
+        return _paired_device_client(device_id).capabilities()
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+def _preflight_check(
+    check_id: str,
+    label: str,
+    status: str,
+    message: str,
+    *,
+    blocking: bool = False,
+) -> dict[str, Any]:
+    return {
+        "id": check_id,
+        "label": label,
+        "status": status,
+        "message": message,
+        "blocking": blocking,
+    }
+
+
+def _workflow_required_capabilities(workflow: dict[str, Any]) -> list[str]:
+    metadata = workflow.get("metadata")
+    if not isinstance(metadata, dict):
+        return []
+    raw = metadata.get("required_capabilities")
+    if not isinstance(raw, list):
+        return []
+    return sorted({
+        str(item).strip()
+        for item in raw
+        if isinstance(item, str) and str(item).strip()
+    })
+
+
+def _workflow_required_packages(workflow: dict[str, Any]) -> list[str]:
+    metadata = workflow.get("metadata")
+    raw = metadata.get("required_packages") if isinstance(metadata, dict) else None
+    if not isinstance(raw, list):
+        return []
+    names: set[str] = set()
+    for item in raw:
+        if isinstance(item, str):
+            name = item.strip()
+        elif isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+        else:
+            name = ""
+        if name:
+            names.add(name)
+    return sorted(names)
+
+
+def _workflow_target_packages(workflow: dict[str, Any]) -> list[str]:
+    """Return explicit and indexed extension packages needed on a target."""
+    return sorted({
+        item["name"]
+        for item in _workflow_target_package_specs(workflow)
+        if item.get("name")
+    })
+
+
+def _package_git_source(path: str) -> str:
+    package_path = Path(path)
+    if not package_path.is_dir():
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(package_path), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    source = result.stdout.strip()
+    match = re.fullmatch(r"git@([^:]+):(.+)", source)
+    if match:
+        return f"https://{match.group(1)}/{match.group(2)}"
+    return source
+
+
+def _workflow_target_package_specs(
+    workflow: dict[str, Any],
+) -> list[dict[str, str]]:
+    index = package_index_payload()
+    indexed_packages = index.get("packages") or {}
+    node_index = index.get("nodes") or {}
+    specs: dict[str, dict[str, str]] = {}
+    local_packages = {
+        info.name: info
+        for info in installed_packages()
+    }
+    local_node_packages = {
+        str(node_type): info
+        for info in local_packages.values()
+        for node_type in info.node_types
+    }
+
+    metadata = workflow.get("metadata")
+    raw_requirements = (
+        metadata.get("required_packages")
+        if isinstance(metadata, dict)
+        else None
+    )
+    if isinstance(raw_requirements, list):
+        for item in raw_requirements:
+            if isinstance(item, str):
+                name = item.strip()
+                git_url = ""
+                version = ""
+            elif isinstance(item, dict):
+                name = str(item.get("name") or "").strip()
+                git_url = str(item.get("git_url") or "").strip()
+                version = str(item.get("version") or "").strip()
+            else:
+                continue
+            indexed = indexed_packages.get(name)
+            if not git_url and isinstance(indexed, dict):
+                git_url = str(indexed.get("git_url") or "").strip()
+            local = local_packages.get(name)
+            if not version and local is not None:
+                version = str(local.version or "").strip()
+            if not version and isinstance(indexed, dict):
+                version = str(indexed.get("version") or "").strip()
+            if name:
+                specs[name] = {
+                    "name": name,
+                    "git_url": git_url,
+                    "version": version,
+                }
+
+    for node_type in workflow_node_types(workflow):
+        resolution = node_index.get(node_type)
+        local_owner = local_node_packages.get(node_type)
+        if isinstance(resolution, dict):
+            name = str(resolution.get("package") or "").strip()
+            git_url = str(resolution.get("git_url") or "").strip()
+        elif local_owner is not None:
+            name = str(local_owner.name or "").strip()
+            git_url = _package_git_source(str(local_owner.path or ""))
+        else:
+            continue
+        if name:
+            existing = specs.get(name)
+            local = local_packages.get(name)
+            indexed = indexed_packages.get(name)
+            version = (
+                str(existing.get("version") or "")
+                if existing
+                else str(local.version or "")
+                if local is not None
+                else str(indexed.get("version") or "")
+                if isinstance(indexed, dict)
+                else ""
+            )
+            specs[name] = {
+                "name": name,
+                "git_url": (
+                    str(existing.get("git_url") or "")
+                    if existing
+                    else git_url
+                ) or git_url,
+                "version": version,
+            }
+    return [specs[name] for name in sorted(specs)]
+
+
+def _device_deployment_workflow(
+    workflow: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if isinstance(workflow, dict):
+        data = json.loads(json.dumps(workflow))
+    else:
+        data = _workflow_payload(
+            "Current graph",
+            metadata={"source": "remote_deployment"},
+        )
+    if not isinstance(data.get("entrypoint"), dict):
+        entrypoint = _infer_export_entrypoint(data)
+        if entrypoint is not None:
+            data["entrypoint"] = entrypoint
+    return data
+
+
+def _device_deployment_hash(workflow: dict[str, Any]) -> str:
+    """Hash deployable graph content without volatile display timestamps."""
+    content = {
+        key: workflow[key]
+        for key in (
+            "kind",
+            "schema_version",
+            "node_meta",
+            "edges",
+            "entrypoint",
+            "metadata",
+        )
+        if key in workflow
+    }
+    canonical = json.dumps(
+        content,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+@app.post("/devices/{device_id}/deployment-preflight")
+def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
+    try:
+        device = _device_registry.get_public(device_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    if device is None:
+        raise HTTPException(404, "Device not found")
+
+    workflow = _device_deployment_workflow(req.workflow)
+
+    checks: list[dict[str, Any]] = []
+    workflow_validation = validate_bn_workflow(workflow).to_dict()
+    if workflow_validation.get("ok"):
+        checks.append(_preflight_check(
+            "workflow",
+            "Workflow",
+            "pass",
+            f"{len(workflow.get('node_meta') or {})} nodes passed workflow validation.",
+        ))
+    else:
+        errors = workflow_validation.get("errors") or []
+        message = "; ".join(
+            str(item.get("message") or item.get("code") or "invalid workflow")
+            for item in errors[:3]
+            if isinstance(item, dict)
+        ) or "Workflow validation failed."
+        checks.append(_preflight_check(
+            "workflow", "Workflow", "fail", message, blocking=True,
+        ))
+
+    dependencies = _workflow_dependency_report(workflow)
+    if dependencies.get("ok"):
+        checks.append(_preflight_check(
+            "local_dependencies",
+            "Editor dependencies",
+            "pass",
+            "The editor can resolve every node and declared package requirement.",
+        ))
+    else:
+        checks.append(_preflight_check(
+            "local_dependencies",
+            "Editor dependencies",
+            "fail",
+            str(dependencies.get("message") or "Workflow dependencies are incomplete."),
+            blocking=True,
+        ))
+
+    try:
+        remote_status = _paired_device_client(device_id).status()
+    except DeviceRegistryError as exc:
+        checks.append(_preflight_check(
+            "service",
+            "Device service",
+            "fail",
+            str(exc),
+            blocking=True,
+        ))
+        checks.extend([
+            _preflight_check(
+                "hardware", "Hardware connection", "pending",
+                "Waiting for the device service.", blocking=True,
+            ),
+            _preflight_check(
+                "safety", "Safety state", "pending",
+                "Waiting for the device service.", blocking=True,
+            ),
+            _preflight_check(
+                "capabilities", "Capabilities", "pending",
+                "Waiting for the device service.", blocking=True,
+            ),
+            _preflight_check(
+                "target_runtime", "Target runtime", "pending",
+                "Waiting for the device service runtime manifest.", blocking=True,
+            ),
+        ])
+        return _deployment_preflight_payload(device, workflow, checks, None, None)
+
+    checks.append(_preflight_check(
+        "service",
+        "Device service",
+        "pass",
+        f"Authenticated with {remote_status.get('device_id') or device['remote_device_id']}.",
+    ))
+
+    connected = bool(remote_status.get("connected"))
+    checks.append(_preflight_check(
+        "hardware",
+        "Hardware connection",
+        "pass" if connected else "fail",
+        (
+            f"{len(remote_status.get('joint_names') or [])} joints are reporting state."
+            if connected
+            else str(remote_status.get("error") or "Hardware is not connected.")
+        ),
+        blocking=not connected,
+    ))
+
+    armed = bool(remote_status.get("armed"))
+    checks.append(_preflight_check(
+        "safety",
+        "Safety state",
+        "fail" if armed else "pass",
+        (
+            "Device is armed. Disarm it before staging a deployment."
+            if armed
+            else "Device is disarmed."
+        ),
+        blocking=armed,
+    ))
+
+    required_capabilities = _workflow_required_capabilities(workflow)
+    available_capabilities = sorted({
+        str(item)
+        for item in (remote_status.get("capabilities") or [])
+        if isinstance(item, str)
+    })
+    if required_capabilities:
+        missing_capabilities = sorted(set(required_capabilities) - set(available_capabilities))
+        checks.append(_preflight_check(
+            "capabilities",
+            "Capabilities",
+            "fail" if missing_capabilities else "pass",
+            (
+                "Missing: " + ", ".join(missing_capabilities)
+                if missing_capabilities
+                else "Available: " + ", ".join(required_capabilities)
+            ),
+            blocking=bool(missing_capabilities),
+        ))
+    else:
+        checks.append(_preflight_check(
+            "capabilities",
+            "Capabilities",
+            "warning",
+            (
+                "Workflow does not declare metadata.required_capabilities. "
+                f"Device reports: {', '.join(available_capabilities) or 'none'}."
+            ),
+        ))
+
+    requires_joint_motion = "joint_group" in required_capabilities
+    calibrated = remote_status.get("calibrated")
+    if requires_joint_motion:
+        checks.append(_preflight_check(
+            "calibration",
+            "Calibration",
+            "pass" if calibrated is True else "fail",
+            (
+                "A calibration profile is active for this device."
+                if calibrated is True
+                else "Joint motion requires the editor calibration profile to be deployed to this device."
+            ),
+            blocking=calibrated is not True,
+        ))
+    elif calibrated is False and "joint_group" in available_capabilities:
+        checks.append(_preflight_check(
+            "calibration",
+            "Calibration",
+            "warning",
+            "No calibration profile is active; any workflow that requires joint_group will be blocked.",
+        ))
+
+    runtime_manifest = None
+    try:
+        runtime_manifest = _device_registry.runtime_client(device_id).manifest()
+        if (
+            runtime_manifest.get("service") != "blacknode-runtime"
+            or runtime_manifest.get("protocol_version") != 1
+        ):
+            raise DeviceRegistryError("Runtime service identity or protocol is incompatible.")
+        features = set(runtime_manifest.get("features") or [])
+        required_features = {"manifest_v1", "deployment_bundle_v1", "process_supervision_v1", "rollback_v1"}
+        missing_features = sorted(required_features - features)
+        blacknode_info = runtime_manifest.get("blacknode") or {}
+        python_version = str((runtime_manifest.get("python") or {}).get("version") or "")
+        try:
+            python_parts = tuple(int(part) for part in python_version.split(".")[:2])
+        except ValueError:
+            python_parts = (0, 0)
+        runtime_package_versions = {
+            str(item.get("name")): str(item.get("version") or "")
+            for item in (runtime_manifest.get("packages") or [])
+            if isinstance(item, dict) and item.get("name")
+        }
+        runtime_packages = set(runtime_package_versions)
+        package_specs = _workflow_target_package_specs(workflow)
+        missing_packages = sorted(
+            set(_workflow_target_packages(workflow)) - runtime_packages
+        )
+        outdated_packages = sorted({
+            item["name"]
+            for item in package_specs
+            if (
+                item.get("version")
+                and item["name"] in runtime_package_versions
+                and runtime_package_versions[item["name"]] != item["version"]
+            )
+        })
+        packages_to_sync = sorted(set(missing_packages) | set(outdated_packages))
+        registered_node_types = runtime_manifest.get("node_types")
+        missing_node_types: list[str] = []
+        if isinstance(registered_node_types, list):
+            missing_node_types = sorted(
+                workflow_node_types(workflow) - {
+                    str(item)
+                    for item in registered_node_types
+                    if isinstance(item, str)
+                }
+            )
+        problems = []
+        if python_parts < (3, 11):
+            problems.append(f"Python {python_version or 'unknown'} is below 3.11")
+        if not blacknode_info.get("installed"):
+            problems.append("Blacknode core is not installed")
+        if missing_features:
+            problems.append("missing runtime features: " + ", ".join(missing_features))
+        package_sync_available = "package_sync_v1" in features
+        installable_packages = {
+            item["name"]
+            for item in package_specs
+            if item.get("git_url")
+        }
+        package_owned_nodes = {
+            str(node_type)
+            for node_type, resolution in (package_index_payload().get("nodes") or {}).items()
+            if (
+                isinstance(resolution, dict)
+                and str(resolution.get("package") or "") in set(packages_to_sync)
+            )
+        }
+        auto_installable = (
+            package_sync_available
+            and set(packages_to_sync) <= installable_packages
+        )
+        hard_missing_nodes = (
+            sorted(set(missing_node_types) - package_owned_nodes)
+            if auto_installable
+            else missing_node_types
+        )
+        if packages_to_sync and not auto_installable:
+            if missing_packages:
+                problems.append("missing target packages: " + ", ".join(missing_packages))
+            if outdated_packages:
+                problems.append("outdated target packages: " + ", ".join(outdated_packages))
+        if hard_missing_nodes:
+            problems.append("unregistered target nodes: " + ", ".join(hard_missing_nodes))
+        package_message = (
+            " · will synchronize " + ", ".join(packages_to_sync) + " when staged"
+            if packages_to_sync and auto_installable
+            else ""
+        )
+        checks.append(_preflight_check(
+            "target_runtime",
+            "Target runtime",
+            (
+                "fail"
+                if problems
+                else "warning"
+                if packages_to_sync and auto_installable
+                else "pass"
+            ),
+            (
+                "; ".join(problems)
+                if problems
+                else (
+                    f"Runtime {runtime_manifest.get('runtime_version')} · "
+                    f"Python {python_version} · "
+                    f"Blacknode {blacknode_info.get('version')}"
+                    f"{package_message}"
+                )
+            ),
+            blocking=bool(problems),
+        ))
+    except (DeviceRegistryError, KeyError) as exc:
+        checks.append(_preflight_check(
+            "target_runtime",
+            "Target runtime",
+            "pending",
+            (
+                f"{exc} Install and start blacknode-runtime on "
+                f"{device.get('runtime_url')}."
+            ),
+            blocking=True,
+        ))
+    return _deployment_preflight_payload(
+        device, workflow, checks, remote_status, runtime_manifest,
+    )
+
+
+def _deployment_preflight_payload(
+    device: dict[str, Any],
+    workflow: dict[str, Any],
+    checks: list[dict[str, Any]],
+    remote_status: dict[str, Any] | None,
+    runtime_manifest: dict[str, Any] | None,
+) -> dict[str, Any]:
+    blocking = [
+        check for check in checks
+        if check.get("blocking") and check.get("status") != "pass"
+    ]
+    return {
+        "ready": not blocking,
+        "summary": (
+            "Deployment preflight passed."
+            if not blocking
+            else f"{len(blocking)} blocking check{'s' if len(blocking) != 1 else ''} need attention."
+        ),
+        "device": device,
+        "workflow": {
+            "name": str(workflow.get("name") or "Current graph"),
+            "node_count": len(workflow.get("node_meta") or {}),
+            "required_capabilities": _workflow_required_capabilities(workflow),
+            "hash": _device_deployment_hash(workflow),
+        },
+        "status": remote_status,
+        "runtime": runtime_manifest,
+        "checks": checks,
+        "checked_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+    }
+
+
+def _runtime_client_or_404(device_id: str):
+    try:
+        return _device_registry.runtime_client(device_id)
+    except KeyError as exc:
+        raise HTTPException(404, "Device not found") from exc
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+
+
+def _require_device_safe_to_start(device_id: str) -> None:
+    try:
+        status = _paired_device_client(device_id).status()
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+    if not status.get("connected"):
+        raise HTTPException(
+            409,
+            str(status.get("error") or "Hardware is not connected."),
+        )
+    if status.get("armed"):
+        raise HTTPException(
+            409,
+            "Device is armed. Disarm it before starting a deployment.",
+        )
+
+
+@app.get("/devices/{device_id}/deployments")
+def list_device_deployments(device_id: str):
+    try:
+        return _runtime_client_or_404(device_id).list_deployments()
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.post("/devices/{device_id}/deployments")
+def stage_device_deployment(device_id: str, req: RemoteDeployReq):
+    workflow = _device_deployment_workflow()
+    current_hash = _device_deployment_hash(workflow)
+    requested_hash = req.workflow_hash.strip().lower()
+    if not requested_hash or requested_hash != current_hash:
+        raise HTTPException(
+            409,
+            "The graph changed after validation. Validate deployment again before staging.",
+        )
+
+    preflight = validate_device_deployment(
+        device_id,
+        DeploymentPreflightReq(workflow=workflow),
+    )
+    if not preflight.get("ready"):
+        blocking = [
+            str(check.get("message") or check.get("label") or "deployment is not ready")
+            for check in preflight.get("checks", [])
+            if check.get("blocking") and check.get("status") != "pass"
+        ]
+        raise HTTPException(
+            409,
+            "Deployment preflight failed: " + "; ".join(blocking[:3]),
+        )
+
+    try:
+        workflow["entrypoint"] = resolve_entrypoint(workflow)
+        script = export_workflow_python(workflow)
+    except (WorkflowRunError, ValueError) as exc:
+        raise HTTPException(400, f"Could not export workflow: {exc}") from exc
+
+    name = req.name.strip() or str(workflow.get("name") or "Deployed graph")
+    runtime_manifest = preflight.get("runtime") or {}
+    payload: dict[str, Any] = {
+        "name": name,
+        "script": script,
+        "manifest": {
+            "schema_version": 1,
+            "workflow_hash": current_hash,
+            "workflow_name": str(workflow.get("name") or name),
+            "entrypoint": dict(workflow["entrypoint"]),
+            "node_count": len(workflow.get("node_meta") or {}),
+            "required_capabilities": _workflow_required_capabilities(workflow),
+            "required_packages": _workflow_target_packages(workflow),
+            "package_requirements": _workflow_target_package_specs(workflow),
+            "blacknode_version": str(getattr(bn, "__version__", "")),
+            "runtime_protocol_version": runtime_manifest.get("protocol_version"),
+            "created_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        },
+    }
+    if req.deployment_id:
+        payload["deployment_id"] = req.deployment_id
+    try:
+        client = _runtime_client_or_404(device_id)
+        package_specs = _workflow_target_package_specs(workflow)
+        if package_specs:
+            client.sync_packages(package_specs)
+            synced_manifest = client.manifest()
+            synced_packages = {
+                str(item.get("name")): str(item.get("version") or "")
+                for item in (synced_manifest.get("packages") or [])
+                if isinstance(item, dict) and item.get("name")
+            }
+            missing_after_sync = sorted(
+                set(_workflow_target_packages(workflow)) - set(synced_packages)
+            )
+            outdated_after_sync = sorted({
+                item["name"]
+                for item in package_specs
+                if (
+                    item.get("version")
+                    and synced_packages.get(item["name"]) != item["version"]
+                )
+            })
+            synced_node_types = {
+                str(item)
+                for item in (synced_manifest.get("node_types") or [])
+                if isinstance(item, str)
+            }
+            missing_nodes_after_sync = sorted(
+                workflow_node_types(workflow) - synced_node_types
+            )
+            if missing_after_sync or outdated_after_sync or missing_nodes_after_sync:
+                details = []
+                if missing_after_sync:
+                    details.append("packages: " + ", ".join(missing_after_sync))
+                if outdated_after_sync:
+                    details.append(
+                        "package versions: " + ", ".join(outdated_after_sync)
+                    )
+                if missing_nodes_after_sync:
+                    details.append("nodes: " + ", ".join(missing_nodes_after_sync))
+                raise HTTPException(
+                    409,
+                    "Target package synchronization did not provide " + "; ".join(details),
+                )
+        deployment = client.stage_deployment(payload)
+        if req.start:
+            _require_device_safe_to_start(device_id)
+            deployment = client.start_deployment(str(deployment["id"]))
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+    return {
+        "deployment": deployment,
+        "workflow_hash": current_hash,
+        "started": bool(req.start),
+    }
+
+
+@app.get("/devices/{device_id}/deployments/{deployment_id}")
+def get_device_deployment(device_id: str, deployment_id: str):
+    try:
+        return _runtime_client_or_404(device_id).get_deployment(deployment_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.post("/devices/{device_id}/deployments/{deployment_id}/start")
+def start_device_deployment(device_id: str, deployment_id: str):
+    _require_device_safe_to_start(device_id)
+    try:
+        return _runtime_client_or_404(device_id).start_deployment(deployment_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.post("/devices/{device_id}/deployments/{deployment_id}/stop")
+def stop_device_deployment(device_id: str, deployment_id: str):
+    try:
+        return _runtime_client_or_404(device_id).stop_deployment(deployment_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.post("/devices/{device_id}/deployments/{deployment_id}/rollback")
+def rollback_device_deployment(
+    device_id: str,
+    deployment_id: str,
+    req: RemoteRollbackReq,
+):
+    if req.start:
+        _require_device_safe_to_start(device_id)
+    try:
+        return _runtime_client_or_404(device_id).rollback_deployment(
+            deployment_id,
+            start=req.start,
+        )
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.get("/devices/{device_id}/deployments/{deployment_id}/logs")
+def get_device_deployment_logs(
+    device_id: str,
+    deployment_id: str,
+    limit: int = 20000,
+):
+    try:
+        return _runtime_client_or_404(device_id).deployment_logs(
+            deployment_id,
+            limit=limit,
+        )
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.delete("/devices/{device_id}/deployments/{deployment_id}")
+def delete_device_deployment(device_id: str, deployment_id: str):
+    try:
+        return _runtime_client_or_404(device_id).delete_deployment(deployment_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.post("/devices/{device_id}/rpc")
+def call_device_rpc(device_id: str, req: DeviceRpcReq):
+    method = req.method.strip()
+    if not method:
+        raise HTTPException(400, "RPC method is required")
+    payload = {
+        "jsonrpc": "2.0",
+        "id": req.id,
+        "method": method,
+        "params": req.params,
+    }
+    try:
+        return _paired_device_client(device_id).rpc(payload)
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.delete("/devices/{device_id}")
+def delete_device(device_id: str):
+    try:
+        deleted = _device_registry.delete(device_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    if not deleted:
+        raise HTTPException(404, "Device not found")
+    return {"ok": True, "id": device_id}
 
 
 @app.get("/deployments")

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -91,6 +91,56 @@ export interface ApiKeyStatus {
   env_var: string
 }
 
+export interface HardwareDevice {
+  id: string
+  name: string
+  base_url: string
+  runtime_url: string
+  remote_device_id: string
+  token_fingerprint: string
+  created_at: string
+  updated_at: string
+}
+
+export interface HardwareDeviceStatus {
+  device_id: string
+  connected: boolean
+  armed: boolean
+  calibrated?: boolean
+  capabilities: string[]
+  joint_names?: string[]
+  positions?: Record<string, number>
+  raw_positions?: Record<string, number>
+  error?: string
+  updated_at?: number
+}
+
+export type DeploymentPreflightStatus = 'pass' | 'fail' | 'warning' | 'pending'
+
+export interface DeploymentPreflightCheck {
+  id: string
+  label: string
+  status: DeploymentPreflightStatus
+  message: string
+  blocking: boolean
+}
+
+export interface DeploymentPreflight {
+  ready: boolean
+  summary: string
+  device: HardwareDevice
+  workflow: {
+    name: string
+    node_count: number
+    required_capabilities: string[]
+    hash: string
+  }
+  status: HardwareDeviceStatus | null
+  runtime: Record<string, unknown> | null
+  checks: DeploymentPreflightCheck[]
+  checked_at: string
+}
+
 export type RunStatus = 'success' | 'error' | 'running'
 
 export interface RunSummary {
@@ -129,6 +179,22 @@ export interface Deployment {
   pid: number | null
   exit_code: number | null
   error: string
+}
+
+export type RemoteDeploymentState = 'staged' | 'running' | 'stopped' | 'exited' | 'failed'
+
+export interface RemoteDeployment {
+  id: string
+  name: string
+  state: RemoteDeploymentState
+  staged_revision: string
+  active_revision: string | null
+  revisions: string[]
+  pid: number | null
+  exit_code: number | null
+  error: string
+  created_at: string
+  updated_at: string
 }
 
 export interface WorkflowSnapshot {
@@ -501,6 +567,99 @@ export const api = {
   getApiKeyStatus:  () => req<Record<string, ApiKeyStatus>>('GET', '/settings/api-key-status'),
   setApiKey:        (provider: string, key: string) =>
     req<{ ok: boolean; restarted?: string | null; credential?: ApiKeyStatus }>('POST', '/settings/api-key', { provider, key }),
+  listDevices:      () => req<{ devices: HardwareDevice[] }>('GET', '/devices'),
+  pairDevice:       (name: string, baseUrl: string, token: string) =>
+    req<{ device: HardwareDevice; status: HardwareDeviceStatus }>(
+      'POST',
+      '/devices',
+      { name, base_url: baseUrl, token },
+      10000,
+    ),
+  deviceStatus:     (id: string) =>
+    req<HardwareDeviceStatus>('GET', `/devices/${encodeURIComponent(id)}/status`, undefined, 7000),
+  deviceCapabilities: (id: string) =>
+    req<{ device_id: string; connected: boolean; capabilities: string[] }>(
+      'GET',
+      `/devices/${encodeURIComponent(id)}/capabilities`,
+      undefined,
+      7000,
+    ),
+  validateDeviceDeployment: (id: string) =>
+    req<DeploymentPreflight>(
+      'POST',
+      `/devices/${encodeURIComponent(id)}/deployment-preflight`,
+      {},
+      10000,
+    ),
+  listRemoteDeployments: (deviceId: string) =>
+    req<{ deployments: RemoteDeployment[] }>(
+      'GET',
+      `/devices/${encodeURIComponent(deviceId)}/deployments`,
+      undefined,
+      10000,
+    ),
+  stageRemoteDeployment: (
+    deviceId: string,
+    name: string,
+    workflowHash: string,
+    start = false,
+    deploymentId?: string,
+  ) =>
+    req<{ deployment: RemoteDeployment; workflow_hash: string; started: boolean }>(
+      'POST',
+      `/devices/${encodeURIComponent(deviceId)}/deployments`,
+      {
+        name,
+        workflow_hash: workflowHash,
+        start,
+        deployment_id: deploymentId ?? null,
+      },
+      600000,
+    ),
+  startRemoteDeployment: (deviceId: string, deploymentId: string) =>
+    req<RemoteDeployment>(
+      'POST',
+      `/devices/${encodeURIComponent(deviceId)}/deployments/${encodeURIComponent(deploymentId)}/start`,
+      {},
+      15000,
+    ),
+  stopRemoteDeployment: (deviceId: string, deploymentId: string) =>
+    req<RemoteDeployment>(
+      'POST',
+      `/devices/${encodeURIComponent(deviceId)}/deployments/${encodeURIComponent(deploymentId)}/stop`,
+      {},
+      15000,
+    ),
+  rollbackRemoteDeployment: (deviceId: string, deploymentId: string, start = false) =>
+    req<RemoteDeployment>(
+      'POST',
+      `/devices/${encodeURIComponent(deviceId)}/deployments/${encodeURIComponent(deploymentId)}/rollback`,
+      { start },
+      15000,
+    ),
+  remoteDeploymentLogs: (deviceId: string, deploymentId: string) =>
+    req<{ id: string; logs: string }>(
+      'GET',
+      `/devices/${encodeURIComponent(deviceId)}/deployments/${encodeURIComponent(deploymentId)}/logs`,
+      undefined,
+      10000,
+    ),
+  deleteRemoteDeployment: (deviceId: string, deploymentId: string) =>
+    req<{ ok: boolean; id: string }>(
+      'DELETE',
+      `/devices/${encodeURIComponent(deviceId)}/deployments/${encodeURIComponent(deploymentId)}`,
+      undefined,
+      15000,
+    ),
+  deviceRpc: (id: string, method: string, params: Record<string, unknown> = {}, requestId: string | number | null = null) =>
+    req<Record<string, unknown>>(
+      'POST',
+      `/devices/${encodeURIComponent(id)}/rpc`,
+      { jsonrpc: '2.0', id: requestId, method, params },
+      10000,
+    ),
+  deleteDevice:     (id: string) =>
+    req<{ ok: boolean; id: string }>('DELETE', `/devices/${encodeURIComponent(id)}`),
   getOnboarding:    () => req<{ package_welcome_seen: boolean }>('GET', '/settings/onboarding'),
   setOnboarding:    (packageWelcomeSeen: boolean) =>
     req<{ ok: boolean; package_welcome_seen: boolean }>('POST', '/settings/onboarding', { package_welcome_seen: packageWelcomeSeen }),

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useState, type CSSProperties } from 'react'
-import { api, type Deployment, type DeploymentState } from '../api'
+import {
+  api,
+  type Deployment,
+  type DeploymentPreflight,
+  type DeploymentPreflightStatus,
+  type DeploymentState,
+  type HardwareDevice,
+  type RemoteDeployment,
+  type RemoteDeploymentState,
+} from '../api'
 import { useStore } from '../store'
 
 const REFRESH_INTERVAL_MS = 3000
@@ -18,19 +27,40 @@ const STATE_LABEL: Record<DeploymentState, string> = {
   failed: 'FAIL',
 }
 
+const REMOTE_STATE_COLOR: Record<RemoteDeploymentState, string> = {
+  staged: 'var(--accent)',
+  running: 'var(--ok)',
+  stopped: 'var(--tx3)',
+  exited: 'var(--tx2)',
+  failed: 'var(--err)',
+}
+
+const REMOTE_STATE_LABEL: Record<RemoteDeploymentState, string> = {
+  staged: 'STAGED',
+  running: 'LIVE',
+  stopped: 'OFF',
+  exited: 'DONE',
+  failed: 'FAIL',
+}
+
 export default function DeploymentsPanel() {
   const [deployments, setDeployments] = useState<Deployment[]>([])
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [openId, setOpenId] = useState<string | null>(null)
   const [logs, setLogs] = useState<Record<string, string>>({})
+  const [devices, setDevices] = useState<HardwareDevice[]>([])
+  const [selectedDeviceId, setSelectedDeviceId] = useState('')
+  const [preflight, setPreflight] = useState<DeploymentPreflight | null>(null)
+  const [remoteDeployments, setRemoteDeployments] = useState<RemoteDeployment[]>([])
+  const [remoteOpenId, setRemoteOpenId] = useState<string | null>(null)
+  const [remoteLogs, setRemoteLogs] = useState<Record<string, string>>({})
   const stopRuntimeServices = useStore(s => s.stopRuntimeServices)
 
   const refresh = async () => {
     try {
       const result = await api.listDeployments()
       setDeployments(result.deployments)
-      setError(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     }
@@ -40,6 +70,38 @@ export default function DeploymentsPanel() {
     refresh()
     const id = window.setInterval(refresh, REFRESH_INTERVAL_MS)
     return () => window.clearInterval(id)
+  }, [])
+
+  useEffect(() => {
+    if (!selectedDeviceId) {
+      setRemoteDeployments([])
+      return
+    }
+    let cancelled = false
+    const pull = async () => {
+      try {
+        const result = await api.listRemoteDeployments(selectedDeviceId)
+        if (!cancelled) setRemoteDeployments(result.deployments)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      }
+    }
+    pull()
+    const id = window.setInterval(pull, REFRESH_INTERVAL_MS)
+    return () => { cancelled = true; window.clearInterval(id) }
+  }, [selectedDeviceId])
+
+  useEffect(() => {
+    api.listDevices()
+      .then(result => {
+        setDevices(result.devices)
+        setSelectedDeviceId(current => (
+          current && result.devices.some(device => device.id === current)
+            ? current
+            : result.devices[0]?.id ?? ''
+        ))
+      })
+      .catch(err => setError(err instanceof Error ? err.message : String(err)))
   }, [])
 
   // Only the open row's log is fetched, and only while it is open, so a long
@@ -59,6 +121,24 @@ export default function DeploymentsPanel() {
     const id = window.setInterval(pull, REFRESH_INTERVAL_MS)
     return () => { cancelled = true; window.clearInterval(id) }
   }, [openId])
+
+  useEffect(() => {
+    if (!selectedDeviceId || !remoteOpenId) return
+    let cancelled = false
+    const pull = async () => {
+      try {
+        const result = await api.remoteDeploymentLogs(selectedDeviceId, remoteOpenId)
+        if (!cancelled) {
+          setRemoteLogs(prev => ({ ...prev, [remoteOpenId]: result.logs }))
+        }
+      } catch {
+        /* deployment state remains visible when a log tail is temporarily unavailable */
+      }
+    }
+    pull()
+    const id = window.setInterval(pull, REFRESH_INTERVAL_MS)
+    return () => { cancelled = true; window.clearInterval(id) }
+  }, [selectedDeviceId, remoteOpenId])
 
   const act = async (fn: () => Promise<unknown>) => {
     setBusy(true)
@@ -107,7 +187,71 @@ export default function DeploymentsPanel() {
     setOpenId(prev => (prev === deployment.id ? null : prev))
   }
 
+  const validateRemoteDeployment = async () => {
+    if (!selectedDeviceId) return
+    setBusy(true)
+    setError(null)
+    setPreflight(null)
+    try {
+      setPreflight(await api.validateDeviceDeployment(selectedDeviceId))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const refreshRemote = async () => {
+    if (!selectedDeviceId) return
+    const result = await api.listRemoteDeployments(selectedDeviceId)
+    setRemoteDeployments(result.deployments)
+  }
+
+  const actRemote = async (fn: () => Promise<unknown>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await fn()
+      await refreshRemote()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const stageRemote = async (
+    start: boolean,
+    existing?: RemoteDeployment,
+  ) => {
+    if (!selectedDeviceId || !preflight?.ready) return
+    let name = existing?.name
+    if (!name) {
+      const entered = window.prompt('Name this remote deployment', preflight.workflow.name)
+      if (entered === null) return
+      name = entered.trim() || preflight.workflow.name || 'Deployed graph'
+    }
+    await actRemote(async () => {
+      const result = await api.stageRemoteDeployment(
+        selectedDeviceId,
+        name!,
+        preflight.workflow.hash,
+        start,
+        existing?.id,
+      )
+      setRemoteOpenId(result.deployment.id)
+    })
+  }
+
+  const deleteRemote = async (deployment: RemoteDeployment) => {
+    if (!selectedDeviceId) return
+    if (!window.confirm(`Delete remote deployment "${deployment.name}"?`)) return
+    await actRemote(() => api.deleteRemoteDeployment(selectedDeviceId, deployment.id))
+    setRemoteOpenId(current => current === deployment.id ? null : current)
+  }
+
   const running = deployments.filter(d => d.state === 'running').length
+  const remoteRunning = remoteDeployments.filter(d => d.state === 'running').length
 
   return (
     <div className="bn-runs-panel">
@@ -120,13 +264,113 @@ export default function DeploymentsPanel() {
         </div>
         <div className="bn-runs-actions">
           <button onClick={refresh} style={miniButton}>Refresh</button>
-          <button onClick={() => handleDeploy(false)} disabled={busy} style={miniButton} title="Save the runnable script without running it">Save only</button>
-          <button onClick={() => handleDeploy(true)} disabled={busy} style={primaryButton} title="Stop the live graph, then run it as a deployment">Deploy &amp; run</button>
+          <button onClick={() => handleDeploy(false)} disabled={busy} style={miniButton} title="Save the runnable script on this computer without running it">Save local</button>
+          <button onClick={() => handleDeploy(true)} disabled={busy} style={primaryButton} title="Stop the live graph, then run it on this computer">Run local</button>
         </div>
       </div>
 
+      <div className="bn-deploy-target">
+        <div className="bn-deploy-target-head">
+          <div>
+            <div className="bn-deploy-target-title">Remote target</div>
+            <div className="bn-runs-subtitle">Validate, stage, and control the selected device</div>
+          </div>
+          <div className="bn-runs-actions">
+            <button
+              onClick={validateRemoteDeployment}
+              disabled={busy || !selectedDeviceId}
+              style={preflight?.ready ? miniButton : primaryButton}
+            >
+              Validate
+            </button>
+            {preflight?.ready && (
+              <>
+                <button onClick={() => stageRemote(false)} disabled={busy} style={miniButton}>
+                  Stage
+                </button>
+                <button onClick={() => stageRemote(true)} disabled={busy} style={primaryButton}>
+                  Stage & run
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+        {devices.length > 0 ? (
+          <select
+            className="bn-deploy-device-select"
+            value={selectedDeviceId}
+            onChange={event => {
+              setSelectedDeviceId(event.target.value)
+              setPreflight(null)
+            }}
+          >
+            {devices.map(device => (
+              <option key={device.id} value={device.id}>
+                {device.name} · {device.base_url}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <div className="bn-device-help">Pair a Raspberry Pi in the Devices tab first.</div>
+        )}
+      </div>
+
+      {preflight && <PreflightResult result={preflight} />}
+
       {error && <div className="bn-runs-error">{error}</div>}
 
+      <div className="bn-deployment-section-head">
+        <div>
+          <strong>Remote deployments</strong>
+          <span>{remoteDeployments.length} total · {remoteRunning} running</span>
+        </div>
+        <button onClick={() => actRemote(refreshRemote)} disabled={busy || !selectedDeviceId} style={miniButton}>
+          Refresh
+        </button>
+      </div>
+      <div className="bn-runs-list">
+        {selectedDeviceId && remoteDeployments.length === 0 && (
+          <div className="bn-runs-empty">
+            No deployment is staged on this device. Validate the graph, then choose
+            <strong> Stage</strong> or <strong>Stage &amp; run</strong>.
+          </div>
+        )}
+        {remoteDeployments.map(deployment => (
+          <RemoteDeploymentRow
+            key={deployment.id}
+            deployment={deployment}
+            busy={busy}
+            canStage={Boolean(preflight?.ready)}
+            expanded={remoteOpenId === deployment.id}
+            log={remoteLogs[deployment.id] ?? ''}
+            onToggle={() => setRemoteOpenId(current => (
+              current === deployment.id ? null : deployment.id
+            ))}
+            onStage={() => stageRemote(false, deployment)}
+            onStart={() => actRemote(() => (
+              api.startRemoteDeployment(selectedDeviceId, deployment.id)
+            ))}
+            onStop={() => actRemote(() => (
+              api.stopRemoteDeployment(selectedDeviceId, deployment.id)
+            ))}
+            onRollback={() => {
+              if (!window.confirm(`Roll back "${deployment.name}" to its previous revision?`)) return
+              actRemote(() => api.rollbackRemoteDeployment(
+                selectedDeviceId,
+                deployment.id,
+              ))
+            }}
+            onDelete={() => deleteRemote(deployment)}
+          />
+        ))}
+      </div>
+
+      <div className="bn-deployment-section-head">
+        <div>
+          <strong>Local deployments</strong>
+          <span>Run by this editor computer</span>
+        </div>
+      </div>
       <div className="bn-runs-list">
         {deployments.length === 0 && !error && (
           <div className="bn-runs-empty">
@@ -149,6 +393,128 @@ export default function DeploymentsPanel() {
           />
         ))}
       </div>
+    </div>
+  )
+}
+
+const PREFLIGHT_LABEL: Record<DeploymentPreflightStatus, string> = {
+  pass: 'PASS',
+  fail: 'FAIL',
+  warning: 'WARN',
+  pending: 'WAIT',
+}
+
+function PreflightResult({ result }: { result: DeploymentPreflight }) {
+  return (
+    <div className="bn-preflight">
+      <div className={`bn-preflight-summary ${result.ready ? 'is-ready' : 'is-blocked'}`}>
+        <strong>{result.ready ? 'Ready' : 'Not ready'}</strong>
+        <span>{result.summary}</span>
+      </div>
+      <div className="bn-preflight-checks">
+        {result.checks.map(check => (
+          <div className="bn-preflight-check" key={check.id}>
+            <span className={`bn-preflight-pill is-${check.status}`}>
+              {PREFLIGHT_LABEL[check.status]}
+            </span>
+            <div>
+              <strong>{check.label}</strong>
+              <span>{check.message}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function RemoteDeploymentRow({
+  deployment,
+  busy,
+  canStage,
+  expanded,
+  log,
+  onToggle,
+  onStage,
+  onStart,
+  onStop,
+  onRollback,
+  onDelete,
+}: {
+  deployment: RemoteDeployment
+  busy: boolean
+  canStage: boolean
+  expanded: boolean
+  log: string
+  onToggle: () => void
+  onStage: () => void
+  onStart: () => void
+  onStop: () => void
+  onRollback: () => void
+  onDelete: () => void
+}) {
+  const isRunning = deployment.state === 'running'
+  const canRollback = deployment.revisions.length > 1
+  const badges = [
+    `${deployment.revisions.length} revision${deployment.revisions.length === 1 ? '' : 's'}`,
+    `staged ${deployment.staged_revision}`,
+    deployment.active_revision ? `active ${deployment.active_revision}` : null,
+    deployment.pid ? `pid ${deployment.pid}` : null,
+  ].filter(Boolean) as string[]
+
+  return (
+    <div
+      className={`bn-run-row${expanded ? ' is-expanded' : ''}`}
+      style={{ '--run-status': REMOTE_STATE_COLOR[deployment.state] } as CSSProperties}
+    >
+      <button onClick={onToggle} className="bn-run-summary" type="button" aria-expanded={expanded}>
+        <div className="bn-run-timeline-mark"><span /></div>
+        <div className="bn-run-main">
+          <div className="bn-run-line">
+            <span className="bn-run-title" title={deployment.name}>{deployment.name}</span>
+            <span className="bn-run-age">{formatTime(deployment.updated_at)}</span>
+          </div>
+          <div className="bn-run-node" title={deployment.id}>{deployment.id}</div>
+          <div className="bn-run-badges">
+            {badges.map(badge => <span key={badge}>{badge}</span>)}
+          </div>
+          {deployment.error && <div className="bn-run-error-line">{deployment.error}</div>}
+        </div>
+        <div className="bn-run-status">
+          <span className="bn-run-status-pill">{REMOTE_STATE_LABEL[deployment.state]}</span>
+          <span>{describeRemoteState(deployment)}</span>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="bn-run-detail">
+          <pre style={logStyle}>{log.trim() || 'No remote output captured yet.'}</pre>
+          <div className="bn-run-detail-actions">
+            {isRunning
+              ? <button onClick={onStop} disabled={busy} style={miniButton}>Stop</button>
+              : <button onClick={onStart} disabled={busy} style={primaryButton}>Run</button>}
+            <button
+              onClick={onStage}
+              disabled={busy || !canStage || isRunning}
+              style={miniButton}
+              title={canStage ? 'Stage the validated graph as a new revision' : 'Validate the graph first'}
+            >
+              Stage update
+            </button>
+            <button
+              onClick={onRollback}
+              disabled={busy || !canRollback}
+              style={miniButton}
+              title={canRollback ? 'Stage the previous revision' : 'No previous revision exists'}
+            >
+              Rollback
+            </button>
+            <button onClick={onDelete} disabled={busy || isRunning} style={miniButton}>
+              Delete
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -217,6 +583,21 @@ function DeploymentRow({ deployment, busy, expanded, log, onToggle, onStart, onS
       )}
     </div>
   )
+}
+
+function describeRemoteState(deployment: RemoteDeployment): string {
+  switch (deployment.state) {
+    case 'staged':
+      return 'Ready to run'
+    case 'running':
+      return 'Running on device'
+    case 'stopped':
+      return 'Stopped'
+    case 'exited':
+      return deployment.exit_code == null ? 'Finished' : `Finished (exit ${deployment.exit_code})`
+    case 'failed':
+      return deployment.exit_code == null ? 'Failed' : `Failed (exit ${deployment.exit_code})`
+  }
 }
 
 function describeState(deployment: Deployment): string {

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useState, type CSSProperties, type FormEvent } from 'react'
+import { api, type HardwareDevice, type HardwareDeviceStatus } from '../api'
+
+type DeviceState = {
+  status?: HardwareDeviceStatus
+  error?: string
+  loading?: boolean
+}
+
+export default function DevicesPanel() {
+  const [devices, setDevices] = useState<HardwareDevice[]>([])
+  const [states, setStates] = useState<Record<string, DeviceState>>({})
+  const [showForm, setShowForm] = useState(false)
+  const [name, setName] = useState('')
+  const [baseUrl, setBaseUrl] = useState('http://192.168.1.87:8765')
+  const [token, setToken] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const refreshStatus = async (device: HardwareDevice) => {
+    setStates(prev => ({ ...prev, [device.id]: { ...prev[device.id], loading: true } }))
+    try {
+      const status = await api.deviceStatus(device.id)
+      setStates(prev => ({ ...prev, [device.id]: { status, loading: false } }))
+    } catch (err) {
+      setStates(prev => ({
+        ...prev,
+        [device.id]: {
+          error: err instanceof Error ? err.message : String(err),
+          loading: false,
+        },
+      }))
+    }
+  }
+
+  const refresh = async () => {
+    setError(null)
+    try {
+      const result = await api.listDevices()
+      setDevices(result.devices)
+      await Promise.all(result.devices.map(refreshStatus))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  useEffect(() => { refresh() }, [])
+
+  const openPairForm = (device?: HardwareDevice) => {
+    setName(device?.name ?? '')
+    setBaseUrl(device?.base_url ?? 'http://192.168.1.87:8765')
+    setToken('')
+    setError(null)
+    setShowForm(true)
+  }
+
+  const pair = async (event: FormEvent) => {
+    event.preventDefault()
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await api.pairDevice(name.trim(), baseUrl.trim(), token.trim())
+      setShowForm(false)
+      setToken('')
+      await refresh()
+      setStates(prev => ({
+        ...prev,
+        [result.device.id]: { status: result.status, loading: false },
+      }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const remove = async (device: HardwareDevice) => {
+    if (!window.confirm(`Remove "${device.name}" from this Blacknode editor?`)) return
+    setBusy(true)
+    setError(null)
+    try {
+      await api.deleteDevice(device.id)
+      setDevices(prev => prev.filter(item => item.id !== device.id))
+      setStates(prev => {
+        const next = { ...prev }
+        delete next[device.id]
+        return next
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="bn-runs-panel">
+      <div className="bn-runs-toolbar">
+        <div>
+          <div className="bn-runs-title">Devices</div>
+          <div className="bn-runs-subtitle">{devices.length} paired</div>
+        </div>
+        <div className="bn-runs-actions">
+          <button onClick={refresh} disabled={busy} style={miniButton}>Refresh</button>
+          <button onClick={() => openPairForm()} disabled={busy} style={primaryButton}>Pair device</button>
+        </div>
+      </div>
+
+      {showForm && (
+        <form className="bn-device-form" onSubmit={pair}>
+          <div className="bn-device-form-title">Pair hardware service</div>
+          <div className="bn-device-help">
+            On the Raspberry Pi, run <code>./pair.sh</code>, then paste its token here.
+          </div>
+          <label>
+            <span>Name</span>
+            <input
+              value={name}
+              onChange={event => setName(event.target.value)}
+              placeholder="Workshop robot"
+              autoComplete="off"
+            />
+          </label>
+          <label>
+            <span>Device URL</span>
+            <input
+              value={baseUrl}
+              onChange={event => setBaseUrl(event.target.value)}
+              placeholder="http://192.168.1.87:8765"
+              required
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+          </label>
+          <label>
+            <span>Pairing token</span>
+            <input
+              value={token}
+              onChange={event => setToken(event.target.value)}
+              type="password"
+              placeholder="Paste token from pair.sh"
+              required
+              autoComplete="new-password"
+            />
+          </label>
+          <div className="bn-device-form-actions">
+            <button type="button" onClick={() => { setShowForm(false); setToken('') }} style={miniButton}>
+              Cancel
+            </button>
+            <button type="submit" disabled={busy} style={primaryButton}>
+              {busy ? 'Checking…' : 'Pair and verify'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {error && <div className="bn-runs-error">{error}</div>}
+
+      <div className="bn-runs-list">
+        {devices.length === 0 && !showForm && !error && (
+          <div className="bn-runs-empty">
+            No hardware device is paired. Run <strong>./pair.sh</strong> on the device,
+            then add its network address and token here.
+          </div>
+        )}
+        {devices.map(device => (
+          <DeviceRow
+            key={device.id}
+            device={device}
+            state={states[device.id]}
+            busy={busy}
+            onRefresh={() => refreshStatus(device)}
+            onRepair={() => openPairForm(device)}
+            onRemove={() => remove(device)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DeviceRow({ device, state, busy, onRefresh, onRepair, onRemove }: {
+  device: HardwareDevice
+  state?: DeviceState
+  busy: boolean
+  onRefresh: () => void
+  onRepair: () => void
+  onRemove: () => void
+}) {
+  const status = state?.status
+  const online = Boolean(status)
+  const connected = Boolean(status?.connected)
+  const color = online ? (connected ? 'var(--ok)' : 'var(--warn)') : 'var(--err)'
+  const label = state?.loading ? 'CHECK' : online ? (connected ? 'READY' : 'ONLINE') : 'OFF'
+
+  return (
+    <div className="bn-run-row is-expanded" style={{ '--run-status': color } as CSSProperties}>
+      <div className="bn-device-summary">
+        <div className="bn-run-timeline-mark"><span /></div>
+        <div className="bn-run-main">
+          <div className="bn-run-line">
+            <span className="bn-run-title">{device.name}</span>
+          </div>
+          <div className="bn-run-node" title={device.base_url}>{device.base_url}</div>
+          <div className="bn-run-node" title={device.runtime_url}>runtime {device.runtime_url}</div>
+          <div className="bn-run-badges">
+            <span>{device.remote_device_id}</span>
+            <span>token {device.token_fingerprint}</span>
+            {status?.joint_names && <span>{status.joint_names.length} joints</span>}
+          </div>
+          {state?.error && <div className="bn-run-error-line">{state.error}</div>}
+          {status?.error && <div className="bn-run-error-line">{status.error}</div>}
+        </div>
+        <div className="bn-run-status">
+          <span className="bn-run-status-pill">{label}</span>
+          <span>{state?.loading ? 'Checking…' : online ? (connected ? 'Hardware connected' : 'Service connected') : 'Unavailable'}</span>
+        </div>
+      </div>
+      <div className="bn-run-detail">
+        <div className="bn-device-facts">
+          <DeviceFact label="Armed" value={status ? (status.armed ? 'Yes' : 'No') : '—'} warn={Boolean(status?.armed)} />
+          <DeviceFact label="Calibrated" value={status?.calibrated == null ? '—' : status.calibrated ? 'Yes' : 'No'} />
+          <DeviceFact label="Capabilities" value={status?.capabilities?.join(', ') || '—'} />
+        </div>
+        <div className="bn-run-detail-actions">
+          <button onClick={onRefresh} disabled={busy || state?.loading} style={miniButton}>Check</button>
+          <button onClick={onRepair} disabled={busy} style={miniButton}>Re-pair</button>
+          <button onClick={onRemove} disabled={busy} style={dangerButton}>Remove</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DeviceFact({ label, value, warn = false }: { label: string; value: string; warn?: boolean }) {
+  return (
+    <div className="bn-device-fact">
+      <span>{label}</span>
+      <strong style={warn ? { color: 'var(--warn)' } : undefined}>{value}</strong>
+    </div>
+  )
+}
+
+const miniButton: CSSProperties = {
+  background: 'transparent',
+  border: '1px solid var(--line2)',
+  color: 'var(--tx2)',
+  padding: '3px 8px',
+  fontSize: 10,
+  fontFamily: 'var(--font-ui)',
+  borderRadius: 4,
+  cursor: 'pointer',
+}
+
+const primaryButton: CSSProperties = {
+  ...miniButton,
+  borderColor: 'var(--ok)',
+  color: 'var(--ok)',
+}
+
+const dangerButton: CSSProperties = {
+  ...miniButton,
+  borderColor: 'var(--err)',
+  color: 'var(--err)',
+}

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -10,6 +10,7 @@ import LearnedNodesPanel from './LearnedNodesPanel'
 import PackagesPanel from './PackagesPanel'
 import RunsPanel from './RunsPanel'
 import DeploymentsPanel from './DeploymentsPanel'
+import DevicesPanel from './DevicesPanel'
 import RuntimePanel from './RuntimePanel'
 import ConsolePanel from './ConsolePanel'
 import ScriptEditor from './ScriptEditor'
@@ -24,7 +25,7 @@ const CATEGORY_ORDER = Object.keys(CATEGORIES)
 interface PaletteSubGroup { name: string; color: string; types: string[] }
 interface PaletteGroup { name: string; color: string; subgroups: PaletteSubGroup[]; count: number }
 
-type Tab = 'nodes' | 'templates' | 'workflows' | 'script' | 'runs' | 'runtime' | 'console' | 'deployments' | 'learned' | 'mcp' | 'packages'
+type Tab = 'nodes' | 'templates' | 'workflows' | 'script' | 'runs' | 'runtime' | 'console' | 'deployments' | 'devices' | 'learned' | 'mcp' | 'packages'
 
 const TOP_BAR_H = 44
 const RAIL_W = 78
@@ -114,6 +115,14 @@ const ICON_DEPLOYMENTS = (
   </svg>
 )
 
+const ICON_DEVICES = (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+    <rect x="3" y="2.5" width="12" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.3"/>
+    <path d="M6 15.5h6M9 11.5v4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+    <circle cx="12.2" cy="5.4" r="1" fill="currentColor"/>
+  </svg>
+)
+
 const ICON_CONSOLE = (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
     <rect x="2" y="3" width="14" height="12" rx="2" stroke="currentColor" strokeWidth="1.3"/>
@@ -129,6 +138,7 @@ const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
   { id: 'script',    label: 'Script',    icon: ICON_SCRIPT    },
   { id: 'runs',      label: 'Runs',      icon: ICON_RUNS      },
   { id: 'deployments', label: 'Deploy',  icon: ICON_DEPLOYMENTS },
+  { id: 'devices',   label: 'Devices',   icon: ICON_DEVICES   },
   { id: 'runtime',   label: 'Runtime',   icon: ICON_RUNTIME   },
   { id: 'console',   label: 'Console',   icon: ICON_CONSOLE   },
   { id: 'learned',   label: 'Learned',   icon: ICON_LEARNED   },
@@ -674,6 +684,8 @@ export default function NodePalette() {
             {activeTab === 'runs' && <RunsPanel />}
 
             {activeTab === 'deployments' && <DeploymentsPanel />}
+
+            {activeTab === 'devices' && <DevicesPanel />}
 
             {/* ── RUNTIME ── */}
             {activeTab === 'runtime' && <RuntimePanel />}

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -581,6 +581,262 @@ body {
   overflow-y: auto;
 }
 
+.bn-device-form {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 12px;
+  border-bottom: 1px solid var(--line);
+  background: var(--lift);
+}
+
+.bn-device-form-title {
+  color: var(--tx1);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.bn-device-help {
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.bn-device-help code {
+  color: var(--tx2);
+  font-family: var(--font-mono);
+}
+
+.bn-device-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--tx3);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.bn-device-form input {
+  width: 100%;
+  padding: 7px 8px;
+  background: var(--panel);
+  border: 1px solid var(--line2);
+  border-radius: 4px;
+  color: var(--tx1);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  outline: none;
+  text-transform: none;
+}
+
+.bn-device-form input:focus {
+  border-color: var(--ok);
+}
+
+.bn-device-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.bn-device-summary {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 8px;
+  padding: 9px 10px 9px 6px;
+  color: var(--tx2);
+}
+
+.bn-device-facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.bn-device-fact {
+  min-width: 0;
+  padding: 6px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.bn-device-fact span,
+.bn-device-fact strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bn-device-fact span {
+  color: var(--tx3);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.bn-device-fact strong {
+  margin-top: 3px;
+  color: var(--tx2);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.bn-deploy-target {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  background: var(--lift);
+}
+
+.bn-deploy-target-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.bn-deploy-target-title {
+  color: var(--tx1);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.bn-deploy-device-select {
+  width: 100%;
+  margin-top: 8px;
+  padding: 6px 7px;
+  background: var(--panel);
+  border: 1px solid var(--line2);
+  border-radius: 4px;
+  color: var(--tx1);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  outline: none;
+}
+
+.bn-deploy-device-select:focus {
+  border-color: var(--ok);
+}
+
+.bn-preflight {
+  border-bottom: 1px solid var(--line);
+  background: var(--bg);
+}
+
+.bn-preflight-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+  font-size: 10px;
+}
+
+.bn-preflight-summary strong {
+  font-size: 11px;
+}
+
+.bn-preflight-summary span {
+  color: var(--tx3);
+  font-family: var(--font-mono);
+}
+
+.bn-preflight-summary.is-ready strong {
+  color: var(--ok);
+}
+
+.bn-preflight-summary.is-blocked strong {
+  color: var(--warn);
+}
+
+.bn-preflight-checks {
+  max-height: 250px;
+  overflow-y: auto;
+}
+
+.bn-preflight-check {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 7px;
+  align-items: start;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.bn-preflight-check:last-child {
+  border-bottom: 0;
+}
+
+.bn-preflight-check strong,
+.bn-preflight-check div > span {
+  display: block;
+}
+
+.bn-preflight-check strong {
+  color: var(--tx2);
+  font-size: 10px;
+}
+
+.bn-preflight-check div > span {
+  margin-top: 2px;
+  color: var(--tx3);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.bn-preflight-pill {
+  padding: 2px 3px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 8px;
+  font-weight: 800;
+  text-align: center;
+}
+
+.bn-preflight-pill.is-pass {
+  color: var(--ok);
+}
+
+.bn-preflight-pill.is-fail {
+  color: var(--err);
+}
+
+.bn-preflight-pill.is-warning,
+.bn-preflight-pill.is-pending {
+  color: var(--warn);
+}
+
+.bn-deployment-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+}
+
+.bn-deployment-section-head strong,
+.bn-deployment-section-head span {
+  display: block;
+}
+
+.bn-deployment-section-head strong {
+  color: var(--tx1);
+  font-size: 10px;
+}
+
+.bn-deployment-section-head span {
+  margin-top: 2px;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+
 .bn-runs-empty {
   padding: 16px;
   color: var(--tx3);

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -5,6 +5,20 @@ from typing import Any, Iterable, Mapping
 
 
 _CORE_PACKAGES: dict[str, dict[str, Any]] = {
+        "blacknode-runtime": {
+            "name": "blacknode-runtime",
+            "layer": "runtime",
+            "components": {
+                "service": {
+                    "name": "service",
+                    "default": True,
+                    "node_types": []
+                }
+            },
+            "git_url": "https://github.com/temiroff/blacknode-runtime.git",
+            "description": "Authenticated remote deployment, runtime inspection, supervision, logs, and rollback.",
+            "node_types": []
+        },
         "blacknode-skills": {
             "name": "blacknode-skills",
             "layer": "skills",

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -1,0 +1,728 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+import urllib.error
+import urllib.parse
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITOR_SERVER_DIR = ROOT / "editor-server"
+
+if str(EDITOR_SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(EDITOR_SERVER_DIR))
+
+import device_registry  # noqa: E402
+import server  # noqa: E402
+
+
+class _JsonResponse:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _limit: int = -1) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class _HardwareService:
+    def __init__(
+        self,
+        token: str = "pairing-secret",
+        *,
+        status_overrides: dict | None = None,
+    ) -> None:
+        self.token = token
+        self.requests: list[tuple[str, str, str | None, dict | None]] = []
+        self.status_payload = {
+            "device_id": "alex-desktop",
+            "connected": True,
+            "armed": False,
+            "calibrated": False,
+            "joint_names": [f"servo_{index}" for index in range(1, 7)],
+            "capabilities": ["joint_group", "servo_bus", "position_feedback"],
+            **(status_overrides or {}),
+        }
+        self.runtime_deployments: dict[str, dict] = {}
+        self.runtime_packages = [
+            {"name": "blacknode-runtime", "version": "0.2.0"},
+        ]
+        self.runtime_node_types = ["Output", "OutputImage"]
+
+    def __call__(self, request, timeout=0):
+        del timeout
+        path = urllib.parse.urlsplit(request.full_url).path
+        authorization = request.get_header("Authorization")
+        body = json.loads(request.data) if request.data else None
+        self.requests.append((request.method, path, authorization, body))
+        if path == "/health":
+            return _JsonResponse({
+                "ok": True,
+                "service": "blacknode-hardware",
+                "auth_required": True,
+            })
+        if authorization != f"Bearer {self.token}":
+            raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", {}, None)
+        if path == "/status":
+            return _JsonResponse(self.status_payload)
+        if path == "/manifest":
+            return _JsonResponse({
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "runtime_version": "0.1.0",
+                "device_id": "alex-desktop",
+                "features": [
+                    "manifest_v1",
+                    "deployment_bundle_v1",
+                    "process_supervision_v1",
+                    "rollback_v1",
+                    "package_sync_v1",
+                ],
+                "python": {"version": "3.12.3"},
+                "blacknode": {"installed": True, "version": "0.3.0"},
+                "packages": self.runtime_packages,
+                "node_types": self.runtime_node_types,
+            })
+        if path == "/packages/sync":
+            installed = []
+            package_index = server.package_index_payload()["packages"]
+            for spec in body.get("packages", []):
+                name = spec["name"]
+                existing = next(
+                    (item for item in self.runtime_packages if item["name"] == name),
+                    None,
+                )
+                if existing is None:
+                    item = {
+                        "name": name,
+                        "version": spec.get("version") or "0.3.0",
+                        "source": "workspace",
+                    }
+                    self.runtime_packages.append(item)
+                    installed.append(item)
+                elif spec.get("version"):
+                    existing["version"] = spec["version"]
+                indexed = package_index.get(name) or {}
+                self.runtime_node_types = sorted(set(
+                    self.runtime_node_types + list(indexed.get("node_types") or [])
+                ))
+            return _JsonResponse({
+                "ok": True,
+                "installed": installed,
+                "already_present": [],
+                "messages": [],
+            })
+        if path == "/deployments":
+            if request.method == "GET":
+                return _JsonResponse({
+                    "deployments": list(self.runtime_deployments.values()),
+                })
+            deployment_id = str(body.get("deployment_id") or "camera-workflow-a1b2c3d4")
+            existing = self.runtime_deployments.get(deployment_id)
+            revisions = list(existing.get("revisions", [])) if existing else []
+            revision = "cafebabecafebabe"
+            if revision not in revisions:
+                revisions.append(revision)
+            record = {
+                "id": deployment_id,
+                "name": body.get("name") or "Deployment",
+                "state": "staged",
+                "staged_revision": revision,
+                "active_revision": existing.get("active_revision") if existing else None,
+                "revisions": revisions,
+                "pid": None,
+                "exit_code": None,
+                "error": "",
+                "created_at": "2026-07-23T00:00:00+00:00",
+                "updated_at": "2026-07-23T00:00:01+00:00",
+            }
+            self.runtime_deployments[deployment_id] = record
+            return _JsonResponse(record)
+        if path.startswith("/deployments/"):
+            parts = path.strip("/").split("/")
+            deployment_id = parts[1]
+            record = self.runtime_deployments.get(deployment_id)
+            if record is None:
+                raise AssertionError(f"Unknown fake deployment: {deployment_id}")
+            action = parts[2] if len(parts) > 2 else ""
+            if request.method == "GET" and action == "logs":
+                return _JsonResponse({"id": deployment_id, "logs": "remote output\n"})
+            if request.method == "GET" and not action:
+                return _JsonResponse(record)
+            if request.method == "DELETE" and not action:
+                del self.runtime_deployments[deployment_id]
+                return _JsonResponse({"ok": True, "id": deployment_id})
+            if action == "start":
+                record.update(state="running", active_revision=record["staged_revision"], pid=4321)
+            elif action == "stop":
+                record.update(state="stopped", pid=None)
+            elif action == "rollback":
+                record.update(state="staged", pid=None)
+            else:
+                raise AssertionError(f"Unexpected fake deployment action: {action}")
+            return _JsonResponse(record)
+        if path == "/capabilities":
+            return _JsonResponse({
+                "device_id": "alex-desktop",
+                "connected": True,
+                "capabilities": ["joint_group", "servo_bus", "position_feedback"],
+            })
+        if path == "/rpc":
+            return _JsonResponse({
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "result": {"ok": True},
+            })
+        raise AssertionError(f"Unexpected device path: {path}")
+
+
+class EditorDeviceApiTests(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(server.app)
+        self._tmp = tempfile.TemporaryDirectory()
+        self.registry_path = Path(self._tmp.name) / ".blacknode" / "devices.json"
+        self._original_registry = server._device_registry
+        server._device_registry = device_registry.DeviceRegistry(self.registry_path)
+
+    def tearDown(self):
+        server._device_registry = self._original_registry
+        self._tmp.cleanup()
+
+    def test_pairing_validates_and_keeps_token_out_of_api_responses(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            response = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765/",
+                "token": hardware.token,
+            })
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["device"]["id"], "alex-desktop")
+        self.assertEqual(payload["device"]["base_url"], "http://192.168.1.87:8765")
+        self.assertEqual(payload["device"]["runtime_url"], "http://192.168.1.87:8766")
+        self.assertNotIn("token", payload["device"])
+        self.assertNotIn(hardware.token, response.text)
+
+        listed = self.client.get("/devices")
+        self.assertEqual(listed.status_code, 200)
+        self.assertNotIn(hardware.token, listed.text)
+        self.assertEqual(listed.json()["devices"][0]["name"], "Workshop arm")
+
+        saved = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        self.assertEqual(saved["devices"]["alex-desktop"]["token"], hardware.token)
+        self.assertEqual(
+            [item[1] for item in hardware.requests],
+            ["/health", "/status"],
+        )
+        self.assertIsNone(hardware.requests[0][2])
+        self.assertEqual(hardware.requests[1][2], f"Bearer {hardware.token}")
+
+    def test_status_and_rpc_use_saved_token_on_fixed_device_endpoints(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            status = self.client.get(f"/devices/{paired['id']}/status")
+            rpc = self.client.post(
+                f"/devices/{paired['id']}/rpc",
+                json={"id": "stop-1", "method": "stop", "params": {}},
+            )
+
+        self.assertTrue(status.json()["connected"])
+        self.assertEqual(rpc.json()["result"], {"ok": True})
+        self.assertEqual(hardware.requests[-2][1], "/status")
+        self.assertEqual(hardware.requests[-2][2], f"Bearer {hardware.token}")
+        self.assertEqual(hardware.requests[-1][1], "/rpc")
+        self.assertEqual(hardware.requests[-1][3]["method"], "stop")
+
+    def test_repairing_same_url_replaces_token_without_duplicating_device(self):
+        first = _HardwareService("first-token")
+        with patch("device_registry.urllib.request.urlopen", side_effect=first):
+            self.client.post("/devices", json={
+                "name": "Old name",
+                "base_url": "http://192.168.1.87:8765",
+                "token": first.token,
+            })
+
+        second = _HardwareService("rotated-token")
+        with patch("device_registry.urllib.request.urlopen", side_effect=second):
+            response = self.client.post("/devices", json={
+                "name": "New name",
+                "base_url": "http://192.168.1.87:8765",
+                "token": second.token,
+            })
+
+        self.assertEqual(response.status_code, 200)
+        devices = self.client.get("/devices").json()["devices"]
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0]["name"], "New name")
+        saved = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        self.assertEqual(saved["devices"]["alex-desktop"]["token"], second.token)
+
+    def test_rejected_token_is_not_saved(self):
+        hardware = _HardwareService()
+
+        def reject_status(request, timeout=0):
+            if urllib.parse.urlsplit(request.full_url).path == "/health":
+                return hardware(request, timeout)
+            raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", {}, None)
+
+        with patch("device_registry.urllib.request.urlopen", side_effect=reject_status):
+            response = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": "wrong-token",
+            })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("rejected", response.json()["detail"].lower())
+        self.assertFalse(self.registry_path.exists())
+
+    def test_invalid_url_and_unknown_device_are_rejected(self):
+        response = self.client.post("/devices", json={
+            "name": "Bad URL",
+            "base_url": "file:///tmp/device",
+            "token": "secret",
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("http", response.json()["detail"].lower())
+        self.assertEqual(self.client.get("/devices/missing/status").status_code, 404)
+
+    def test_delete_removes_local_pairing(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+
+        response = self.client.delete(f"/devices/{device_id}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.get("/devices").json()["devices"], [])
+
+    def test_deployment_preflight_reports_safety_capabilities_and_runtime(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            response = self.client.post(
+                f"/devices/{device_id}/deployment-preflight",
+                json={"workflow": _workflow(["joint_group"])},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        report = response.json()
+        checks = {item["id"]: item for item in report["checks"]}
+        self.assertEqual(checks["workflow"]["status"], "pass")
+        self.assertEqual(checks["service"]["status"], "pass")
+        self.assertEqual(checks["hardware"]["status"], "pass")
+        self.assertEqual(checks["safety"]["status"], "pass")
+        self.assertEqual(checks["capabilities"]["status"], "pass")
+        self.assertEqual(checks["calibration"]["status"], "fail")
+        self.assertTrue(checks["calibration"]["blocking"])
+        self.assertEqual(checks["target_runtime"]["status"], "pass")
+        self.assertFalse(checks["target_runtime"]["blocking"])
+        self.assertFalse(report["ready"])
+        self.assertNotIn(hardware.token, response.text)
+
+    def test_deployment_preflight_keeps_runtime_unavailable_as_a_blocker(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+
+        def hardware_only(request, timeout=0):
+            if urllib.parse.urlsplit(request.full_url).port == 8766:
+                raise urllib.error.URLError("connection refused")
+            return hardware(request, timeout)
+
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware_only):
+            response = self.client.post(
+                f"/devices/{device_id}/deployment-preflight",
+                json={"workflow": _workflow([])},
+            )
+
+        checks = {item["id"]: item for item in response.json()["checks"]}
+        self.assertEqual(checks["target_runtime"]["status"], "pending")
+        self.assertTrue(checks["target_runtime"]["blocking"])
+
+    def test_deployment_preflight_reports_auto_installable_target_package(self):
+        hardware = _HardwareService()
+        workflow = json.loads(
+            (
+                ROOT
+                / "packages"
+                / "blacknode-perception"
+                / "templates"
+                / "vision-camera-console.json"
+            ).read_text(encoding="utf-8")
+        )
+        workflow["metadata"].pop("required_packages", None)
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop camera",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            response = self.client.post(
+                f"/devices/{device_id}/deployment-preflight",
+                json={"workflow": workflow},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        target_runtime = next(
+            item for item in response.json()["checks"]
+            if item["id"] == "target_runtime"
+        )
+        self.assertEqual(target_runtime["status"], "warning")
+        self.assertFalse(target_runtime["blocking"])
+        self.assertIn("blacknode-perception", target_runtime["message"])
+        self.assertTrue(response.json()["ready"])
+
+    def test_target_package_specs_use_live_package_registry_for_new_package(self):
+        package_dir = Path(self._tmp.name) / "blacknode-new-camera"
+        package_dir.mkdir()
+        subprocess.run(["git", "init", str(package_dir)], check=True, capture_output=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(package_dir),
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:example/blacknode-new-camera.git",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        package = SimpleNamespace(
+            name="blacknode-new-camera",
+            version="1.4.0",
+            node_types=["NewCamera"],
+            path=str(package_dir),
+        )
+        workflow = {
+            "node_meta": {"camera": {"type": "NewCamera"}},
+            "edges": [],
+        }
+
+        with (
+            patch.object(server, "installed_packages", return_value=[package]),
+            patch.object(
+                server,
+                "package_index_payload",
+                return_value={"packages": {}, "nodes": {}},
+            ),
+        ):
+            specs = server._workflow_target_package_specs(workflow)
+
+        self.assertEqual(specs, [{
+            "name": "blacknode-new-camera",
+            "git_url": "https://github.com/example/blacknode-new-camera.git",
+            "version": "1.4.0",
+        }])
+
+    def test_staging_auto_installs_extension_packages_before_upload(self):
+        hardware = _HardwareService()
+        workflow = json.loads(
+            (
+                ROOT
+                / "packages"
+                / "blacknode-perception"
+                / "templates"
+                / "vision-camera-console.json"
+            ).read_text(encoding="utf-8")
+        )
+        workflow["metadata"].pop("required_packages", None)
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop camera",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            with patch.object(server, "_workflow_payload", return_value=workflow):
+                preflight = self.client.post(
+                    f"/devices/{device_id}/deployment-preflight",
+                    json={},
+                ).json()
+                response = self.client.post(
+                    f"/devices/{device_id}/deployments",
+                    json={
+                        "name": "Camera workflow",
+                        "workflow_hash": preflight["workflow"]["hash"],
+                    },
+                )
+
+        self.assertEqual(response.status_code, 200)
+        runtime_paths = [
+            path
+            for method, path, _auth, _body in hardware.requests
+            if method == "POST" and path in {"/packages/sync", "/deployments"}
+        ]
+        self.assertEqual(runtime_paths[-2:], ["/packages/sync", "/deployments"])
+        sync_request = next(
+            item for item in hardware.requests
+            if item[0] == "POST" and item[1] == "/packages/sync"
+        )
+        self.assertEqual(
+            sync_request[3]["packages"],
+            [{
+                "name": "blacknode-perception",
+                "git_url": "https://github.com/temiroff/blacknode-perception.git",
+                "version": "0.3.0",
+            }],
+        )
+
+    def test_deployment_preflight_returns_structured_failure_when_device_is_offline(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+
+        with patch(
+            "device_registry.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            response = self.client.post(
+                f"/devices/{device_id}/deployment-preflight",
+                json={"workflow": _workflow([])},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        report = response.json()
+        checks = {item["id"]: item for item in report["checks"]}
+        self.assertEqual(checks["service"]["status"], "fail")
+        self.assertTrue(checks["service"]["blocking"])
+        self.assertIsNone(report["status"])
+        self.assertFalse(report["ready"])
+
+    def test_deployment_preflight_uses_current_editor_graph_when_workflow_is_omitted(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            with patch.object(server, "_workflow_payload", return_value=_workflow([])):
+                response = self.client.post(
+                    f"/devices/{device_id}/deployment-preflight",
+                    json={},
+                )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["workflow"]["name"], "Device preflight")
+        self.assertEqual(response.json()["workflow"]["node_count"], 1)
+        self.assertEqual(len(response.json()["workflow"]["hash"]), 64)
+
+    def test_validated_graph_can_be_staged_and_started_on_runtime(self):
+        hardware = _HardwareService()
+        workflow = _workflow([])
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            with patch.object(server, "_workflow_payload", return_value=workflow):
+                preflight = self.client.post(
+                    f"/devices/{device_id}/deployment-preflight",
+                    json={},
+                ).json()
+                response = self.client.post(
+                    f"/devices/{device_id}/deployments",
+                    json={
+                        "name": "Camera workflow",
+                        "workflow_hash": preflight["workflow"]["hash"],
+                        "start": True,
+                    },
+                )
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertTrue(result["started"])
+        self.assertEqual(result["deployment"]["state"], "running")
+        stage_request = next(
+            item for item in hardware.requests
+            if item[0] == "POST" and item[1] == "/deployments"
+        )
+        self.assertIn("from __future__ import annotations", stage_request[3]["script"])
+        self.assertEqual(
+            stage_request[3]["manifest"]["workflow_hash"],
+            preflight["workflow"]["hash"],
+        )
+        self.assertNotIn(hardware.token, response.text)
+
+    def test_staging_rejects_graph_changed_after_validation(self):
+        hardware = _HardwareService()
+        original = _workflow([])
+        changed = json.loads(json.dumps(original))
+        changed["node_meta"]["out"]["params"]["changed"] = True
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            with patch.object(server, "_workflow_payload", return_value=original):
+                workflow_hash = self.client.post(
+                    f"/devices/{device_id}/deployment-preflight",
+                    json={},
+                ).json()["workflow"]["hash"]
+            with patch.object(server, "_workflow_payload", return_value=changed):
+                response = self.client.post(
+                    f"/devices/{device_id}/deployments",
+                    json={
+                        "name": "Changed graph",
+                        "workflow_hash": workflow_hash,
+                    },
+                )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("changed after validation", response.json()["detail"])
+        self.assertFalse(any(
+            method == "POST" and path == "/deployments"
+            for method, path, _auth, _body in hardware.requests
+        ))
+
+    def test_remote_deployment_controls_proxy_with_saved_token(self):
+        hardware = _HardwareService()
+        hardware.runtime_deployments["camera-workflow-a1b2c3d4"] = {
+            "id": "camera-workflow-a1b2c3d4",
+            "name": "Camera workflow",
+            "state": "staged",
+            "staged_revision": "cafebabecafebabe",
+            "active_revision": None,
+            "revisions": ["cafebabecafebabe", "feedfacefeedface"],
+            "pid": None,
+            "exit_code": None,
+            "error": "",
+            "created_at": "2026-07-23T00:00:00+00:00",
+            "updated_at": "2026-07-23T00:00:01+00:00",
+        }
+        deployment_id = "camera-workflow-a1b2c3d4"
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            listed = self.client.get(f"/devices/{device_id}/deployments")
+            started = self.client.post(
+                f"/devices/{device_id}/deployments/{deployment_id}/start",
+            )
+            logs = self.client.get(
+                f"/devices/{device_id}/deployments/{deployment_id}/logs",
+            )
+            stopped = self.client.post(
+                f"/devices/{device_id}/deployments/{deployment_id}/stop",
+            )
+            rolled_back = self.client.post(
+                f"/devices/{device_id}/deployments/{deployment_id}/rollback",
+                json={},
+            )
+
+        self.assertEqual(listed.json()["deployments"][0]["id"], deployment_id)
+        self.assertEqual(started.json()["state"], "running")
+        self.assertEqual(logs.json()["logs"], "remote output\n")
+        self.assertEqual(stopped.json()["state"], "stopped")
+        self.assertEqual(rolled_back.json()["state"], "staged")
+        remote_requests = [
+            item for item in hardware.requests if item[1].startswith("/deployments")
+        ]
+        self.assertTrue(remote_requests)
+        self.assertTrue(all(
+            authorization == f"Bearer {hardware.token}"
+            for _method, _path, authorization, _body in remote_requests
+        ))
+
+    def test_remote_start_rechecks_device_safety(self):
+        hardware = _HardwareService(status_overrides={"armed": True})
+        deployment_id = "camera-workflow-a1b2c3d4"
+        hardware.runtime_deployments[deployment_id] = {
+            "id": deployment_id,
+            "name": "Camera workflow",
+            "state": "staged",
+            "staged_revision": "cafebabecafebabe",
+            "active_revision": None,
+            "revisions": ["cafebabecafebabe"],
+            "pid": None,
+            "exit_code": None,
+            "error": "",
+            "created_at": "2026-07-23T00:00:00+00:00",
+            "updated_at": "2026-07-23T00:00:01+00:00",
+        }
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            response = self.client.post(
+                f"/devices/{device_id}/deployments/{deployment_id}/start",
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("disarm", response.json()["detail"].lower())
+        self.assertFalse(any(
+            path.endswith("/start") for _method, path, _auth, _body in hardware.requests
+        ))
+
+
+def _workflow(required_capabilities: list[str]) -> dict:
+    fn = server._NODE_REGISTRY["Output"]
+    return {
+        "kind": "blacknode.workflow",
+        "schema_version": 1,
+        "name": "Device preflight",
+        "saved_at": "2026-07-23T00:00:00",
+        "entrypoint": {"node_id": "out", "port": "value"},
+        "metadata": {"required_capabilities": required_capabilities},
+        "node_meta": {
+            "out": {
+                "id": "out",
+                "type": "Output",
+                "params": {},
+                "pos": [0, 0],
+                "inputs": list(getattr(fn, "_bn_inputs", [])),
+                "outputs": list(getattr(fn, "_bn_outputs", [])),
+                "input_types": dict(getattr(fn, "_bn_input_types", {})),
+                "output_types": dict(getattr(fn, "_bn_output_types", {})),
+                "input_defaults": dict(getattr(fn, "_bn_input_defaults", {})),
+            },
+        },
+        "edges": [],
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- pair and inspect remote Blacknode hardware devices without exposing tokens to the browser
- validate, hash-bind, stage, start, stop, log, update, and roll back device deployments
- synchronize required extension packages and versions automatically before staging
- document the modular HTTP, MQTT, Zenoh, execution, and OTA provider boundaries

## Why
Blacknode workflows need a safe deployment path from the visual editor to Raspberry Pi and Jetson targets while keeping hardware, transport, execution, and platform-update providers replaceable.

## Validation
- 510 core tests passed, 8 skipped, 45 subtests passed
- 17 focused device deployment tests passed after rebase
- editor TypeScript and production build passed
- blacknode-runtime: 9 tests passed, 1 skipped