### PR TITLE
Improve robot deployment setup and guidance

### DIFF
--- a/docker-down.ps1
+++ b/docker-down.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param(
+    [switch] $Volumes
+)
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$DockerCheck = Join-Path $Root "docker-up.ps1"
+
+& $DockerCheck -CheckOnly -ReadyTimeoutSeconds 30
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+$Docker = Get-Command docker -ErrorAction SilentlyContinue
+
+if (-not $Docker) {
+    Write-Host "ERROR: Docker CLI was not found."
+    exit 1
+}
+
+$DockerExe = if ($Docker.Source) { $Docker.Source } else { $Docker.Path }
+$ComposeArguments = @("compose", "down", "--remove-orphans")
+if ($Volumes) {
+    $ComposeArguments += "--volumes"
+}
+
+Push-Location $Root
+try {
+    & $DockerExe @ComposeArguments
+    exit $LASTEXITCODE
+} finally {
+    Pop-Location
+}

--- a/docker-up.ps1
+++ b/docker-up.ps1
@@ -1,6 +1,19 @@
+[CmdletBinding()]
+param(
+    [switch] $RepairWsl,
+    [switch] $CheckOnly,
+    [ValidateRange(10, 300)]
+    [int] $ReadyTimeoutSeconds = 90,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $ComposeArguments = @()
+)
+
 $ErrorActionPreference = "Stop"
 
 $Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$DockerProbeTimeoutMs = 8000
+$Mutex = $null
+$HasMutex = $false
 
 function Write-ComposeHint {
     param(
@@ -29,91 +42,322 @@ function Write-ComposeHint {
 }
 
 function Invoke-Captured {
-    param([string[]] $Command)
+    param(
+        [string[]] $Command,
+        [int] $TimeoutMs = 10000
+    )
 
-    $PreviousErrorActionPreference = $ErrorActionPreference
-    $Output = @()
-    $ExitCode = 1
+    $StartInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $StartInfo.FileName = $Command[0]
+    $StartInfo.UseShellExecute = $false
+    $StartInfo.CreateNoWindow = $true
+    $StartInfo.RedirectStandardOutput = $true
+    $StartInfo.RedirectStandardError = $true
+
+    $Arguments = if ($Command.Count -gt 1) {
+        @($Command[1..($Command.Count - 1)])
+    } else {
+        @()
+    }
+    if ($StartInfo.PSObject.Properties.Name -contains "ArgumentList") {
+        foreach ($Argument in $Arguments) {
+            $StartInfo.ArgumentList.Add([string] $Argument)
+        }
+    } else {
+        $StartInfo.Arguments = (
+            $Arguments | ForEach-Object {
+                '"' + ([string] $_).Replace('"', '\"') + '"'
+            }
+        ) -join " "
+    }
+
+    $Process = [System.Diagnostics.Process]::new()
+    $Process.StartInfo = $StartInfo
     try {
-        $ErrorActionPreference = "Continue"
-        $Arguments = if ($Command.Count -gt 1) { @($Command[1..($Command.Count - 1)]) } else { @() }
-        $Output = & $Command[0] @Arguments 2>&1
-        $ExitCode = $LASTEXITCODE
+        if (-not $Process.Start()) {
+            throw "Could not start $($Command[0])."
+        }
+        $OutputTask = $Process.StandardOutput.ReadToEndAsync()
+        $ErrorTask = $Process.StandardError.ReadToEndAsync()
+        $TimedOut = -not $Process.WaitForExit($TimeoutMs)
+        if ($TimedOut) {
+            try {
+                $Process.Kill($true)
+            } catch {
+                $Process.Kill()
+            }
+            $Process.WaitForExit()
+        }
+        $OutputText = $OutputTask.GetAwaiter().GetResult()
+        $ErrorText = $ErrorTask.GetAwaiter().GetResult()
+        $Lines = @(
+            @($OutputText, $ErrorText) |
+                Where-Object { $_ } |
+                ForEach-Object { $_ -split "\r?\n" } |
+                Where-Object { $_ }
+        )
+        return @{
+            ExitCode = if ($TimedOut) { 124 } else { $Process.ExitCode }
+            TimedOut = $TimedOut
+            Output = $Lines
+        }
     } catch {
-        $Output += $_.Exception.Message
-        if ($LASTEXITCODE) {
-            $ExitCode = $LASTEXITCODE
+        return @{
+            ExitCode = 1
+            TimedOut = $false
+            Output = @($_.Exception.Message)
         }
     } finally {
-        $ErrorActionPreference = $PreviousErrorActionPreference
-    }
-
-    return @{
-        ExitCode = $ExitCode
-        Output = @($Output | ForEach-Object { $_.ToString() })
+        $Process.Dispose()
     }
 }
 
-$Docker = Get-Command docker -ErrorAction SilentlyContinue
-if (-not $Docker) {
-    Write-ComposeHint `
-        -Title "Docker CLI was not found." `
-        -Fixes @(
-            "Install Docker Desktop for Windows.",
-            "Reopen this terminal after installation so docker.exe is on PATH."
-        )
-    exit 1
+function Find-DockerDesktop {
+    $Candidates = @()
+    if ($env:ProgramFiles) {
+        $Candidates += Join-Path $env:ProgramFiles "Docker\Docker\Docker Desktop.exe"
+    }
+    if ($env:LOCALAPPDATA) {
+        $Candidates += Join-Path $env:LOCALAPPDATA "Docker\Docker Desktop.exe"
+    }
+    return $Candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
 }
 
-$DockerExe = if ($Docker.Source) { $Docker.Source } else { $Docker.Path }
-
-$ComposeVersion = Invoke-Captured @($DockerExe, "compose", "version")
-if ($ComposeVersion.ExitCode -ne 0) {
-    Write-ComposeHint `
-        -Title "Docker Compose v2 is not available." `
-        -Details $ComposeVersion.Output `
-        -Fixes @(
-            "Update Docker Desktop.",
-            "Confirm 'docker compose version' works before starting Blacknode."
-        )
-    exit $ComposeVersion.ExitCode
+function Find-DockerCli {
+    $Desktop = Find-DockerDesktop
+    if (-not $Desktop) {
+        return $null
+    }
+    $Candidate = Join-Path (Split-Path -Parent $Desktop) "DockerCli.exe"
+    if (Test-Path -LiteralPath $Candidate) {
+        return $Candidate
+    }
+    return $null
 }
 
-$DockerInfo = Invoke-Captured @($DockerExe, "info", "--format", "{{.ServerVersion}}")
-if ($DockerInfo.ExitCode -ne 0) {
-    $OutputText = ($DockerInfo.Output -join "`n")
-    $PipeMissing = $OutputText -match "dockerDesktopLinuxEngine|//\./pipe|open //|The system cannot find the file specified"
-    $Details = @("Docker CLI is installed, but the Docker engine is not reachable.")
-    $DockerMessage = @($DockerInfo.Output | Where-Object { $_.Trim() } | Select-Object -First 1)
-    if ($DockerMessage.Count -gt 0) {
-        $Details += "Docker said: $($DockerMessage[0])"
+function Get-DockerDesktopProcesses {
+    return @(
+        Get-Process -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.ProcessName -in @(
+                    "Docker Desktop",
+                    "com.docker.backend",
+                    "com.docker.build",
+                    "docker-agent",
+                    "docker-sandbox"
+                )
+            }
+    )
+}
+
+function Start-DockerDesktop {
+    if ((Get-DockerDesktopProcesses).Count -gt 0) {
+        return
+    }
+    $Desktop = Find-DockerDesktop
+    if (-not $Desktop) {
+        throw "Docker Desktop is installed, but Docker Desktop.exe could not be found."
+    }
+    Write-Host "Starting Docker Desktop..."
+    Start-Process -FilePath $Desktop -WindowStyle Hidden | Out-Null
+}
+
+function Get-RunningNonDockerWslDistros {
+    $Result = Invoke-Captured @("wsl.exe", "--list", "--running", "--quiet") 5000
+    if ($Result.ExitCode -ne 0) {
+        return @("unknown")
+    }
+    return @(
+        $Result.Output |
+            ForEach-Object {
+                ([string] $_).Replace(([char] 0).ToString(), "").Trim()
+            } |
+            Where-Object { $_ -and $_ -ne "docker-desktop" }
+    )
+}
+
+function Repair-DockerWslEngine {
+    Write-Host "Repairing the stuck Docker Desktop WSL engine..."
+    $DockerCli = Find-DockerCli
+    if ($DockerCli) {
+        $null = Invoke-Captured @($DockerCli, "-Shutdown") 15000
     }
 
-    $Fixes = if ($PipeMissing) {
-        @(
-            "Start Docker Desktop and wait until it says Docker Desktop is running.",
-            "Make sure Docker Desktop is using Linux containers.",
-            "If Docker Desktop is stuck, run 'wsl --shutdown', reopen Docker Desktop, then retry '.\docker-up.ps1'."
-        )
-    } else {
-        @(
-            "Start Docker Desktop or your Docker engine.",
-            "Confirm 'docker info' works before starting Blacknode.",
-            "If you use a remote Docker context, switch to a reachable context with 'docker context use <name>'."
-        )
+    $Processes = Get-DockerDesktopProcesses
+    if ($Processes.Count -gt 0) {
+        $Processes | Stop-Process -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 2
     }
 
-    Write-ComposeHint `
-        -Title "Docker engine is not running or not reachable." `
-        -Details $Details `
-        -Fixes $Fixes
-    exit $DockerInfo.ExitCode
+    $Shutdown = Invoke-Captured @("wsl.exe", "--shutdown") 20000
+    if ($Shutdown.ExitCode -ne 0) {
+        throw "WSL shutdown failed: $($Shutdown.Output -join ' ')"
+    }
+    Start-DockerDesktop
 }
 
-Push-Location $Root
+function Get-DockerEngineProbe {
+    param([string] $DockerExe)
+    return Invoke-Captured @(
+        $DockerExe,
+        "info",
+        "--format",
+        "{{.ServerVersion}}"
+    ) $DockerProbeTimeoutMs
+}
+
+function Wait-DockerEngine {
+    param(
+        [string] $DockerExe,
+        [int] $TimeoutSeconds
+    )
+
+    $Deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $LastProbe = $null
+    do {
+        $LastProbe = Get-DockerEngineProbe $DockerExe
+        if ($LastProbe.ExitCode -eq 0) {
+            return $LastProbe
+        }
+        Start-Sleep -Seconds 2
+    } while ([DateTime]::UtcNow -lt $Deadline)
+    return $LastProbe
+}
+
 try {
-    & $DockerExe compose up --build @args
-    exit $LASTEXITCODE
+    $Mutex = [System.Threading.Mutex]::new($false, "Local\BlacknodeDockerUp")
+    try {
+        $HasMutex = $Mutex.WaitOne(0)
+    } catch [System.Threading.AbandonedMutexException] {
+        $HasMutex = $true
+    }
+    if (-not $HasMutex) {
+        Write-ComposeHint `
+            -Title "Another Blacknode Docker launcher is already running." `
+            -Fixes @(
+                "Use the existing terminal instead of starting Docker twice.",
+                "Run '.\docker-down.ps1' from a separate terminal when you want to stop the stack."
+            )
+        exit 1
+    }
+
+    $Docker = Get-Command docker -ErrorAction SilentlyContinue
+    if (-not $Docker) {
+        Write-ComposeHint `
+            -Title "Docker CLI was not found." `
+            -Fixes @(
+                "Install Docker Desktop for Windows.",
+                "Reopen this terminal after installation so docker.exe is on PATH."
+            )
+        exit 1
+    }
+    $DockerExe = if ($Docker.Source) { $Docker.Source } else { $Docker.Path }
+
+    $ComposeVersion = Invoke-Captured @($DockerExe, "compose", "version") 10000
+    if ($ComposeVersion.ExitCode -ne 0) {
+        Write-ComposeHint `
+            -Title "Docker Compose v2 is not available." `
+            -Details $ComposeVersion.Output `
+            -Fixes @(
+                "Update Docker Desktop.",
+                "Confirm 'docker compose version' works before starting Blacknode."
+            )
+        exit $ComposeVersion.ExitCode
+    }
+
+    $InitialProbe = Get-DockerEngineProbe $DockerExe
+    if ($InitialProbe.ExitCode -ne 0) {
+        $DesktopProcesses = Get-DockerDesktopProcesses
+        $NonDockerDistros = Get-RunningNonDockerWslDistros
+        $DesktopStart = $DesktopProcesses |
+            Where-Object { $_.StartTime } |
+            Sort-Object StartTime |
+            Select-Object -First 1
+        $DesktopStuck = (
+            $DesktopStart -and
+            $DesktopStart.StartTime -lt (Get-Date).AddMinutes(-1)
+        )
+        $SafeAutomaticRepair = $DesktopStuck -and $NonDockerDistros.Count -eq 0
+
+        if ($RepairWsl -or $SafeAutomaticRepair) {
+            if ($SafeAutomaticRepair -and -not $RepairWsl) {
+                Write-Host "Docker Desktop has been unresponsive for more than one minute."
+                Write-Host "No other WSL distribution is running, so Blacknode can safely reset Docker's WSL engine."
+            }
+            Repair-DockerWslEngine
+        } elseif ($DesktopProcesses.Count -eq 0) {
+            Start-DockerDesktop
+        } elseif ($NonDockerDistros.Count -gt 0) {
+            Write-ComposeHint `
+                -Title "Docker Desktop is stuck while another WSL distribution is running." `
+                -Details @(
+                    "Running WSL distributions: $($NonDockerDistros -join ', ')",
+                    "Blacknode did not stop them automatically."
+                ) `
+                -Fixes @(
+                    "Save work in those WSL distributions.",
+                    "Run '.\docker-up.ps1 -RepairWsl' to reset WSL and restart Docker Desktop."
+                )
+            exit 1
+        }
+
+        Write-Host "Waiting up to $ReadyTimeoutSeconds seconds for the Docker engine..."
+        $DockerInfo = Wait-DockerEngine $DockerExe $ReadyTimeoutSeconds
+    } else {
+        $DockerInfo = $InitialProbe
+    }
+
+    if ($DockerInfo.ExitCode -ne 0) {
+        $Details = @("Docker Desktop started, but its engine did not become ready.")
+        if ($DockerInfo.TimedOut) {
+            $Details += "The Docker CLI probe timed out instead of freezing this launcher."
+        }
+        $DockerMessage = @(
+            $DockerInfo.Output |
+                Where-Object { $_.Trim() } |
+                Select-Object -First 1
+        )
+        if ($DockerMessage.Count -gt 0) {
+            $Details += "Docker said: $($DockerMessage[0])"
+        }
+        Write-ComposeHint `
+            -Title "Docker engine startup timed out." `
+            -Details $Details `
+            -Fixes @(
+                "Run '.\docker-up.ps1 -RepairWsl' after saving work in other WSL distributions.",
+                "Open Docker Desktop Troubleshoot if the repair still fails."
+            )
+        exit 1
+    }
+
+    $ServerVersion = @($DockerInfo.Output | Where-Object { $_.Trim() } | Select-Object -First 1)
+    $VersionSuffix = if ($ServerVersion.Count -gt 0) {
+        " (server $($ServerVersion[0]))"
+    } else {
+        ""
+    }
+    Write-Host "Docker engine ready$VersionSuffix."
+
+    if ($CheckOnly) {
+        exit 0
+    }
+
+    Push-Location $Root
+    try {
+        & $DockerExe compose up --build --remove-orphans @ComposeArguments
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
 } finally {
-    Pop-Location
+    if ($HasMutex -and $Mutex) {
+        try {
+            $Mutex.ReleaseMutex()
+        } catch {
+            # The process is already exiting; there is nothing left to release.
+        }
+    }
+    if ($Mutex) {
+        $Mutex.Dispose()
+    }
 }

--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -62,6 +62,53 @@ Large artifacts do not have to travel through the command transport. An MQTT
 or Zenoh command can carry a content-addressed HTTPS or object-store reference,
 while the same artifact manifest and hashes remain authoritative.
 
+The editor persists deployment requirements in workflow metadata. A remote
+robot deployment currently targets one physical robot. Additional robots use
+separate workflows and are deployed one at a time to the computer connected to
+each robot. The Deployments panel guides robot setup in three steps:
+
+1. choose the profile for the workflow's `Robot` node;
+2. choose and activate the matching physical robot calibration, or open the
+   guided calibration workflow to create one; and
+3. check the setup before sending the workflow to the device.
+
+Several calibrations may be saved for the same profile because each calibration
+has a human-readable name and is bound to a stable physical hardware identity.
+The deployment selector shows both values, selects exactly one calibration, and
+records its stable identity in workflow metadata.
+
+Blacknode derives `metadata.required_capabilities` from the workflow. Robot
+motion workflows receive `joint_group`, `position_feedback`, and `servo_bus`.
+Guided calibration workflows receive the feedback and bus capabilities they
+need while calibration is being created.
+
+Hardware-bound calibration is declared separately as
+`metadata.device_calibration`:
+
+```json
+{
+  "metadata": {
+    "required_capabilities": [
+      "joint_group",
+      "position_feedback",
+      "servo_bus"
+    ],
+    "device_calibration": {
+      "profile_id": "so_arm101_v002",
+      "hardware_id": "5B41531481"
+    }
+  }
+}
+```
+
+Selecting a calibration records the intended profile and physical hardware in
+the workflow. **Use this calibration** uploads it to the paired, connected,
+disarmed device. Preflight accepts `joint_group` only when the
+workflow selection, Robot profile, device hardware identity, and device's
+active calibration all match. The staged workflow embeds the same profile and
+calibration so the robot driver applies the reviewed home positions and safe
+joint ranges.
+
 ### Deployment transport
 
 A transport adapter exposes these semantic operations regardless of protocol:

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -20,12 +20,34 @@ goes through the Caddy `proxy` profile. See
 
 ### 1. Start everything
 
-On Windows, use the helper so Docker Desktop/engine problems get a clear
-actionable message:
+On Windows, use the helper. It starts Docker Desktop when needed, bounds every
+engine readiness check, and prevents two Blacknode Compose launchers from
+running at the same time:
 
 ```powershell
 .\docker-up.ps1
 ```
+
+If Docker Desktop's WSL engine remains stuck while another WSL distribution is
+running, save that distribution's work and request a full WSL repair:
+
+```powershell
+.\docker-up.ps1 -RepairWsl
+```
+
+Check Docker readiness without starting the Compose services:
+
+```powershell
+.\docker-up.ps1 -CheckOnly
+```
+
+Stop and remove the Blacknode Compose containers and network:
+
+```powershell
+.\docker-down.ps1
+```
+
+Add `-Volumes` only when the Compose volumes should also be removed.
 
 On Linux, macOS, or after confirming `docker info` works:
 

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -84,6 +84,23 @@ class HardwareDeviceClient:
     def capabilities(self) -> dict[str, Any]:
         return self._request("GET", "/capabilities")
 
+    def calibration(self) -> dict[str, Any]:
+        return self._request("GET", "/calibration")
+
+    def activate_calibration(
+        self,
+        profile: dict[str, Any],
+        calibration: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            "/calibration",
+            payload={"profile": profile, "calibration": calibration},
+        )
+
+    def deactivate_calibration(self) -> dict[str, Any]:
+        return self._request("DELETE", "/calibration")
+
     def rpc(self, payload: dict[str, Any]) -> dict[str, Any]:
         return self._request("POST", "/rpc", payload=payload)
 
@@ -136,6 +153,12 @@ class HardwareDeviceClient:
                 raise DeviceRegistryError(
                     "Pairing token was rejected. Run ./pair.sh --show on the device "
                     "and paste the current token."
+                ) from exc
+            if exc.code == 404 and endpoint == "/calibration":
+                raise DeviceRegistryError(
+                    "This device service does not support calibration activation yet. "
+                    "Update blacknode-hardware on the device, run "
+                    "'./service.sh restart', then refresh the device in Blacknode."
                 ) from exc
             detail = ""
             try:

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -143,7 +143,8 @@ def _save_now() -> None:
     try:
         with open(_SAVE_PATH, "w") as f:
             json.dump({"node_meta": _session.node_meta,
-                       "edges":     _session.graph._edges}, f, indent=2)
+                       "edges":     _session.graph._edges,
+                       "metadata":  _session.metadata}, f, indent=2)
     except Exception as e:
         print(f"[blacknode] save error: {e}")
 
@@ -169,6 +170,8 @@ def _load() -> None:
             data = json.load(f)
         meta_map: dict = data.get("node_meta", {})
         edges:    list = data.get("edges",     [])
+        metadata = data.get("metadata")
+        _session.metadata = dict(metadata) if isinstance(metadata, dict) else {}
         # only restore nodes whose type is still registered
         migrated = False
         for node_id, meta in meta_map.items():
@@ -206,6 +209,7 @@ class Session:
     def __init__(self):
         self.graph = bn.Graph()
         self.node_meta: dict[str, dict] = {}
+        self.metadata: dict[str, Any] = {}
 
 _session = Session()
 
@@ -271,6 +275,11 @@ class CookGraphReq(BaseModel):
 class SetGraphReq(BaseModel):
     nodes: list[dict[str, Any]] = []
     edges: list[dict[str, Any]] = []
+    metadata: dict[str, Any] = {}
+
+class UpdateWorkflowRequirementsReq(BaseModel):
+    required_capabilities: list[str] = []
+    device_calibration: dict[str, str] | None = None
 
 class ExecNodeReq(BaseModel):
     code: str
@@ -1245,14 +1254,58 @@ def get_graph():
                 "input_defaults": getattr(fn, "_bn_input_defaults", meta.get("input_defaults", {})),
                 "live_capable":   bool(getattr(fn, "_bn_live_capable", False)),
             })
-    return {"nodes": nodes, "edges": _session.graph._edges}
+    return {
+        "nodes": nodes,
+        "edges": _session.graph._edges,
+        "metadata": dict(_session.metadata),
+    }
 
 
 @app.post("/graph")
 def set_graph(req: SetGraphReq):
-    _restore_session_from_nodes(req.nodes, req.edges)
+    _restore_session_from_nodes(req.nodes, req.edges, metadata=req.metadata)
     _save()
     return get_graph()
+
+
+def _normalized_required_capabilities(values: list[Any]) -> list[str]:
+    capabilities: set[str] = set()
+    for value in values:
+        name = str(value or "").strip()
+        if not re.fullmatch(r"[a-z][a-z0-9_.-]{0,63}", name):
+            raise HTTPException(400, f"Invalid capability name: {name or '(empty)'}")
+        capabilities.add(name)
+    if len(capabilities) > 32:
+        raise HTTPException(400, "A workflow may declare at most 32 capabilities.")
+    return sorted(capabilities)
+
+
+def _normalized_calibration_selection(value: dict[str, str] | None) -> dict[str, str] | None:
+    if value is None:
+        return None
+    profile_id = str(value.get("profile_id") or "").strip()
+    hardware_id = str(value.get("hardware_id") or "").strip()
+    if not profile_id or not hardware_id:
+        raise HTTPException(400, "Calibration selection requires profile_id and hardware_id.")
+    if len(profile_id) > 128 or len(hardware_id) > 256:
+        raise HTTPException(400, "Calibration selection is too long.")
+    return {"profile_id": profile_id, "hardware_id": hardware_id}
+
+
+@app.patch("/graph/requirements")
+def update_workflow_requirements(req: UpdateWorkflowRequirementsReq):
+    metadata = dict(_session.metadata)
+    metadata["required_capabilities"] = _normalized_required_capabilities(
+        req.required_capabilities
+    )
+    calibration = _normalized_calibration_selection(req.device_calibration)
+    if calibration is None:
+        metadata.pop("device_calibration", None)
+    else:
+        metadata["device_calibration"] = calibration
+    _session.metadata = metadata
+    _save()
+    return {"metadata": dict(metadata)}
 
 
 @app.post("/nodes")
@@ -2798,6 +2851,29 @@ def get_device_capabilities(device_id: str):
         raise HTTPException(502, str(exc)) from exc
 
 
+@app.post("/devices/{device_id}/calibration")
+def activate_device_calibration(device_id: str):
+    workflow = _device_deployment_workflow()
+    try:
+        profile, calibration = _selected_local_calibration(workflow)
+        client = _paired_device_client(device_id)
+        status = client.status()
+        if not status.get("connected"):
+            raise HTTPException(
+                409,
+                str(status.get("error") or "Hardware must be connected first."),
+            )
+        if status.get("armed"):
+            raise HTTPException(409, "Disarm the device before activating calibration.")
+        result = client.activate_calibration(profile, calibration)
+        refreshed = client.status()
+    except ValueError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+    return {"ok": True, "activation": result, "status": refreshed}
+
+
 def _preflight_check(
     check_id: str,
     label: str,
@@ -2827,6 +2903,214 @@ def _workflow_required_capabilities(workflow: dict[str, Any]) -> list[str]:
         for item in raw
         if isinstance(item, str) and str(item).strip()
     })
+
+
+def _workflow_calibration_selection(
+    workflow: dict[str, Any],
+) -> dict[str, str] | None:
+    metadata = workflow.get("metadata")
+    raw = metadata.get("device_calibration") if isinstance(metadata, dict) else None
+    if not isinstance(raw, dict):
+        return None
+    profile_id = str(raw.get("profile_id") or "").strip()
+    hardware_id = str(raw.get("hardware_id") or "").strip()
+    if not profile_id or not hardware_id:
+        return None
+    return {"profile_id": profile_id, "hardware_id": hardware_id}
+
+
+def _robot_profiles_root() -> Path:
+    configured = str(os.environ.get("BLACKNODE_ROBOTS_DIR") or "").strip()
+    return (
+        Path(configured).expanduser().resolve()
+        if configured
+        else (Path.cwd() / "robots").resolve()
+    )
+
+
+def _workflow_robot_profile_ids(workflow: dict[str, Any]) -> set[str]:
+    profile_ids: set[str] = set()
+    for meta in (workflow.get("node_meta") or {}).values():
+        if not isinstance(meta, dict) or meta.get("type") not in {"Robot", "RobotProfileLoad"}:
+            continue
+        params = meta.get("params") if isinstance(meta.get("params"), dict) else {}
+        profile_id = str(params.get("profile_id") or "").strip()
+        if profile_id:
+            profile_ids.add(profile_id)
+    return profile_ids
+
+
+def _workflow_robot_nodes(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        meta
+        for meta in (workflow.get("node_meta") or {}).values()
+        if isinstance(meta, dict) and meta.get("type") in {"Robot", "RobotProfileLoad"}
+    ]
+
+
+def _local_calibration_candidates(
+    workflow: dict[str, Any],
+) -> list[dict[str, Any]]:
+    profile_ids = _workflow_robot_profile_ids(workflow)
+    if not profile_ids:
+        return []
+    root = _robot_profiles_root()
+    if not root.is_dir():
+        return []
+    candidates: list[dict[str, Any]] = []
+    for profile_path in sorted(root.glob("*/profile.json")):
+        try:
+            profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(profile, dict):
+            continue
+        profile_id = str(profile.get("id") or "").strip()
+        if profile_id not in profile_ids:
+            continue
+        calibration_dir = profile_path.parent / "calibrations"
+        for calibration_path in sorted(calibration_dir.glob("*.json")):
+            try:
+                calibration = json.loads(calibration_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(calibration, dict):
+                continue
+            hardware_id = str(calibration.get("hardware_id") or "").strip()
+            if (
+                not hardware_id
+                or str(calibration.get("profile_id") or "").strip() != profile_id
+            ):
+                continue
+            candidates.append({
+                "profile_id": profile_id,
+                "profile_name": str(profile.get("display_name") or profile_id),
+                "name": str(calibration.get("name") or hardware_id),
+                "hardware_id": hardware_id,
+                "recorded_at": str(calibration.get("recorded_at") or ""),
+                "joint_count": len(calibration.get("joints") or {}),
+            })
+    return candidates
+
+
+def _available_robot_profiles(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    profile_ids = set(_workflow_robot_profile_ids(workflow))
+    robot_fn = _NODE_REGISTRY.get("Robot")
+    choices = getattr(robot_fn, "_bn_input_choices", {}) if robot_fn else {}
+    raw_choices = choices.get("profile_id") if isinstance(choices, dict) else []
+    if isinstance(raw_choices, list):
+        profile_ids.update(str(value).strip() for value in raw_choices if str(value).strip())
+
+    profiles: dict[str, dict[str, Any]] = {
+        profile_id: {
+            "id": profile_id,
+            "name": profile_id,
+            "saved": False,
+            "calibration_count": 0,
+        }
+        for profile_id in profile_ids
+    }
+    root = _robot_profiles_root()
+    if root.is_dir():
+        for profile_path in sorted(root.glob("*/profile.json")):
+            try:
+                profile = json.loads(profile_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(profile, dict):
+                continue
+            profile_id = str(profile.get("id") or "").strip()
+            if not profile_id:
+                continue
+            calibration_dir = profile_path.parent / "calibrations"
+            profiles[profile_id] = {
+                "id": profile_id,
+                "name": str(profile.get("display_name") or profile_id),
+                "saved": True,
+                "calibration_count": sum(1 for _ in calibration_dir.glob("*.json")),
+            }
+    return sorted(profiles.values(), key=lambda item: (item["name"].lower(), item["id"]))
+
+
+def _selected_local_calibration(
+    workflow: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    selection = _workflow_calibration_selection(workflow)
+    if selection is None:
+        raise ValueError("Select a device calibration for this workflow.")
+    root = _robot_profiles_root()
+    for profile_path in sorted(root.glob("*/profile.json")):
+        try:
+            profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if (
+            not isinstance(profile, dict)
+            or str(profile.get("id") or "").strip() != selection["profile_id"]
+        ):
+            continue
+        calibration_dir = profile_path.parent / "calibrations"
+        for calibration_path in sorted(calibration_dir.glob("*.json")):
+            try:
+                calibration = json.loads(calibration_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if (
+                isinstance(calibration, dict)
+                and str(calibration.get("profile_id") or "").strip()
+                == selection["profile_id"]
+                and str(calibration.get("hardware_id") or "").strip()
+                == selection["hardware_id"]
+            ):
+                return profile, calibration
+    raise ValueError(
+        "The selected calibration file is unavailable for "
+        f"{selection['profile_id']} / {selection['hardware_id']}."
+    )
+
+
+def _embed_selected_calibration(workflow: dict[str, Any]) -> None:
+    selection = _workflow_calibration_selection(workflow)
+    if selection is None:
+        return
+    profile, calibration = _selected_local_calibration(workflow)
+    robot_nodes = _workflow_robot_nodes(workflow)
+    matching_nodes = [
+        meta
+        for meta in robot_nodes
+        if str((meta.get("params") or {}).get("profile_id") or "").strip()
+        == selection["profile_id"]
+    ]
+    if len(robot_nodes) != 1 or len(matching_nodes) != 1:
+        raise ValueError(
+            "Remote device calibration currently requires exactly one Robot node "
+            "using the selected profile."
+        )
+    meta = matching_nodes[0]
+    params = meta.setdefault("params", {})
+    params["profile"] = profile
+    params["calibration"] = calibration
+    inputs = list(meta.get("inputs") or [])
+    for port in ("profile", "calibration"):
+        if port not in inputs:
+            inputs.append(port)
+    meta["inputs"] = inputs
+    input_types = dict(meta.get("input_types") or {})
+    input_types.update({"profile": "Dict", "calibration": "Dict"})
+    meta["input_types"] = input_types
+    defaults = dict(meta.get("input_defaults") or {})
+    defaults.update({"profile": {}, "calibration": {}})
+    meta["input_defaults"] = defaults
+
+
+@app.get("/graph/calibrations")
+def list_graph_calibrations():
+    workflow = _device_deployment_workflow()
+    return {
+        "profiles": _available_robot_profiles(workflow),
+        "calibrations": _local_calibration_candidates(workflow),
+        "selected": _workflow_calibration_selection(workflow),
+    }
 
 
 def _workflow_required_packages(workflow: dict[str, Any]) -> list[str]:
@@ -2978,6 +3262,12 @@ def _device_deployment_workflow(
         entrypoint = _infer_export_entrypoint(data)
         if entrypoint is not None:
             data["entrypoint"] = entrypoint
+    try:
+        _embed_selected_calibration(data)
+    except ValueError:
+        # Preflight reports a focused calibration error. Keeping the graph
+        # intact here lets workflow validation and dependency checks still run.
+        pass
     return data
 
 
@@ -3148,16 +3438,58 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
     requires_joint_motion = "joint_group" in required_capabilities
     calibrated = remote_status.get("calibrated")
     if requires_joint_motion:
+        selection = _workflow_calibration_selection(workflow)
+        active_calibration = (
+            remote_status.get("calibration")
+            if isinstance(remote_status.get("calibration"), dict)
+            else {}
+        )
+        calibration_matches = bool(
+            selection
+            and calibrated is True
+            and str(active_calibration.get("profile_id") or "") == selection["profile_id"]
+            and str(active_calibration.get("hardware_id") or "") == selection["hardware_id"]
+        )
+        selection_error = ""
+        if selection is not None:
+            try:
+                _selected_local_calibration(workflow)
+                robot_nodes = _workflow_robot_nodes(workflow)
+                matching_nodes = [
+                    meta
+                    for meta in robot_nodes
+                    if str((meta.get("params") or {}).get("profile_id") or "").strip()
+                    == selection["profile_id"]
+                ]
+                if len(robot_nodes) != 1 or len(matching_nodes) != 1:
+                    selection_error = (
+                        "Remote device calibration currently requires exactly one "
+                        "Robot node using the selected profile."
+                    )
+            except ValueError as exc:
+                selection_error = str(exc)
         checks.append(_preflight_check(
             "calibration",
             "Calibration",
-            "pass" if calibrated is True else "fail",
+            "pass" if calibration_matches and not selection_error else "fail",
             (
-                "A calibration profile is active for this device."
-                if calibrated is True
-                else "Joint motion requires the editor calibration profile to be deployed to this device."
+                (
+                    f"Active: {selection['profile_id']} / {selection['hardware_id']}."
+                    if selection
+                    else ""
+                )
+                if calibration_matches and not selection_error
+                else selection_error
+                or (
+                    "Select a saved device calibration, then activate it on this device."
+                    if selection is None
+                    else (
+                        f"Activate {selection['profile_id']} / {selection['hardware_id']} "
+                        "on this device before staging."
+                    )
+                )
             ),
-            blocking=calibrated is not True,
+            blocking=not calibration_matches or bool(selection_error),
         ))
     elif calibrated is False and "joint_group" in available_capabilities:
         checks.append(_preflight_check(
@@ -4829,6 +5161,7 @@ def _safe_custom_node_filename(filename: str) -> str:
 def reset():
     _session.graph = bn.Graph()
     _session.node_meta.clear()
+    _session.metadata.clear()
     _save()
     return {"ok": True}
 
@@ -4872,8 +5205,11 @@ def _workflow_payload(
     }
     if entrypoint is not None:
         payload["entrypoint"] = dict(entrypoint)
+    combined_metadata = dict(_session.metadata)
     if metadata is not None:
-        payload["metadata"] = dict(metadata)
+        combined_metadata.update(metadata)
+    if combined_metadata:
+        payload["metadata"] = combined_metadata
     return payload
 
 
@@ -5100,10 +5436,16 @@ def _save_workflow(name: str, previous_slug: str | None = None):
             os.remove(old_path)
     return {"ok": True, "slug": slug}
 
-def _restore_session(node_meta: dict, edges: list):
+def _restore_session(
+    node_meta: dict,
+    edges: list,
+    *,
+    metadata: dict[str, Any] | None = None,
+):
     """Replace current session with the given node_meta + edges."""
     _session.graph = bn.Graph()
     _session.node_meta.clear()
+    _session.metadata = dict(metadata) if isinstance(metadata, dict) else {}
     for node_id, meta in node_meta.items():
         if meta["type"] not in _NODE_REGISTRY and meta["type"] not in _SUBGRAPH_NODE_TYPES:
             continue
@@ -5127,8 +5469,17 @@ def _restore_session(node_meta: dict, edges: list):
     ]
 
 
-def _restore_session_from_nodes(nodes: list[dict], edges: list):
-    _restore_session({node["id"]: node for node in nodes if "id" in node}, edges)
+def _restore_session_from_nodes(
+    nodes: list[dict],
+    edges: list,
+    *,
+    metadata: dict[str, Any] | None = None,
+):
+    _restore_session(
+        {node["id"]: node for node in nodes if "id" in node},
+        edges,
+        metadata=metadata,
+    )
 
 
 def _node_pos(meta: dict) -> tuple[float, float]:
@@ -5270,7 +5621,11 @@ def load_template(slug: str):
     report = validate_bn_workflow(data)
     if not report.ok:
         raise HTTPException(400, report.to_dict())
-    _restore_session(data.get("node_meta", {}), data.get("edges", []))
+    _restore_session(
+        data.get("node_meta", {}),
+        data.get("edges", []),
+        metadata=data.get("metadata") if isinstance(data.get("metadata"), dict) else {},
+    )
     _save()
     return get_graph()
 
@@ -5444,7 +5799,11 @@ def load_workflow(slug: str):
         raise HTTPException(404, f"Workflow '{slug}' not found")
     with open(path) as f:
         data = json.load(f)
-    _restore_session(data.get("node_meta", {}), data.get("edges", []))
+    _restore_session(
+        data.get("node_meta", {}),
+        data.get("edges", []),
+        metadata=data.get("metadata") if isinstance(data.get("metadata"), dict) else {},
+    )
     _save()
     return get_graph()
 

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -21,7 +21,7 @@ import NodeSearch from './components/NodeSearch'
 import { portsCompatible } from './portColors'
 import { PYTHON_TOOL_TYPES, resolvePythonToolPreset } from './pythonToolPresets'
 import type { BnNodeDef, ConnectionDraft } from './types'
-import { api, type FrameworkExportTarget } from './api'
+import { api, type FrameworkExportTarget, type WorkflowMetadata } from './api'
 import { inferGraphRunTargets } from './graphRun'
 import { copyTextToClipboard } from './clipboard'
 
@@ -332,6 +332,11 @@ export default function App() {
             await openGraphAsTab(name, {
               nodes: Object.values(nodeMeta),
               edges,
+              metadata: (
+                record.metadata && typeof record.metadata === 'object'
+                  ? record.metadata
+                  : {}
+              ) as WorkflowMetadata,
             })
             if (action.payload?.organize !== false) {
               await organizeNodes()
@@ -534,6 +539,7 @@ export default function App() {
       let tabName = name
       let nodeMeta: Record<string, any> = {}
       let edges: any[] = []
+      let metadata: WorkflowMetadata = {}
       let sourceLabel = 'workflow'
 
       if (lowerName.endsWith('.py')) {
@@ -548,6 +554,11 @@ export default function App() {
           ? workflow.node_meta
           : {}
         edges = Array.isArray(workflow.edges) ? workflow.edges : []
+        metadata = (
+          workflow.metadata && typeof workflow.metadata === 'object'
+            ? workflow.metadata
+            : {}
+        ) as WorkflowMetadata
         sourceLabel = 'Python'
       } else {
         const parsed = JSON.parse(text)
@@ -558,6 +569,11 @@ export default function App() {
           tabName = typeof workflow.name === 'string' && workflow.name.trim() ? workflow.name : name
           nodeMeta = workflow.node_meta as Record<string, any>
           edges = Array.isArray(workflow.edges) ? workflow.edges : []
+          metadata = (
+            workflow.metadata && typeof workflow.metadata === 'object'
+              ? workflow.metadata
+              : {}
+          ) as WorkflowMetadata
         } else if (Array.isArray(workflow?.nodes)) {
           tabName = typeof workflow.name === 'string' && workflow.name.trim() ? workflow.name : name
           nodeMeta = Object.fromEntries(
@@ -566,6 +582,11 @@ export default function App() {
               .map((node: any) => [node.id, node])
           )
           edges = Array.isArray(workflow.edges) ? workflow.edges : []
+          metadata = (
+            workflow.metadata && typeof workflow.metadata === 'object'
+              ? workflow.metadata
+              : {}
+          ) as WorkflowMetadata
         } else {
           throw new Error('Drop a Blacknode workflow JSON file or a Blacknode-generated Python/LangGraph export.')
         }
@@ -579,6 +600,7 @@ export default function App() {
       await openGraphAsTab(tabName, {
         nodes: Object.values(nodeMeta),
         edges,
+        metadata,
       })
       await organizeNodes()
       fitCurrentCanvas(320)

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -113,6 +113,44 @@ export interface HardwareDeviceStatus {
   raw_positions?: Record<string, number>
   error?: string
   updated_at?: number
+  calibration?: {
+    name?: string
+    profile_id?: string
+    hardware_id?: string
+    activated_at?: string
+    joint_count?: number
+    digest?: string
+  }
+}
+
+export interface WorkflowMetadata extends Record<string, unknown> {
+  required_capabilities?: string[]
+  device_calibration?: {
+    profile_id: string
+    hardware_id: string
+  }
+}
+
+export interface GraphSnapshot {
+  nodes: any[]
+  edges: any[]
+  metadata: WorkflowMetadata
+}
+
+export interface DeviceCalibrationCandidate {
+  profile_id: string
+  profile_name: string
+  name: string
+  hardware_id: string
+  recorded_at: string
+  joint_count: number
+}
+
+export interface DeviceRobotProfile {
+  id: string
+  name: string
+  saved: boolean
+  calibration_count: number
 }
 
 export type DeploymentPreflightStatus = 'pass' | 'fail' | 'warning' | 'pending'
@@ -500,13 +538,27 @@ export const api = {
       changes: Array<{ package: string; component: string; version: string; enabled: boolean }>
     }>('GET', `/packages/${encodeURIComponent(name)}/components/${encodeURIComponent(component)}/dependencies`),
   deletePackage: (name: string)              => req<{ ok: boolean }>('DELETE', `/packages/${encodeURIComponent(name)}`),
-  getGraph:  ()                              => req<{ nodes: any[]; edges: any[] }>('GET', '/graph'),
-  setGraph:  (nodes: any[], edges: any[])    => req<{ nodes: any[]; edges: any[] }>('POST', '/graph', { nodes, edges }),
+  getGraph:  ()                              => req<GraphSnapshot>('GET', '/graph'),
+  setGraph:  (nodes: any[], edges: any[], metadata: WorkflowMetadata = {}) =>
+    req<GraphSnapshot>('POST', '/graph', { nodes, edges, metadata }),
+  updateWorkflowRequirements: (
+    requiredCapabilities: string[],
+    deviceCalibration: { profile_id: string; hardware_id: string } | null,
+  ) => req<{ metadata: WorkflowMetadata }>('PATCH', '/graph/requirements', {
+    required_capabilities: requiredCapabilities,
+    device_calibration: deviceCalibration,
+  }, 10000),
+  listGraphCalibrations: () =>
+    req<{
+      profiles: DeviceRobotProfile[]
+      calibrations: DeviceCalibrationCandidate[]
+      selected: { profile_id: string; hardware_id: string } | null
+    }>('GET', '/graph/calibrations', undefined, 10000),
   addNode:   (type_name: string, pos: [number,number], params = {}) =>
     req<BnNodeMeta>('POST', '/nodes', { type_name, pos, params }),
   removeNode: (id: string)                  => req('DELETE', `/nodes/${id}`),
   updateParam:(id: string, key: string, value: unknown) =>
-    req('PATCH', `/nodes/${id}/params`, { key, value }),
+    req('PATCH', `/nodes/${id}/params`, { key, value }, 10000),
   controlNode:(id: string, action: string) =>
     req<{ ok: boolean; node_id: string; outputs: Record<string, unknown> }>('POST', `/nodes/${id}/control`, { action }),
   pickDirectory:(initialPath = '') =>
@@ -583,6 +635,13 @@ export const api = {
       `/devices/${encodeURIComponent(id)}/capabilities`,
       undefined,
       7000,
+    ),
+  activateDeviceCalibration: (id: string) =>
+    req<{ ok: boolean; activation: Record<string, unknown>; status: HardwareDeviceStatus }>(
+      'POST',
+      `/devices/${encodeURIComponent(id)}/calibration`,
+      {},
+      10000,
     ),
   validateDeviceDeployment: (id: string) =>
     req<DeploymentPreflight>(
@@ -672,9 +731,9 @@ export const api = {
   saveWorkflow: (name: string, previousSlug?: string | null) =>
     req<{ ok: boolean; slug: string }>('POST', '/workflows', { name, previous_slug: previousSlug ?? null }),
   loadWorkflow: (slug: string) =>
-    req<{ nodes: any[]; edges: any[] }>('POST', `/workflows/${encodeURIComponent(slug)}/load`),
+    req<GraphSnapshot>('POST', `/workflows/${encodeURIComponent(slug)}/load`),
   insertWorkflow: (slug: string) =>
-    req<{ nodes: any[]; edges: any[] }>('POST', `/workflows/${encodeURIComponent(slug)}/insert`),
+    req<GraphSnapshot>('POST', `/workflows/${encodeURIComponent(slug)}/insert`),
   renameWorkflow: (slug: string, name: string) =>
     req<{ slug: string; name: string; saved_at: string }>('PATCH', `/workflows/${encodeURIComponent(slug)}`, { name }),
   duplicateWorkflow: (slug: string) =>
@@ -685,7 +744,7 @@ export const api = {
   listTemplates: () =>
     req<TemplateMeta[]>('GET', '/templates'),
   loadTemplate: (slug: string) =>
-    req<{ nodes: any[]; edges: any[] }>('POST', `/templates/${encodeURIComponent(slug)}/load`),
+    req<GraphSnapshot>('POST', `/templates/${encodeURIComponent(slug)}/load`),
 
   listFrameworkExportTargets: () =>
     req<{ targets: FrameworkExportTarget[] }>('GET', '/export/frameworks'),

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -1639,6 +1639,35 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
           border: `1px solid ${calibrationActive ? 'var(--warn)' : calibrationPaused ? 'var(--accent)' : calibrationSaved ? 'var(--ok)' : 'var(--line)'}`,
           background: calibrationActive ? 'rgba(245,158,11,.08)' : 'rgba(255,255,255,.02)',
         }}>
+          <label style={{
+            display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 8,
+            color: 'var(--tx3)', fontFamily: 'var(--font-ui)', fontSize: 9,
+            fontWeight: 700, textTransform: 'uppercase',
+          }}>
+            Calibration name
+            <input
+              key={String(data.params?.calibration_name ?? '')}
+              defaultValue={String(data.params?.calibration_name ?? '')}
+              placeholder="Workshop arm"
+              onClick={e => e.stopPropagation()}
+              onKeyDown={e => {
+                e.stopPropagation()
+                if (e.key === 'Enter') e.currentTarget.blur()
+              }}
+              onBlur={e => {
+                const name = e.currentTarget.value.trim()
+                if (name !== String(data.params?.calibration_name ?? '')) {
+                  void updateParam(id, 'calibration_name', name)
+                }
+              }}
+              style={{
+                width: '100%', boxSizing: 'border-box', padding: '6px 7px',
+                border: '1px solid var(--line2)', borderRadius: 5,
+                background: 'var(--lift)', color: 'var(--tx1)',
+                fontFamily: 'var(--font-ui)', fontSize: 11,
+              }}
+            />
+          </label>
           <div style={{
             marginBottom: 7, color: calibrationActive ? 'var(--warn)' : calibrationPaused ? 'var(--accent)' : calibrationSaved ? 'var(--ok)' : 'var(--tx2)',
             fontFamily: 'var(--font-ui)', fontSize: 10, fontWeight: 800,
@@ -1863,7 +1892,14 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
         {visibleInputs.map(inp => {
           const type = effectivePortType(inp, 'input')
           const connected = edges.some(e => e.target === id && e.targetHandle === inp)
-          if ((isManualMove || isRobotCalibration || isEpisodeRecorder) && inp === 'action' && !connected) return null
+          if (
+            (
+              (isManualMove || isRobotCalibration || isEpisodeRecorder)
+              && inp === 'action'
+              && !connected
+            )
+            || (isRobotCalibration && inp === 'calibration_name' && !connected)
+          ) return null
           const showImageInput = type === 'Image'
             && !connected
             && !isWireOnlyInput(data.type, inp, type)

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -1,17 +1,27 @@
-import { useEffect, useState, type CSSProperties } from 'react'
+import { useEffect, useMemo, useState, type CSSProperties } from 'react'
 import {
   api,
+  type DeviceCalibrationCandidate,
+  type DeviceRobotProfile,
   type Deployment,
   type DeploymentPreflight,
   type DeploymentPreflightStatus,
   type DeploymentState,
   type HardwareDevice,
+  type HardwareDeviceStatus,
   type RemoteDeployment,
   type RemoteDeploymentState,
 } from '../api'
 import { useStore } from '../store'
 
 const REFRESH_INTERVAL_MS = 3000
+const ROBOT_NODE_TYPES = new Set(['Robot', 'RobotProfileLoad'])
+const JOINT_MOTION_NODE_TYPES = new Set([
+  'ROS2SetJoint',
+  'ROS2ManualMove',
+  'ROS2JointSliders',
+  'PolicyRuntime',
+])
 
 const STATE_COLOR: Record<DeploymentState, string> = {
   running: 'var(--ok)',
@@ -43,7 +53,11 @@ const REMOTE_STATE_LABEL: Record<RemoteDeploymentState, string> = {
   failed: 'FAIL',
 }
 
-export default function DeploymentsPanel() {
+interface DeploymentsPanelProps {
+  onOpenTemplates: (query: string) => void
+}
+
+export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelProps) {
   const [deployments, setDeployments] = useState<Deployment[]>([])
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -56,6 +70,73 @@ export default function DeploymentsPanel() {
   const [remoteOpenId, setRemoteOpenId] = useState<string | null>(null)
   const [remoteLogs, setRemoteLogs] = useState<Record<string, string>>({})
   const stopRuntimeServices = useStore(s => s.stopRuntimeServices)
+  const tabs = useStore(s => s.tabs)
+  const activeTabId = useStore(s => s.activeTabId)
+  const switchTab = useStore(s => s.switchTab)
+  const workflowRevision = useStore(s => s.workflowRevision)
+  const workflowMetadata = useStore(s => s.workflowMetadata)
+  const setWorkflowRequirements = useStore(s => s.setWorkflowRequirements)
+  const nodes = useStore(s => s.nodes)
+  const nodeDefs = useStore(s => s.nodeDefs)
+  const updateParam = useStore(s => s.updateParam)
+  const selectNode = useStore(s => s.selectNode)
+  const [robotProfiles, setRobotProfiles] = useState<DeviceRobotProfile[]>([])
+  const [calibrations, setCalibrations] = useState<DeviceCalibrationCandidate[]>([])
+  const [targetStatus, setTargetStatus] = useState<HardwareDeviceStatus | null>(null)
+  const [requirementsBusy, setRequirementsBusy] = useState(false)
+  const [profileBusyId, setProfileBusyId] = useState<string | null>(null)
+
+  const requiredCapabilities = Array.isArray(workflowMetadata.required_capabilities)
+    ? workflowMetadata.required_capabilities.map(String)
+    : []
+  const selectedCalibration = (
+    workflowMetadata.device_calibration
+    && typeof workflowMetadata.device_calibration === 'object'
+  )
+    ? workflowMetadata.device_calibration
+    : null
+  const robotNodes = useMemo(
+    () => nodes.filter(node => ROBOT_NODE_TYPES.has(node.data.type)),
+    [nodes],
+  )
+  const isCalibrationWorkflow = nodes.some(
+    node => node.data.type === 'RobotCalibrationRecorder',
+  )
+  const calibrationNode = nodes.find(
+    node => node.data.type === 'RobotCalibrationRecorder',
+  )
+  const deploymentWorkflowTab = tabs.find(tab => {
+    if (tab.id === activeTabId || !tab.graph) return false
+    const graphNodes = Array.isArray(tab.graph.nodes) ? tab.graph.nodes : []
+    const nodeTypes = graphNodes.map(node => String(node?.type ?? node?.data?.type ?? ''))
+    return (
+      nodeTypes.some(type => ROBOT_NODE_TYPES.has(type))
+      && !nodeTypes.includes('RobotCalibrationRecorder')
+    )
+  })
+  const hasJointMotion = nodes.some(
+    node => JOINT_MOTION_NODE_TYPES.has(node.data.type),
+  )
+  const inferredCapabilities = robotNodes.length > 0
+    ? [
+        ...(hasJointMotion && !isCalibrationWorkflow ? ['joint_group'] : []),
+        'position_feedback',
+        'servo_bus',
+      ].sort()
+    : requiredCapabilities
+  const activeCalibration = targetStatus?.calibration
+  const selectedCalibrationCandidate = calibrations.find(
+    calibration => (
+      calibration.profile_id === selectedCalibration?.profile_id
+      && calibration.hardware_id === selectedCalibration?.hardware_id
+    ),
+  )
+  const calibrationIsActive = Boolean(
+    selectedCalibration
+    && targetStatus?.calibrated
+    && activeCalibration?.profile_id === selectedCalibration.profile_id
+    && activeCalibration?.hardware_id === selectedCalibration.hardware_id
+  )
 
   const refresh = async () => {
     try {
@@ -71,6 +152,119 @@ export default function DeploymentsPanel() {
     const id = window.setInterval(refresh, REFRESH_INTERVAL_MS)
     return () => window.clearInterval(id)
   }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    const loadRequirements = async () => {
+      try {
+        const calibrationResult = await api.listGraphCalibrations()
+        if (cancelled) return
+        setRobotProfiles(calibrationResult.profiles ?? [])
+        setCalibrations(calibrationResult.calibrations)
+        if (!selectedDeviceId) {
+          setTargetStatus(null)
+          return
+        }
+        try {
+          const status = await api.deviceStatus(selectedDeviceId)
+          if (!cancelled) setTargetStatus(status)
+        } catch {
+          if (!cancelled) setTargetStatus(null)
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      }
+    }
+    void loadRequirements()
+    return () => { cancelled = true }
+  }, [activeTabId, selectedDeviceId, workflowRevision])
+
+  const updateRequirements = async (
+    capabilities: string[],
+    calibration: { profile_id: string; hardware_id: string } | null,
+  ) => {
+    setRequirementsBusy(true)
+    setError(null)
+    try {
+      await setWorkflowRequirements(capabilities, calibration)
+      setPreflight(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRequirementsBusy(false)
+    }
+  }
+
+  const selectCalibration = (value: string) => {
+    const calibration = calibrations.find(
+      item => `${item.profile_id}\u0000${item.hardware_id}` === value,
+    )
+    void updateRequirements(
+      inferredCapabilities,
+      calibration
+        ? { profile_id: calibration.profile_id, hardware_id: calibration.hardware_id }
+        : null,
+    )
+  }
+
+  const changeRobotProfile = async (nodeId: string, profileId: string) => {
+    setProfileBusyId(nodeId)
+    setError(null)
+    try {
+      await updateParam(nodeId, 'profile_id', profileId)
+      await setWorkflowRequirements(inferredCapabilities, null)
+      const calibrationResult = await api.listGraphCalibrations()
+      setRobotProfiles(calibrationResult.profiles ?? [])
+      setCalibrations(calibrationResult.calibrations)
+      setPreflight(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setProfileBusyId(null)
+    }
+  }
+
+  useEffect(() => {
+    if (
+      robotNodes.length !== 1
+      || calibrations.length !== 1
+      || selectedCalibration
+      || requirementsBusy
+      || profileBusyId
+      || !hasJointMotion
+      || isCalibrationWorkflow
+    ) return
+    const calibration = calibrations[0]
+    void updateRequirements(inferredCapabilities, {
+      profile_id: calibration.profile_id,
+      hardware_id: calibration.hardware_id,
+    })
+  }, [
+    calibrations,
+    inferredCapabilities.join('|'),
+    hasJointMotion,
+    isCalibrationWorkflow,
+    profileBusyId,
+    requirementsBusy,
+    robotNodes.length,
+    selectedCalibration,
+  ])
+
+  const activateCalibration = async () => {
+    if (!selectedDeviceId || !selectedCalibration) return
+    setBusy(true)
+    setError(null)
+    try {
+      await api.activateDeviceCalibration(selectedDeviceId)
+      const status = await api.deviceStatus(selectedDeviceId)
+      setTargetStatus(status)
+      setPreflight(await api.validateDeviceDeployment(selectedDeviceId))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
 
   useEffect(() => {
     if (!selectedDeviceId) {
@@ -193,6 +387,7 @@ export default function DeploymentsPanel() {
     setError(null)
     setPreflight(null)
     try {
+      await setWorkflowRequirements(inferredCapabilities, selectedCalibration)
       setPreflight(await api.validateDeviceDeployment(selectedDeviceId))
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -254,7 +449,7 @@ export default function DeploymentsPanel() {
   const remoteRunning = remoteDeployments.filter(d => d.state === 'running').length
 
   return (
-    <div className="bn-runs-panel">
+    <div className="bn-runs-panel bn-deploy-panel">
       <div className="bn-runs-toolbar">
         <div>
           <div className="bn-runs-title">Deployments</div>
@@ -269,30 +464,16 @@ export default function DeploymentsPanel() {
         </div>
       </div>
 
+      {error && <div className="bn-runs-error">{error}</div>}
+
       <div className="bn-deploy-target">
         <div className="bn-deploy-target-head">
           <div>
-            <div className="bn-deploy-target-title">Remote target</div>
-            <div className="bn-runs-subtitle">Validate, stage, and control the selected device</div>
-          </div>
-          <div className="bn-runs-actions">
-            <button
-              onClick={validateRemoteDeployment}
-              disabled={busy || !selectedDeviceId}
-              style={preflight?.ready ? miniButton : primaryButton}
-            >
-              Validate
-            </button>
-            {preflight?.ready && (
-              <>
-                <button onClick={() => stageRemote(false)} disabled={busy} style={miniButton}>
-                  Stage
-                </button>
-                <button onClick={() => stageRemote(true)} disabled={busy} style={primaryButton}>
-                  Stage & run
-                </button>
-              </>
-            )}
+            <div className="bn-deploy-target-title">Deploy one robot</div>
+            <div className="bn-runs-subtitle">
+              Choose the computer physically connected to this robot. Use a separate
+              deployment workflow for each additional robot.
+            </div>
           </div>
         </div>
         {devices.length > 0 ? (
@@ -313,11 +494,302 @@ export default function DeploymentsPanel() {
         ) : (
           <div className="bn-device-help">Pair a Raspberry Pi in the Devices tab first.</div>
         )}
+
+        <div className="bn-robot-deploy-steps">
+          <section className={`bn-robot-deploy-step${robotNodes.length > 0 ? ' is-complete' : ' is-needed'}`}>
+            <div className="bn-robot-step-number">1</div>
+            <div className="bn-robot-step-content">
+              <div className="bn-robot-step-title">Choose one robot profile</div>
+              <div className="bn-robot-step-help">
+                The profile describes this robot’s model, joints, servo IDs, and driver.
+              </div>
+
+              {robotNodes.length === 0 ? (
+                <div className="bn-robot-step-empty">
+                  <strong>No Robot node is in this workflow.</strong>
+                  <span>Start with a robot workflow, then return here to deploy it.</span>
+                  <button
+                    type="button"
+                    onClick={() => onOpenTemplates('SO-ARM101 Motion Test')}
+                    style={primaryButton}
+                  >
+                    Open robot starter
+                  </button>
+                </div>
+              ) : (
+                <div className="bn-robot-profile-list">
+                  {robotNodes.length > 1 && (
+                    <div className="bn-robot-step-status is-warning">
+                      This workflow contains {robotNodes.length} robot connections. Keep one
+                      Robot node in each deployable workflow, then deploy the robots one at a time.
+                    </div>
+                  )}
+                  {robotNodes.map((node, index) => {
+                    const definition = nodeDefs[node.data.type]
+                    const currentProfile = String(
+                      node.data.params?.profile_id
+                      ?? definition?.input_defaults?.profile_id
+                      ?? 'so_arm101',
+                    )
+                    const choices = Array.from(new Set([
+                      currentProfile,
+                      ...robotProfiles.map(profile => profile.id),
+                      ...(definition?.input_choices?.profile_id ?? []),
+                    ])).filter(Boolean)
+                    const fallbackName = node.data.type === 'RobotProfileLoad'
+                      ? 'Legacy Robot'
+                      : 'Robot'
+                    const nodeName = String(
+                      node.data.params?.label
+                      || (robotNodes.length === 1 ? fallbackName : `${fallbackName} ${index + 1}`),
+                    )
+                    return (
+                      <div className="bn-robot-profile-row" key={node.id}>
+                        <label>
+                          <span>{nodeName}</span>
+                          <select
+                            className="bn-deploy-device-select"
+                            value={currentProfile}
+                            disabled={profileBusyId === node.id}
+                            onChange={event => {
+                              void changeRobotProfile(node.id, event.target.value)
+                            }}
+                          >
+                            {choices.map(profileId => {
+                              const profile = robotProfiles.find(item => item.id === profileId)
+                              const calibrationLabel = profile?.calibration_count
+                                ? ` · ${profile.calibration_count} calibration${profile.calibration_count === 1 ? '' : 's'}`
+                                : ''
+                              return (
+                                <option value={profileId} key={profileId}>
+                                  {profile?.name || profileId}{calibrationLabel}
+                                </option>
+                              )
+                            })}
+                          </select>
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => selectNode(node.id)}
+                          style={miniButton}
+                        >
+                          Show node
+                        </button>
+                      </div>
+                    )
+                  })}
+                  <button
+                    type="button"
+                    className="bn-robot-setup-action"
+                    onClick={() => onOpenTemplates('Editable SO-ARM101 Robot Profile')}
+                    style={miniButton}
+                  >
+                    Create or edit robot profile
+                  </button>
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className={`bn-robot-deploy-step${
+            isCalibrationWorkflow || !hasJointMotion || calibrationIsActive
+              ? ' is-complete'
+              : calibrations.length > 0
+              ? ' is-pending'
+              : ' is-needed'
+          }`}>
+            <div className="bn-robot-step-number">2</div>
+            <div className="bn-robot-step-content">
+              <div className="bn-robot-step-title">Prepare the safety calibration</div>
+              <div className="bn-robot-step-help">
+                Calibration saves this physical robot’s neutral Home position and safe joint ranges.
+              </div>
+
+              {isCalibrationWorkflow ? (
+                <>
+                  <div className="bn-robot-step-status is-info">
+                    <strong>This tab creates calibrations; it does not choose one for deployment.</strong>
+                    {' '}
+                    Name and record the calibration here, then return to the robot workflow.
+                    Its Step 2 contains the calibration picker.
+                  </div>
+                  {calibrationNode && (
+                    <button
+                      type="button"
+                      className="bn-robot-setup-action"
+                      onClick={() => selectNode(calibrationNode.id)}
+                      style={primaryButton}
+                    >
+                      Open calibration controls
+                    </button>
+                  )}
+                  {deploymentWorkflowTab ? (
+                    <button
+                      type="button"
+                      className="bn-robot-setup-action"
+                      onClick={() => void switchTab(deploymentWorkflowTab.id)}
+                      style={primaryButton}
+                    >
+                      Return to {deploymentWorkflowTab.name} and choose calibration
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="bn-robot-setup-action"
+                      onClick={() => onOpenTemplates('SO-ARM101 Motion Test')}
+                      style={miniButton}
+                    >
+                      Open robot deployment workflow
+                    </button>
+                  )}
+                  {calibrations.length > 0 && (
+                    <div className="bn-robot-step-status">
+                      {calibrations.length} saved calibration{calibrations.length === 1 ? '' : 's'}
+                      {' '}
+                      match this profile. You will choose one after returning to the deployment
+                      workflow.
+                    </div>
+                  )}
+                </>
+              ) : robotNodes.length === 0 ? (
+                <div className="bn-robot-step-status">
+                  A robot calibration will appear here after the workflow has a Robot node.
+                </div>
+              ) : !hasJointMotion ? (
+                <div className="bn-robot-step-status is-info">
+                  This workflow only reads robot state, so a safety calibration is optional.
+                  Blacknode will require one automatically when motion controls are added.
+                </div>
+              ) : robotNodes.length > 1 ? (
+                <div className="bn-robot-step-status is-warning">
+                  Calibration is selected per deployment. Split this graph so it contains one
+                  Robot node, then choose that physical robot’s calibration below.
+                </div>
+              ) : calibrations.length === 0 ? (
+                <div className="bn-robot-step-empty">
+                  <strong>No saved calibration matches this profile.</strong>
+                  <span>
+                    Open the guided workflow, calibrate this connected robot locally, then return
+                    here and select the saved calibration.
+                  </span>
+                </div>
+              ) : (
+                <>
+                  <label className="bn-robot-calibration-choice">
+                    <span>Calibration for this robot</span>
+                    <select
+                      className="bn-deploy-device-select"
+                      value={selectedCalibration
+                        ? `${selectedCalibration.profile_id}\u0000${selectedCalibration.hardware_id}`
+                        : ''}
+                      disabled={requirementsBusy}
+                      onChange={event => selectCalibration(event.target.value)}
+                    >
+                      {calibrations.length > 1 && (
+                        <option value="">
+                          Choose one of {calibrations.length} saved calibrations…
+                        </option>
+                      )}
+                      {calibrations.map(calibration => (
+                        <option
+                          key={`${calibration.profile_id}\u0000${calibration.hardware_id}`}
+                          value={`${calibration.profile_id}\u0000${calibration.hardware_id}`}
+                        >
+                          {calibration.name} · {calibration.profile_name}
+                          {' · '}
+                          {calibration.hardware_id}
+                          {' · '}
+                          {formatCalibrationTime(calibration.recorded_at)}
+                          {' · '}
+                          {calibration.joint_count} joints
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  {calibrationIsActive ? (
+                    <div className="bn-robot-step-status is-success">
+                      Ready: {activeCalibration?.name
+                        || selectedCalibrationCandidate?.name
+                        || 'this calibration'} is active on
+                      {' '}
+                      {targetStatus?.device_id || 'the device'}.
+                    </div>
+                  ) : (
+                    <div className="bn-robot-calibration-activate">
+                      <div className="bn-robot-step-status is-warning">
+                        {selectedCalibration
+                          ? 'Saved calibration found. Activate it on the connected, disarmed device.'
+                          : 'Choose which physical robot is connected to this device.'}
+                      </div>
+                      <button
+                        onClick={() => void activateCalibration()}
+                        disabled={busy || requirementsBusy || !selectedDeviceId || !selectedCalibration}
+                        style={primaryButton}
+                      >
+                        Use this calibration
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+              {!isCalibrationWorkflow && robotNodes.length === 1 && (
+                <button
+                  type="button"
+                  className="bn-robot-setup-action"
+                  onClick={() => onOpenTemplates('Guided Calibration')}
+                  style={calibrations.length === 0 ? primaryButton : miniButton}
+                >
+                  {calibrations.length === 0
+                    ? 'Create calibration'
+                    : 'Create another calibration'}
+                </button>
+              )}
+            </div>
+          </section>
+
+          <section className={`bn-robot-deploy-step${preflight?.ready ? ' is-complete' : ''}`}>
+            <div className="bn-robot-step-number">3</div>
+            <div className="bn-robot-step-content">
+              <div className="bn-robot-step-title">Check and deploy</div>
+              <div className="bn-robot-step-help">
+                Blacknode selected the workflow requirements automatically:
+                {' '}
+                {inferredCapabilities.length > 0
+                  ? inferredCapabilities.join(', ')
+                  : 'no device-specific capabilities'}.
+              </div>
+              <div className="bn-robot-step-actions">
+                <button
+                  onClick={validateRemoteDeployment}
+                  disabled={
+                    busy
+                    || requirementsBusy
+                    || Boolean(profileBusyId)
+                    || !selectedDeviceId
+                    || robotNodes.length > 1
+                  }
+                  style={preflight?.ready ? miniButton : primaryButton}
+                >
+                  Check setup
+                </button>
+                {preflight?.ready && (
+                  <>
+                    <button onClick={() => stageRemote(false)} disabled={busy} style={miniButton}>
+                      Send to device
+                    </button>
+                    <button onClick={() => stageRemote(true)} disabled={busy} style={primaryButton}>
+                      Send &amp; run
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          </section>
+        </div>
       </div>
 
       {preflight && <PreflightResult result={preflight} />}
-
-      {error && <div className="bn-runs-error">{error}</div>}
 
       <div className="bn-deployment-section-head">
         <div>
@@ -619,6 +1091,12 @@ function formatTime(value: string | null): string {
   if (!value) return '--'
   const date = new Date(value)
   return Number.isNaN(date.getTime()) ? value : date.toLocaleTimeString()
+}
+
+function formatCalibrationTime(value: string): string {
+  if (!value) return 'date unknown'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
 }
 
 const miniButton: CSSProperties = {

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -5,6 +5,7 @@ type DeviceState = {
   status?: HardwareDeviceStatus
   error?: string
   loading?: boolean
+  checkedAt?: number
 }
 
 export default function DevicesPanel() {
@@ -21,13 +22,17 @@ export default function DevicesPanel() {
     setStates(prev => ({ ...prev, [device.id]: { ...prev[device.id], loading: true } }))
     try {
       const status = await api.deviceStatus(device.id)
-      setStates(prev => ({ ...prev, [device.id]: { status, loading: false } }))
+      setStates(prev => ({
+        ...prev,
+        [device.id]: { status, loading: false, checkedAt: Date.now() },
+      }))
     } catch (err) {
       setStates(prev => ({
         ...prev,
         [device.id]: {
           error: err instanceof Error ? err.message : String(err),
           loading: false,
+          checkedAt: Date.now(),
         },
       }))
     }
@@ -65,7 +70,7 @@ export default function DevicesPanel() {
       await refresh()
       setStates(prev => ({
         ...prev,
-        [result.device.id]: { status: result.status, loading: false },
+        [result.device.id]: { status: result.status, loading: false, checkedAt: Date.now() },
       }))
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -193,6 +198,7 @@ function DeviceRow({ device, state, busy, onRefresh, onRepair, onRemove }: {
   const connected = Boolean(status?.connected)
   const color = online ? (connected ? 'var(--ok)' : 'var(--warn)') : 'var(--err)'
   const label = state?.loading ? 'CHECK' : online ? (connected ? 'READY' : 'ONLINE') : 'OFF'
+  const recoveryHint = hardwareRecoveryHint(status?.error)
 
   return (
     <div className="bn-run-row is-expanded" style={{ '--run-status': color } as CSSProperties}>
@@ -209,8 +215,13 @@ function DeviceRow({ device, state, busy, onRefresh, onRepair, onRemove }: {
             <span>token {device.token_fingerprint}</span>
             {status?.joint_names && <span>{status.joint_names.length} joints</span>}
           </div>
-          {state?.error && <div className="bn-run-error-line">{state.error}</div>}
-          {status?.error && <div className="bn-run-error-line">{status.error}</div>}
+          {state?.error && (
+            <div className="bn-run-error-line bn-device-error" role="alert">{state.error}</div>
+          )}
+          {status?.error && (
+            <div className="bn-run-error-line bn-device-error" role="alert">{status.error}</div>
+          )}
+          {recoveryHint && <div className="bn-device-recovery-hint">{recoveryHint}</div>}
         </div>
         <div className="bn-run-status">
           <span className="bn-run-status-pill">{label}</span>
@@ -222,6 +233,7 @@ function DeviceRow({ device, state, busy, onRefresh, onRepair, onRemove }: {
           <DeviceFact label="Armed" value={status ? (status.armed ? 'Yes' : 'No') : '—'} warn={Boolean(status?.armed)} />
           <DeviceFact label="Calibrated" value={status?.calibrated == null ? '—' : status.calibrated ? 'Yes' : 'No'} />
           <DeviceFact label="Capabilities" value={status?.capabilities?.join(', ') || '—'} />
+          <DeviceFact label="Last check" value={formatCheckedAt(state?.checkedAt)} />
         </div>
         <div className="bn-run-detail-actions">
           <button onClick={onRefresh} disabled={busy || state?.loading} style={miniButton}>Check</button>
@@ -231,6 +243,19 @@ function DeviceRow({ device, state, busy, onRefresh, onRepair, onRemove }: {
       </div>
     </div>
   )
+}
+
+function hardwareRecoveryHint(error?: string): string | null {
+  if (!error) return null
+  const normalized = error.toLowerCase()
+  if (normalized.includes('no response from servo') || normalized.includes('no position response from servo')) {
+    return 'The latest check reached the device service, but the servo bus did not answer. Check servo power, bus wiring, the configured serial port, baud rate, and servo IDs. On the device, run ./probe.sh --servos 6.'
+  }
+  return null
+}
+
+function formatCheckedAt(checkedAt?: number): string {
+  return checkedAt ? new Date(checkedAt).toLocaleTimeString() : '—'
 }
 
 function DeviceFact({ label, value, warn = false }: { label: string; value: string; warn?: boolean }) {

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -31,7 +31,9 @@ const TOP_BAR_H = 44
 const RAIL_W = 78
 const PANEL_DEFAULT_W = 240
 const PANEL_MIN_W = 188
-const PANEL_MAX_W = 520
+const PANEL_DEPLOY_W = 460
+const PANEL_EXPANDED_W = 760
+const PANEL_MAX_W = 860
 const welcomeButtonStyle: React.CSSProperties = {
   border: '1px solid var(--line2)',
   borderRadius: 6,
@@ -147,16 +149,81 @@ const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
 ]
 
 export default function NodePalette() {
-  const { nodeTypes, nodeDefs, packages, nodes, selectedId, addNode, loadNodeTypes, learnedNodeHighlight } = useStore()
+  const {
+    nodeTypes,
+    nodeDefs,
+    packages,
+    nodes,
+    selectedId,
+    addNode,
+    loadNodeTypes,
+    learnedNodeHighlight,
+  } = useStore()
   const [activeTab, setActiveTab] = useState<Tab | null>('templates')
   const [showPackageWelcome, setShowPackageWelcome] = useState(false)
   const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_W)
+  const [panelExpanded, setPanelExpanded] = useState(false)
+  const [templateSearch, setTemplateSearch] = useState('')
+  const [templateOpenInNewTab, setTemplateOpenInNewTab] = useState(false)
   const [openGroups, setOpenGroups] = useState<Set<string>>(() => new Set())
   const dragRef = useRef<{ startX: number; startW: number } | null>(null)
+  const compactWidthRef = useRef(PANEL_DEPLOY_W)
+
+  const clampPanelWidth = (width: number) => {
+    const viewportMax = Math.max(PANEL_MIN_W, window.innerWidth - RAIL_W - 220)
+    return Math.max(PANEL_MIN_W, Math.min(PANEL_MAX_W, viewportMax, width))
+  }
+
+  const selectTab = (tab: Tab) => {
+    if (activeTab === tab) {
+      setActiveTab(null)
+      return
+    }
+    setActiveTab(tab)
+    if (tab === 'templates') {
+      setTemplateSearch('')
+      setTemplateOpenInNewTab(false)
+    }
+    if (tab === 'deployments' && panelWidth < PANEL_DEPLOY_W) {
+      setPanelWidth(clampPanelWidth(PANEL_DEPLOY_W))
+    } else if (tab !== 'deployments' && panelExpanded) {
+      setPanelWidth(clampPanelWidth(compactWidthRef.current))
+      setPanelExpanded(false)
+    }
+  }
+
+  const togglePanelExpanded = () => {
+    if (panelExpanded) {
+      setPanelWidth(clampPanelWidth(compactWidthRef.current))
+      setPanelExpanded(false)
+      return
+    }
+    compactWidthRef.current = panelWidth
+    setPanelWidth(clampPanelWidth(PANEL_EXPANDED_W))
+    setPanelExpanded(true)
+  }
+
+  const openTemplateGuide = (query: string) => {
+    setTemplateSearch(query)
+    setTemplateOpenInNewTab(true)
+    setActiveTab('templates')
+    if (panelExpanded) {
+      setPanelWidth(clampPanelWidth(compactWidthRef.current))
+      setPanelExpanded(false)
+    }
+  }
 
   useEffect(() => {
     if (activeTab === 'nodes') loadNodeTypes()
   }, [activeTab, loadNodeTypes])
+
+  useEffect(() => {
+    const handleViewportResize = () => {
+      setPanelWidth(width => clampPanelWidth(width))
+    }
+    window.addEventListener('resize', handleViewportResize)
+    return () => window.removeEventListener('resize', handleViewportResize)
+  }, [])
 
   useEffect(() => {
     let active = true
@@ -187,7 +254,10 @@ export default function NodePalette() {
     dragRef.current = { startX: e.clientX, startW: panelWidth }
     const onMove = (ev: MouseEvent) => {
       if (!dragRef.current) return
-      setPanelWidth(Math.max(PANEL_MIN_W, Math.min(PANEL_MAX_W, dragRef.current.startW + ev.clientX - dragRef.current.startX)))
+      setPanelWidth(clampPanelWidth(
+        dragRef.current.startW + ev.clientX - dragRef.current.startX,
+      ))
+      setPanelExpanded(false)
     }
     const onUp = () => {
       dragRef.current = null
@@ -533,7 +603,7 @@ export default function NodePalette() {
             return (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(active ? null : tab.id)}
+                onClick={() => selectTab(tab.id)}
                 title={tab.label}
                 style={{
                   width: '100%',
@@ -619,6 +689,8 @@ export default function NodePalette() {
             borderBottom: '1px solid var(--line)',
             display: 'flex',
             alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 8,
             flexShrink: 0,
           }}>
             <span style={{
@@ -631,6 +703,27 @@ export default function NodePalette() {
             }}>
               {TABS.find(t => t.id === activeTab)?.label}
             </span>
+            {activeTab === 'deployments' && (
+              <button
+                type="button"
+                onClick={togglePanelExpanded}
+                title={panelExpanded ? 'Return the deployment panel to its previous width' : 'Expand the deployment panel'}
+                aria-label={panelExpanded ? 'Compact deployment panel' : 'Expand deployment panel'}
+                style={{
+                  padding: '4px 7px',
+                  border: '1px solid var(--line2)',
+                  borderRadius: 4,
+                  background: 'transparent',
+                  color: 'var(--tx2)',
+                  cursor: 'pointer',
+                  fontFamily: 'var(--font-ui)',
+                  fontSize: 9,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {panelExpanded ? 'Compact' : 'Expand'}
+              </button>
+            )}
           </div>
 
           <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
@@ -666,7 +759,10 @@ export default function NodePalette() {
             {/* ── TEMPLATES ── */}
             {activeTab === 'templates' && (
               <div style={{ flex: 1, overflowY: 'auto' }}>
-                <TemplateGallery />
+                <TemplateGallery
+                  initialQuery={templateSearch}
+                  openInNewTab={templateOpenInNewTab}
+                />
               </div>
             )}
 
@@ -683,7 +779,9 @@ export default function NodePalette() {
             {/* ── RUNS ── */}
             {activeTab === 'runs' && <RunsPanel />}
 
-            {activeTab === 'deployments' && <DeploymentsPanel />}
+            {activeTab === 'deployments' && (
+              <DeploymentsPanel onOpenTemplates={openTemplateGuide} />
+            )}
 
             {activeTab === 'devices' && <DevicesPanel />}
 

--- a/editor/src/components/RunsPanel.tsx
+++ b/editor/src/components/RunsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type CSSProperties } from 'react'
-import { api, type RunRecord, type RunStatus, type RunSummary } from '../api'
+import { api, type RunRecord, type RunStatus, type RunSummary, type WorkflowMetadata } from '../api'
 import { useStore } from '../store'
 
 const REFRESH_INTERVAL_MS = 4000
@@ -349,6 +349,7 @@ function RunDetail({ runId, runStatus, onDelete }: { runId: string; runStatus: R
         {
           nodes: Object.values(record.workflow.node_meta ?? {}),
           edges: record.workflow.edges ?? [],
+          metadata: (record.workflow.metadata ?? {}) as WorkflowMetadata,
         },
       )
       clearReplay()

--- a/editor/src/components/TemplateGallery.tsx
+++ b/editor/src/components/TemplateGallery.tsx
@@ -10,8 +10,16 @@ import {
 } from '../api'
 import { useStore } from '../store'
 
-export default function TemplateGallery() {
-  const { loadGraph, loadNodeTypes, organizeNodes } = useStore()
+interface TemplateGalleryProps {
+  initialQuery?: string
+  openInNewTab?: boolean
+}
+
+export default function TemplateGallery({
+  initialQuery = '',
+  openInNewTab = false,
+}: TemplateGalleryProps) {
+  const { loadGraph, loadNodeTypes, openGraphAsTab, organizeNodes } = useStore()
   const [templates, setTemplates] = useState<TemplateMeta[]>([])
   const [loading, setLoading] = useState<string | null>(null)
   const [loaded, setLoaded] = useState<string | null>(null)
@@ -20,7 +28,11 @@ export default function TemplateGallery() {
   const [missing, setMissing] = useState<Record<string, TemplateDependencyError>>({})
   const [error, setError] = useState<string | null>(null)
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set())
-  const [query, setQuery] = useState('')
+  const [query, setQuery] = useState(initialQuery)
+
+  useEffect(() => {
+    setQuery(initialQuery)
+  }, [initialQuery])
 
   const templateGroups = useMemo(() => {
     const groups = new Map<string, { name: string; color: string; templates: TemplateMeta[] }>()
@@ -77,9 +89,18 @@ export default function TemplateGallery() {
     setLoading(template.slug)
     setLoaded(null)
     const previousGraph = await api.getGraph().catch(() => null)
+    let openedNewTab = false
     try {
       await api.loadTemplate(template.slug)
-      await loadGraph()
+      if (openInNewTab && previousGraph) {
+        const templateGraph = await api.getGraph()
+        await api.setGraph(previousGraph.nodes, previousGraph.edges, previousGraph.metadata)
+        await loadGraph()
+        await openGraphAsTab(template.name, templateGraph)
+        openedNewTab = true
+      } else {
+        await loadGraph()
+      }
       await loadNodeTypes()
       await organizeNodes()
       window.dispatchEvent(new Event('blacknode:fit-view'))
@@ -89,6 +110,15 @@ export default function TemplateGallery() {
         delete next[template.slug]
         return next
       })
+      if (openedNewTab) {
+        window.dispatchEvent(new CustomEvent('blacknode:notice', {
+          detail: {
+            kind: 'info',
+            title: `${template.name} opened`,
+            message: 'The deployment workflow remains available in its original tab.',
+          },
+        }))
+      }
     } catch (err) {
       console.error(err)
       const dependencyError = templateDependencyError(err)
@@ -96,8 +126,8 @@ export default function TemplateGallery() {
         setMissing(current => ({ ...current, [template.slug]: dependencyError }))
         return
       }
-      if (previousGraph) {
-        await api.setGraph(previousGraph.nodes, previousGraph.edges).catch(console.error)
+      if (previousGraph && !openedNewTab) {
+        await api.setGraph(previousGraph.nodes, previousGraph.edges, previousGraph.metadata).catch(console.error)
         await loadGraph().catch(console.error)
       }
       window.dispatchEvent(new CustomEvent('blacknode:notice', {
@@ -182,7 +212,9 @@ export default function TemplateGallery() {
         padding: '2px 4px 8px',
         lineHeight: 1.5,
       }}>
-        One-click starter graphs. Loads into the canvas.
+        {openInNewTab
+          ? 'Choose a setup guide. It opens in a new workflow tab and keeps your deployment workflow unchanged.'
+          : 'One-click starter graphs. Loads into the canvas.'}
       </div>
 
       <input

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -651,7 +651,7 @@ body {
 
 .bn-device-facts {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 6px;
   margin-bottom: 10px;
 }
@@ -706,6 +706,8 @@ body {
 
 .bn-deploy-device-select {
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
   margin-top: 8px;
   padding: 6px 7px;
   background: var(--panel);
@@ -729,6 +731,7 @@ body {
 .bn-preflight-summary {
   display: flex;
   align-items: baseline;
+  flex-wrap: wrap;
   gap: 7px;
   padding: 8px 12px;
   border-bottom: 1px solid var(--line);
@@ -740,8 +743,10 @@ body {
 }
 
 .bn-preflight-summary span {
+  min-width: 0;
   color: var(--tx3);
   font-family: var(--font-mono);
+  overflow-wrap: anywhere;
 }
 
 .bn-preflight-summary.is-ready strong {
@@ -785,6 +790,7 @@ body {
   color: var(--tx3);
   font-size: 10px;
   line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .bn-preflight-pill {
@@ -982,6 +988,279 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.bn-robot-deploy-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.bn-robot-deploy-step {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 9px;
+  padding: 10px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+.bn-robot-deploy-step.is-complete {
+  border-color: color-mix(in srgb, var(--ok) 48%, var(--line));
+}
+
+.bn-robot-deploy-step.is-needed {
+  border-color: color-mix(in srgb, var(--warn) 52%, var(--line));
+}
+
+.bn-robot-step-number {
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line2);
+  border-radius: 50%;
+  color: var(--tx2);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.bn-robot-deploy-step.is-complete .bn-robot-step-number {
+  color: var(--ok);
+  border-color: var(--ok);
+}
+
+.bn-robot-deploy-step.is-needed .bn-robot-step-number {
+  color: var(--warn);
+  border-color: var(--warn);
+}
+
+.bn-robot-step-content {
+  min-width: 0;
+}
+
+.bn-robot-step-title {
+  color: var(--tx1);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.bn-robot-step-help {
+  margin-top: 3px;
+  color: var(--tx3);
+  font-size: 10px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.bn-robot-profile-list {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-top: 9px;
+}
+
+.bn-robot-profile-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 6px;
+}
+
+.bn-robot-profile-row label,
+.bn-robot-calibration-choice {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bn-robot-profile-row label > span,
+.bn-robot-calibration-choice > span {
+  color: var(--tx3);
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.bn-robot-profile-row .bn-deploy-device-select,
+.bn-robot-calibration-choice .bn-deploy-device-select {
+  margin-top: 0;
+}
+
+.bn-robot-step-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  margin-top: 9px;
+  padding: 8px;
+  background: var(--lift);
+  border-radius: 5px;
+  color: var(--tx3);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.bn-robot-step-empty strong {
+  color: var(--tx2);
+}
+
+.bn-robot-guide-link {
+  align-self: flex-start;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: var(--accent);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  text-align: left;
+}
+
+.bn-robot-setup-action {
+  align-self: flex-start;
+  margin-top: 9px;
+}
+
+.bn-robot-calibration-choice {
+  margin-top: 9px;
+}
+
+.bn-robot-calibration-choice + .bn-robot-step-status,
+.bn-robot-calibration-choice + .bn-robot-calibration-activate {
+  margin-bottom: 7px;
+}
+
+.bn-robot-step-status {
+  margin-top: 8px;
+  padding: 7px 8px;
+  background: var(--lift);
+  border-left: 2px solid var(--line2);
+  border-radius: 3px;
+  color: var(--tx3);
+  font-size: 10px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.bn-robot-step-status.is-success {
+  color: var(--ok);
+  border-left-color: var(--ok);
+}
+
+.bn-robot-step-status.is-warning {
+  color: var(--warn);
+  border-left-color: var(--warn);
+}
+
+.bn-robot-step-status.is-info {
+  color: var(--accent);
+  border-left-color: var(--accent);
+}
+
+.bn-robot-calibration-activate,
+.bn-robot-step-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.bn-robot-calibration-activate .bn-robot-step-status {
+  flex: 1 1 240px;
+  margin-top: 0;
+}
+
+.bn-deploy-panel {
+  container-name: deployment-panel;
+  container-type: inline-size;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.bn-deploy-panel > .bn-runs-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  flex: 0 0 auto;
+  background: var(--panel);
+}
+
+.bn-deploy-panel > .bn-runs-list {
+  flex: 0 0 auto;
+  min-height: auto;
+  overflow: visible;
+}
+
+.bn-deploy-panel .bn-preflight-checks {
+  max-height: none;
+  overflow: visible;
+}
+
+.bn-deploy-panel .bn-run-error-line,
+.bn-deploy-panel .bn-run-node,
+.bn-deploy-panel .bn-run-badges span {
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+@container deployment-panel (max-width: 620px) {
+  .bn-deploy-target-head,
+  .bn-deploy-panel > .bn-runs-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .bn-deploy-target-head .bn-runs-actions,
+  .bn-deploy-panel > .bn-runs-toolbar .bn-runs-actions {
+    justify-content: flex-start;
+  }
+
+  .bn-robot-calibration-activate {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
+@container deployment-panel (max-width: 330px) {
+  .bn-robot-profile-row {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .bn-deploy-panel .bn-run-summary {
+    grid-template-columns: 16px minmax(0, 1fr);
+  }
+
+  .bn-deploy-panel .bn-run-status {
+    grid-column: 2;
+    align-items: flex-start;
+    white-space: normal;
+  }
+}
+
+.bn-run-error-line.bn-device-error {
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.bn-device-recovery-hint {
+  margin-top: 6px;
+  color: var(--warn);
+  font-size: 10px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .bn-run-status {

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -3,7 +3,7 @@ import {
   Node, Edge, addEdge, applyNodeChanges, applyEdgeChanges,
   NodeChange, EdgeChange, Connection,
 } from 'reactflow'
-import { api, type ApiKeyStatus, type CookEvent, type DriverInfo, type DriverStatus, type LearnedNodeSummary, type RunRecord, type RuntimeStopResult } from './api'
+import { api, type ApiKeyStatus, type CookEvent, type DriverInfo, type DriverStatus, type GraphSnapshot, type LearnedNodeSummary, type RunRecord, type RuntimeStopResult, type WorkflowMetadata } from './api'
 import { BnNodeDef, BnNodeMeta, BnPackage, ConnectionDraft, NodeCookState, SubnetFrame } from './types'
 import { VALUE_NODE_TYPES, registerDynamicColors } from './categories'
 import { portsCompatible, portColor } from './portColors'
@@ -35,11 +35,6 @@ export interface WorkflowTab {
   // as idle - and it has to hold for every node type, not the few whose
   // runtime happens to report which node owns its work.
   liveState?: Record<string, Record<string, unknown>>
-}
-
-interface GraphSnapshot {
-  nodes: any[]
-  edges: any[]
 }
 
 export interface NodeData extends BnNodeMeta, NodeCookState {}
@@ -104,6 +99,7 @@ interface Store {
   tabs: WorkflowTab[]
   activeTabId: string
   workflowRevision: number
+  workflowMetadata: WorkflowMetadata
   undoHistory: UndoSnapshot[]
   cookLog: CookLogEntry[]
   cookActive: boolean
@@ -145,6 +141,10 @@ interface Store {
   duplicateSavedWorkflow: (slug: string) => Promise<{ name: string; slug: string }>
   deleteWorkflow: (slug: string) => Promise<void>
   saveActiveTabSnapshot: () => Promise<GraphSnapshot | null>
+  setWorkflowRequirements: (
+    requiredCapabilities: string[],
+    deviceCalibration: { profile_id: string; hardware_id: string } | null,
+  ) => Promise<void>
 
   subnetStack: SubnetFrame[]
   diveIntoSubnet: (subnetId: string) => Promise<void>
@@ -944,6 +944,7 @@ function graphSnapshotFromState(s: Store): GraphSnapshot {
   return {
     nodes: Object.values(current.node_meta),
     edges: current.edges,
+    metadata: cloneDeep(s.workflowMetadata),
   }
 }
 
@@ -1252,7 +1253,7 @@ function cloneGraph(graph: GraphSnapshot): GraphSnapshot {
 }
 
 function blankGraph(): GraphSnapshot {
-  return { nodes: [], edges: [] }
+  return { nodes: [], edges: [], metadata: {} }
 }
 
 function cookStateFromTab(tab?: WorkflowTab): Pick<Store, 'cookLog' | 'cookActive' | 'cookStatusHidden'> {
@@ -1317,6 +1318,7 @@ export const useStore = create<Store>((set, get) => ({
   tabs: [{ id: 'default', name: 'Untitled', slug: null, dirty: false, graph: null, cookLog: [], cookActive: false, cookStatusHidden: false }],
   activeTabId: 'default',
   workflowRevision: 0,
+  workflowMetadata: {},
   undoHistory: [],
   cookLog: [],
   cookActive: false,
@@ -1604,9 +1606,14 @@ export const useStore = create<Store>((set, get) => ({
   },
 
   loadGraph: async () => {
-    const { nodes: bnNodes, edges: bnEdges } = await api.getGraph()
-    const parsed = parseGraph(bnNodes, bnEdges)
-    set({ nodes: ensureConnectedToolBoxSlots(parsed.nodes, parsed.edges), edges: parsed.edges, selectedId: null })
+    const graph = await api.getGraph()
+    const parsed = parseGraph(graph.nodes, graph.edges)
+    set({
+      nodes: ensureConnectedToolBoxSlots(parsed.nodes, parsed.edges),
+      edges: parsed.edges,
+      workflowMetadata: graph.metadata ?? {},
+      selectedId: null,
+    })
     await get().reattachRuntimeState()
   },
 
@@ -1630,6 +1637,27 @@ export const useStore = create<Store>((set, get) => ({
     }
   },
 
+  setWorkflowRequirements: async (requiredCapabilities, deviceCalibration) => {
+    const result = await api.updateWorkflowRequirements(
+      requiredCapabilities,
+      deviceCalibration,
+    )
+    set(s => ({
+      workflowMetadata: result.metadata,
+      tabs: s.tabs.map(tab => (
+        tab.id === s.activeTabId
+          ? {
+              ...tab,
+              dirty: true,
+              graph: tab.graph
+                ? { ...tab.graph, metadata: cloneDeep(result.metadata) }
+                : tab.graph,
+            }
+          : tab
+      )),
+    }))
+  },
+
   newTab: async (name) => {
     await get().saveActiveTabSnapshot()
     const id = makeTabId()
@@ -1643,7 +1671,7 @@ export const useStore = create<Store>((set, get) => ({
       cookStatusHidden: false,
     }))
     await api.reset()
-    set({ nodes: [], edges: [], selectedId: null })
+    set({ nodes: [], edges: [], workflowMetadata: {}, selectedId: null })
   },
 
   insertTab: async (tabId) => {
@@ -1664,7 +1692,7 @@ export const useStore = create<Store>((set, get) => ({
       cookStatusHidden: false,
     })
     await api.reset()
-    set({ nodes: [], edges: [] })
+    set({ nodes: [], edges: [], workflowMetadata: {} })
   },
 
   switchTab: async (tabId) => {
@@ -1678,7 +1706,7 @@ export const useStore = create<Store>((set, get) => ({
     set({ activeTabId: tabId, selectedId: null, undoHistory: [], ...cookStateFromTab(tab) })
     if (tab.graph) {
       const graph = cloneGraph(tab.graph)
-      await api.setGraph(graph.nodes, graph.edges)
+      await api.setGraph(graph.nodes, graph.edges, graph.metadata)
       await get().loadGraph()
       get().restoreTabLiveState(tabId)
     } else if (tab.slug) {
@@ -1688,7 +1716,7 @@ export const useStore = create<Store>((set, get) => ({
       get().restoreTabLiveState(tabId)
     } else {
       await api.reset()
-      set({ nodes: [], edges: [], selectedId: null })
+      set({ nodes: [], edges: [], workflowMetadata: {}, selectedId: null })
     }
   },
 
@@ -1704,6 +1732,7 @@ export const useStore = create<Store>((set, get) => ({
         activeTabId: tab.id,
         nodes: [],
         edges: [],
+        workflowMetadata: {},
         selectedId: null,
         subnetStack: [],
         undoHistory: [],
@@ -1720,7 +1749,7 @@ export const useStore = create<Store>((set, get) => ({
       set({ tabs: newTabs, activeTabId: next.id, selectedId: null, undoHistory: [], ...cookStateFromTab(next) })
       if (next.graph) {
         const graph = cloneGraph(next.graph)
-        await api.setGraph(graph.nodes, graph.edges)
+        await api.setGraph(graph.nodes, graph.edges, graph.metadata)
         await get().loadGraph()
       } else if (next.slug) {
         const graph = await api.loadWorkflow(next.slug)
@@ -1728,7 +1757,7 @@ export const useStore = create<Store>((set, get) => ({
         await get().loadGraph()
       } else {
         await api.reset()
-        set({ nodes: [], edges: [], selectedId: null })
+        set({ nodes: [], edges: [], workflowMetadata: {}, selectedId: null })
       }
     } else {
       set({ tabs: newTabs })
@@ -1769,7 +1798,7 @@ export const useStore = create<Store>((set, get) => ({
       cookActive: false,
       cookStatusHidden: false,
     })
-    await api.setGraph(graph.nodes, graph.edges)
+    await api.setGraph(graph.nodes, graph.edges, graph.metadata)
     await get().loadGraph()
   },
 
@@ -1808,7 +1837,7 @@ export const useStore = create<Store>((set, get) => ({
       cookActive: false,
       cookStatusHidden: false,
     }))
-    await api.setGraph(nextGraph.nodes, nextGraph.edges)
+    await api.setGraph(nextGraph.nodes, nextGraph.edges, nextGraph.metadata)
     await get().loadGraph()
   },
 
@@ -3377,11 +3406,12 @@ export const useStore = create<Store>((set, get) => ({
     if (idx < 0) return
 
     const snapshot = undoHistory[idx]
-    await api.setGraph(snapshot.graph.nodes, snapshot.graph.edges)
+    await api.setGraph(snapshot.graph.nodes, snapshot.graph.edges, snapshot.graph.metadata)
     dragUndoActive = false
     set(s => ({
       nodes: cloneDeep(snapshot.nodes),
       edges: cloneDeep(snapshot.edges),
+      workflowMetadata: cloneDeep(snapshot.graph.metadata),
       subnetStack: cloneDeep(snapshot.subnetStack),
       selectedId: snapshot.selectedId,
       undoHistory: undoHistory.slice(0, idx),
@@ -3395,6 +3425,7 @@ export const useStore = create<Store>((set, get) => ({
     set(s => ({
       nodes: [],
       edges: [],
+      workflowMetadata: {},
       selectedId: null,
       tabs: s.tabs.map(t =>
         t.id === s.activeTabId

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -447,7 +447,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         original_metadata = dict(server._session.metadata)
         original_node_meta = dict(server._session.node_meta)
         workflow = _workflow(["joint_group"])
-        robot_fn = server._NODE_REGISTRY["Robot"]
+        robot_fn = server._NODE_REGISTRY["Output"]
         workflow["node_meta"]["robot"] = {
             "id": "robot",
             "type": "Robot",
@@ -473,6 +473,7 @@ class EditorDeviceApiTests(unittest.TestCase):
                 },
             }
             with (
+                patch.dict(server._NODE_REGISTRY, {"Robot": robot_fn}),
                 patch.dict("os.environ", {"BLACKNODE_ROBOTS_DIR": str(robots_root)}),
                 patch("device_registry.urllib.request.urlopen", side_effect=hardware),
             ):

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import subprocess
 import sys
@@ -78,6 +79,30 @@ class _HardwareService:
             raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", {}, None)
         if path == "/status":
             return _JsonResponse(self.status_payload)
+        if path == "/calibration":
+            if request.method == "POST":
+                calibration = body["calibration"]
+                profile = body["profile"]
+                active = {
+                    "active": True,
+                    "profile_id": profile["id"],
+                    "hardware_id": calibration["hardware_id"],
+                    "target_device_id": self.status_payload["device_id"],
+                    "activated_at": "2026-07-24T00:00:00+00:00",
+                    "joint_count": len(calibration["joints"]),
+                    "digest": "0123456789abcdef",
+                }
+                self.status_payload["calibrated"] = True
+                self.status_payload["calibration"] = {
+                    key: value
+                    for key, value in active.items()
+                    if key not in {"active", "target_device_id"}
+                }
+                return _JsonResponse({"ok": True, "calibration": active})
+            return _JsonResponse({
+                "active": bool(self.status_payload.get("calibrated")),
+                **(self.status_payload.get("calibration") or {}),
+            })
         if path == "/manifest":
             return _JsonResponse({
                 "service": "blacknode-runtime",
@@ -200,6 +225,43 @@ class EditorDeviceApiTests(unittest.TestCase):
     def tearDown(self):
         server._device_registry = self._original_registry
         self._tmp.cleanup()
+
+    def test_workflow_requirements_are_normalized_and_exposed_by_graph(self):
+        original_metadata = dict(server._session.metadata)
+        try:
+            server._session.metadata = {"required_packages": ["blacknode-robot"]}
+            with patch.object(server, "_save"):
+                response = self.client.patch("/graph/requirements", json={
+                    "required_capabilities": [
+                        "servo_bus",
+                        "joint_group",
+                        "servo_bus",
+                        "position_feedback",
+                    ],
+                    "device_calibration": {
+                        "profile_id": "so_arm101_v002",
+                        "hardware_id": "USB-SERIAL-42",
+                    },
+                })
+            graph = self.client.get("/graph").json()
+        finally:
+            server._session.metadata = original_metadata
+
+        self.assertEqual(response.status_code, 200)
+        metadata = response.json()["metadata"]
+        self.assertEqual(
+            metadata["required_capabilities"],
+            ["joint_group", "position_feedback", "servo_bus"],
+        )
+        self.assertEqual(
+            metadata["device_calibration"],
+            {
+                "profile_id": "so_arm101_v002",
+                "hardware_id": "USB-SERIAL-42",
+            },
+        )
+        self.assertEqual(metadata["required_packages"], ["blacknode-robot"])
+        self.assertEqual(graph["metadata"], metadata)
 
     def test_pairing_validates_and_keeps_token_out_of_api_responses(self):
         hardware = _HardwareService()
@@ -346,6 +408,142 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertFalse(checks["target_runtime"]["blocking"])
         self.assertFalse(report["ready"])
         self.assertNotIn(hardware.token, response.text)
+
+    def test_selected_calibration_can_be_activated_and_satisfies_preflight(self):
+        hardware = _HardwareService()
+        robots_root = Path(self._tmp.name) / "robots"
+        profile_dir = robots_root / "arm_profile"
+        calibration_dir = profile_dir / "calibrations"
+        calibration_dir.mkdir(parents=True)
+        profile = {
+            "schema_version": 1,
+            "id": "arm_profile",
+            "display_name": "Arm profile",
+            "joints": [
+                {"id": f"servo_{index}", "servo_id": index}
+                for index in range(1, 7)
+            ],
+        }
+        calibration = {
+            "schema_version": 1,
+            "name": "Workshop left arm",
+            "profile_id": "arm_profile",
+            "hardware_id": "USB-SERIAL-42",
+            "recorded_at": "2026-07-24T00:00:00Z",
+            "joints": {
+                f"servo_{index}": {
+                    "home_ticks": 2048,
+                    "safe_min_deg": -80.0,
+                    "safe_max_deg": 80.0,
+                }
+                for index in range(1, 7)
+            },
+        }
+        (profile_dir / "profile.json").write_text(json.dumps(profile), encoding="utf-8")
+        (calibration_dir / "usb_serial_42.json").write_text(
+            json.dumps(calibration),
+            encoding="utf-8",
+        )
+        original_metadata = dict(server._session.metadata)
+        original_node_meta = dict(server._session.node_meta)
+        workflow = _workflow(["joint_group"])
+        robot_fn = server._NODE_REGISTRY["Robot"]
+        workflow["node_meta"]["robot"] = {
+            "id": "robot",
+            "type": "Robot",
+            "params": {"profile_id": "arm_profile"},
+            "pos": [200, 0],
+            "inputs": list(getattr(robot_fn, "_bn_inputs", [])),
+            "outputs": list(getattr(robot_fn, "_bn_outputs", [])),
+            "input_types": dict(getattr(robot_fn, "_bn_input_types", {})),
+            "output_types": dict(getattr(robot_fn, "_bn_output_types", {})),
+            "input_defaults": dict(getattr(robot_fn, "_bn_input_defaults", {})),
+        }
+        workflow["metadata"]["device_calibration"] = {
+            "profile_id": "arm_profile",
+            "hardware_id": "USB-SERIAL-42",
+        }
+        try:
+            server._session.metadata = dict(workflow["metadata"])
+            server._session.node_meta = {
+                "robot": {
+                    "id": "robot",
+                    "type": "Robot",
+                    "params": {"profile_id": "arm_profile"},
+                },
+            }
+            with (
+                patch.dict("os.environ", {"BLACKNODE_ROBOTS_DIR": str(robots_root)}),
+                patch("device_registry.urllib.request.urlopen", side_effect=hardware),
+            ):
+                device_id = self.client.post("/devices", json={
+                    "name": "Workshop arm",
+                    "base_url": "http://192.168.1.87:8765",
+                    "token": hardware.token,
+                }).json()["device"]["id"]
+                candidates = self.client.get("/graph/calibrations")
+                activated = self.client.post(f"/devices/{device_id}/calibration")
+                preflight = self.client.post(
+                    f"/devices/{device_id}/deployment-preflight",
+                    json={"workflow": workflow},
+                )
+        finally:
+            server._session.metadata = original_metadata
+            server._session.node_meta = original_node_meta
+
+        self.assertEqual(candidates.status_code, 200)
+        listed_profile = next(
+            item
+            for item in candidates.json()["profiles"]
+            if item["id"] == "arm_profile"
+        )
+        self.assertEqual(listed_profile["name"], "Arm profile")
+        self.assertTrue(listed_profile["saved"])
+        self.assertEqual(listed_profile["calibration_count"], 1)
+        self.assertEqual(
+            candidates.json()["calibrations"][0]["hardware_id"],
+            "USB-SERIAL-42",
+        )
+        self.assertEqual(
+            candidates.json()["calibrations"][0]["name"],
+            "Workshop left arm",
+        )
+        self.assertEqual(activated.status_code, 200)
+        self.assertTrue(activated.json()["status"]["calibrated"])
+        checks = {item["id"]: item for item in preflight.json()["checks"]}
+        self.assertEqual(checks["calibration"]["status"], "pass")
+        self.assertFalse(checks["calibration"]["blocking"])
+        calibration_requests = [
+            item for item in hardware.requests if item[1] == "/calibration"
+        ]
+        self.assertEqual(len(calibration_requests), 1)
+        self.assertEqual(
+            calibration_requests[0][3]["calibration"]["hardware_id"],
+            "USB-SERIAL-42",
+        )
+
+    def test_old_device_service_reports_calibration_upgrade_action(self):
+        response = io.BytesIO(b'{"ok": false, "error": "not found"}')
+        error = urllib.error.HTTPError(
+            "http://192.168.1.87:8765/calibration",
+            404,
+            "Not Found",
+            {},
+            response,
+        )
+        client = device_registry.HardwareDeviceClient(
+            "http://192.168.1.87:8765",
+            "pairing-token",
+        )
+
+        with (
+            patch("device_registry.urllib.request.urlopen", side_effect=error),
+            self.assertRaisesRegex(
+                device_registry.DeviceRegistryError,
+                r"Update blacknode-hardware.*service\.sh restart",
+            ),
+        ):
+            client.activate_calibration({}, {})
 
     def test_deployment_preflight_keeps_runtime_unavailable_as_a_blocker(self):
         hardware = _HardwareService()


### PR DESCRIPTION
## What changed

- guides remote deployment through one robot profile, one named calibration, and one target device
- infers workflow capabilities and persists the selected calibration in workflow metadata
- keeps calibration/profile templates in separate tabs and adds direct setup actions
- reports legacy device-service calibration API errors with upgrade instructions
- improves deployment-panel sizing, button visibility, and long-message wrapping
- hardens Docker Desktop startup and adds a matching safe shutdown script

## Why

Robot setup exposed profile and calibration state without a clear sequence, template navigation could replace the deployment graph, and repeated Docker startup could leave the local environment stuck. This makes the deployment path explicit and preserves the user's workflow while setup tasks happen separately.

## Validation

- `python -m unittest discover -s tests -p test_editor_devices.py` — 20 passed
- `npm run build` in `editor/` — passed
- Docker readiness and script syntax checks — passed
