### PR TITLE
Bind deployments to explicit robot ports

### DIFF
--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -234,6 +234,24 @@ Credentials are referenced by a local credential ID or operating-system secret
 store. They are never embedded in workflows, deployment artifacts, browser
 responses, logs, or provider-neutral configuration.
 
+Each paired robot record uses the exact hardware service URL printed by
+`blacknode-hardware` pairing. On a multi-robot computer, hardware services use
+`8765`, `8767`, `8768`, and subsequent assigned ports. Port `8766` remains the
+shared deployment runtime. The editor requires the hardware port explicitly,
+rejects `8766` as a robot hardware endpoint, and derives the runtime URL from
+the same host.
+
+For a workflow containing one `Robot` node, deployment also embeds the serial
+path reported by the selected hardware service and disables runtime USB
+auto-discovery. This makes the editor device selection authoritative when
+multiple robots share one computer: each deployment opens the physical bus
+behind the paired service it targeted.
+
+Immediately before the runtime starts that workflow, the editor asks only the
+targeted hardware service to release its read-only serial monitor. Stopping or
+rolling back the deployment resumes that monitor. Other paired robot services
+and serial buses remain active.
+
 The deployment plan sends package source and version from the editor. The
 runtime package provider is generic: it does not contain a list of perception,
 robot, training, or other extension packages. Publishing a new extension

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -105,6 +105,12 @@ class HardwareDeviceClient:
         return self._request("POST", "/rpc", payload=payload)
 
     def validate_pairing(self) -> dict[str, Any]:
+        if urllib.parse.urlsplit(self.base_url).port == 8766:
+            raise DeviceRegistryError(
+                "Port 8766 is the shared Blacknode runtime, not a robot hardware "
+                "service. Use the hardware URL printed by './pair.sh --all --show', "
+                "such as port 8765 or 8767."
+            )
         health = self.health()
         if health.get("service") != "blacknode-hardware":
             raise DeviceRegistryError(

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -3103,6 +3103,87 @@ def _embed_selected_calibration(workflow: dict[str, Any]) -> None:
     meta["input_defaults"] = defaults
 
 
+def _bind_robot_to_device(
+    workflow: dict[str, Any],
+    remote_status: dict[str, Any],
+) -> None:
+    """Bind a one-robot deployment to the serial device behind its paired service."""
+    robot_nodes = _workflow_robot_nodes(workflow)
+    if not robot_nodes:
+        return
+    if len(robot_nodes) != 1:
+        raise ValueError(
+            "Deploy one Robot node per device so its physical hardware binding is unambiguous."
+        )
+    connection = (
+        remote_status.get("connection")
+        if isinstance(remote_status.get("connection"), dict)
+        else {}
+    )
+    serial_port = str(connection.get("port") or "").strip()
+    if str(connection.get("transport") or "").strip() != "serial" or not serial_port:
+        raise ValueError(
+            "The paired hardware service did not report its serial port. "
+            "Update blacknode-hardware and restart this robot service."
+        )
+    calibration = (
+        remote_status.get("calibration")
+        if isinstance(remote_status.get("calibration"), dict)
+        else {}
+    )
+    hardware_id = str(
+        calibration.get("hardware_id")
+        or remote_status.get("device_id")
+        or ""
+    ).strip()
+    if not hardware_id:
+        raise ValueError("The paired hardware service did not report a hardware identity.")
+
+    recommended = {
+        "path": serial_port,
+        "serial": hardware_id,
+        "serial_number": hardware_id,
+    }
+    hardware = {
+        "found": True,
+        "ready": bool(remote_status.get("connected")),
+        "port": serial_port,
+        "serial": hardware_id,
+        "recommended": recommended,
+        "devices": [recommended],
+        "permissions": {},
+        "report": (
+            "Deployment target\n"
+            f"serial_port: {serial_port}\n"
+            f"hardware_id: {hardware_id}"
+        ),
+    }
+    meta = robot_nodes[0]
+    params = meta.setdefault("params", {})
+    params["hardware"] = hardware
+    params["auto_discover"] = False
+    params["serial_port"] = serial_port
+    inputs = list(meta.get("inputs") or [])
+    for port in ("hardware", "auto_discover", "serial_port"):
+        if port not in inputs:
+            inputs.append(port)
+    meta["inputs"] = inputs
+    input_types = dict(meta.get("input_types") or {})
+    input_types.update({
+        "hardware": "Dict",
+        "auto_discover": "Bool",
+        "serial_port": "Text",
+    })
+    meta["input_types"] = input_types
+    defaults = dict(meta.get("input_defaults") or {})
+    defaults.update({
+        "hardware": {},
+        "auto_discover": True,
+        "serial_port": "",
+    })
+    meta["input_defaults"] = defaults
+
+
 @app.get("/graph/calibrations")
 def list_graph_calibrations():
     workflow = _device_deployment_workflow()
@@ -3405,6 +3486,28 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
         blocking=armed,
     ))
 
+    robot_nodes = _workflow_robot_nodes(workflow)
+    if robot_nodes:
+        try:
+            binding_probe = json.loads(json.dumps(workflow))
+            _bind_robot_to_device(binding_probe, remote_status)
+        except ValueError as exc:
+            checks.append(_preflight_check(
+                "hardware_binding",
+                "Robot hardware binding",
+                "fail",
+                str(exc),
+                blocking=True,
+            ))
+        else:
+            connection = remote_status.get("connection") or {}
+            checks.append(_preflight_check(
+                "hardware_binding",
+                "Robot hardware binding",
+                "pass",
+                f"Deployment will use {connection.get('port')}.",
+            ))
+
     required_capabilities = _workflow_required_capabilities(workflow)
     available_capabilities = sorted({
         str(item)
@@ -3684,6 +3787,31 @@ def _require_device_safe_to_start(device_id: str) -> None:
         )
 
 
+def _set_device_deployment_lease(device_id: str, *, leased: bool) -> None:
+    method = "release" if leased else "resume"
+    payload = {
+        "jsonrpc": "2.0",
+        "id": f"deployment-{method}",
+        "method": method,
+        "params": {},
+    }
+    try:
+        result = _paired_device_client(device_id).rpc(payload)
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+    error = result.get("error") if isinstance(result, dict) else None
+    if error:
+        message = (
+            str(error.get("message") or error)
+            if isinstance(error, dict)
+            else str(error)
+        )
+        raise HTTPException(
+            502,
+            f"Could not {method} the robot hardware monitor: {message}",
+        )
+
+
 @app.get("/devices/{device_id}/deployments")
 def list_device_deployments(device_id: str):
     try:
@@ -3719,6 +3847,7 @@ def stage_device_deployment(device_id: str, req: RemoteDeployReq):
         )
 
     try:
+        _bind_robot_to_device(workflow, preflight.get("status") or {})
         workflow["entrypoint"] = resolve_entrypoint(workflow)
         script = export_workflow_python(workflow)
     except (WorkflowRunError, ValueError) as exc:
@@ -3792,7 +3921,12 @@ def stage_device_deployment(device_id: str, req: RemoteDeployReq):
         deployment = client.stage_deployment(payload)
         if req.start:
             _require_device_safe_to_start(device_id)
-            deployment = client.start_deployment(str(deployment["id"]))
+            _set_device_deployment_lease(device_id, leased=True)
+            try:
+                deployment = client.start_deployment(str(deployment["id"]))
+            except Exception:
+                _set_device_deployment_lease(device_id, leased=False)
+                raise
     except DeviceRegistryError as exc:
         raise HTTPException(502, str(exc)) from exc
     return {
@@ -3813,18 +3947,24 @@ def get_device_deployment(device_id: str, deployment_id: str):
 @app.post("/devices/{device_id}/deployments/{deployment_id}/start")
 def start_device_deployment(device_id: str, deployment_id: str):
     _require_device_safe_to_start(device_id)
+    _set_device_deployment_lease(device_id, leased=True)
     try:
         return _runtime_client_or_404(device_id).start_deployment(deployment_id)
-    except DeviceRegistryError as exc:
-        raise HTTPException(502, str(exc)) from exc
+    except Exception as exc:
+        _set_device_deployment_lease(device_id, leased=False)
+        if isinstance(exc, DeviceRegistryError):
+            raise HTTPException(502, str(exc)) from exc
+        raise
 
 
 @app.post("/devices/{device_id}/deployments/{deployment_id}/stop")
 def stop_device_deployment(device_id: str, deployment_id: str):
     try:
-        return _runtime_client_or_404(device_id).stop_deployment(deployment_id)
+        deployment = _runtime_client_or_404(device_id).stop_deployment(deployment_id)
     except DeviceRegistryError as exc:
         raise HTTPException(502, str(exc)) from exc
+    _set_device_deployment_lease(device_id, leased=False)
+    return deployment
 
 
 @app.post("/devices/{device_id}/deployments/{deployment_id}/rollback")
@@ -3835,13 +3975,21 @@ def rollback_device_deployment(
 ):
     if req.start:
         _require_device_safe_to_start(device_id)
+        _set_device_deployment_lease(device_id, leased=True)
     try:
-        return _runtime_client_or_404(device_id).rollback_deployment(
+        deployment = _runtime_client_or_404(device_id).rollback_deployment(
             deployment_id,
             start=req.start,
         )
-    except DeviceRegistryError as exc:
-        raise HTTPException(502, str(exc)) from exc
+    except Exception as exc:
+        if req.start:
+            _set_device_deployment_lease(device_id, leased=False)
+        if isinstance(exc, DeviceRegistryError):
+            raise HTTPException(502, str(exc)) from exc
+        raise
+    if not req.start:
+        _set_device_deployment_lease(device_id, leased=False)
+    return deployment
 
 
 @app.get("/devices/{device_id}/deployments/{deployment_id}/logs")

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -8,12 +8,64 @@ type DeviceState = {
   checkedAt?: number
 }
 
+const DEFAULT_HARDWARE_URL = 'http://192.168.1.87:8765'
+const FIRST_HARDWARE_PORT = 8765
+const RUNTIME_PORT = 8766
+
+function suggestedHardwareUrl(devices: HardwareDevice[]): string {
+  const latest = devices[devices.length - 1]
+  if (!latest) return DEFAULT_HARDWARE_URL
+  try {
+    const latestUrl = new URL(latest.base_url)
+    const usedPorts = new Set(
+      devices.flatMap(device => {
+        try {
+          const parsed = new URL(device.base_url)
+          if (parsed.protocol !== latestUrl.protocol || parsed.hostname !== latestUrl.hostname) {
+            return []
+          }
+          return parsed.port ? [Number(parsed.port)] : []
+        } catch {
+          return []
+        }
+      }),
+    )
+    let port = FIRST_HARDWARE_PORT
+    while (port === RUNTIME_PORT || usedPorts.has(port)) port += 1
+    const host = latestUrl.hostname.includes(':')
+      ? `[${latestUrl.hostname}]`
+      : latestUrl.hostname
+    return `${latestUrl.protocol}//${host}:${port}`
+  } catch {
+    return DEFAULT_HARDWARE_URL
+  }
+}
+
+function hardwareUrlError(value: string): string | null {
+  let parsed: URL
+  try {
+    parsed = new URL(value.trim())
+  } catch {
+    return 'Enter the complete hardware URL printed by pair.sh.'
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return 'Hardware URL must start with http:// or https://.'
+  }
+  if (!parsed.port) {
+    return 'Include the hardware service port printed by pair.sh.'
+  }
+  if (Number(parsed.port) === RUNTIME_PORT) {
+    return 'Port 8766 is the shared Blacknode runtime. Use the robot hardware port printed by pair.sh, such as 8765 or 8767.'
+  }
+  return null
+}
+
 export default function DevicesPanel() {
   const [devices, setDevices] = useState<HardwareDevice[]>([])
   const [states, setStates] = useState<Record<string, DeviceState>>({})
   const [showForm, setShowForm] = useState(false)
   const [name, setName] = useState('')
-  const [baseUrl, setBaseUrl] = useState('http://192.168.1.87:8765')
+  const [baseUrl, setBaseUrl] = useState(DEFAULT_HARDWARE_URL)
   const [token, setToken] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -53,7 +105,7 @@ export default function DevicesPanel() {
 
   const openPairForm = (device?: HardwareDevice) => {
     setName(device?.name ?? '')
-    setBaseUrl(device?.base_url ?? 'http://192.168.1.87:8765')
+    setBaseUrl(device?.base_url ?? suggestedHardwareUrl(devices))
     setToken('')
     setError(null)
     setShowForm(true)
@@ -61,6 +113,11 @@ export default function DevicesPanel() {
 
   const pair = async (event: FormEvent) => {
     event.preventDefault()
+    const urlError = hardwareUrlError(baseUrl)
+    if (urlError) {
+      setError(urlError)
+      return
+    }
     setBusy(true)
     setError(null)
     try {
@@ -98,6 +155,8 @@ export default function DevicesPanel() {
     }
   }
 
+  const pairUrlError = showForm ? hardwareUrlError(baseUrl) : null
+
   return (
     <div className="bn-runs-panel">
       <div className="bn-runs-toolbar">
@@ -115,7 +174,9 @@ export default function DevicesPanel() {
         <form className="bn-device-form" onSubmit={pair}>
           <div className="bn-device-form-title">Pair hardware service</div>
           <div className="bn-device-help">
-            On the Raspberry Pi, run <code>./pair.sh</code>, then paste its token here.
+            On the hardware computer, run <code>./pair.sh --all --show</code>, then copy
+            one robot’s name, complete hardware URL, and token. Port 8766 is reserved
+            for the shared runtime service.
           </div>
           <label>
             <span>Name</span>
@@ -127,7 +188,7 @@ export default function DevicesPanel() {
             />
           </label>
           <label>
-            <span>Device URL</span>
+            <span>Hardware service URL · port required</span>
             <input
               value={baseUrl}
               onChange={event => setBaseUrl(event.target.value)}
@@ -138,6 +199,11 @@ export default function DevicesPanel() {
               spellCheck={false}
             />
           </label>
+          {pairUrlError && (
+            <div className="bn-device-recovery-hint" role="alert">
+              {pairUrlError}
+            </div>
+          )}
           <label>
             <span>Pairing token</span>
             <input

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -55,6 +55,10 @@ class _HardwareService:
             "calibrated": False,
             "joint_names": [f"servo_{index}" for index in range(1, 7)],
             "capabilities": ["joint_group", "servo_bus", "position_feedback"],
+            "connection": {
+                "transport": "serial",
+                "port": "/dev/serial/by-id/workshop-arm",
+            },
             **(status_overrides or {}),
         }
         self.runtime_deployments: dict[str, dict] = {}
@@ -357,6 +361,53 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("rejected", response.json()["detail"].lower())
         self.assertFalse(self.registry_path.exists())
+
+    def test_runtime_port_is_rejected_as_a_hardware_pairing_url(self):
+        response = self.client.post("/devices", json={
+            "name": "Wrong endpoint",
+            "base_url": "http://192.168.1.87:8766",
+            "token": "pairing-token",
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("shared Blacknode runtime", response.json()["detail"])
+        self.assertFalse(self.registry_path.exists())
+
+    def test_robot_deployment_is_bound_to_the_paired_service_serial_port(self):
+        workflow = {
+            "node_meta": {
+                "robot": {
+                    "id": "robot",
+                    "type": "Robot",
+                    "params": {},
+                    "inputs": [],
+                    "input_types": {},
+                    "input_defaults": {},
+                },
+            },
+            "edges": [],
+        }
+
+        server._bind_robot_to_device(workflow, {
+            "device_id": "robot-service-id",
+            "connected": True,
+            "connection": {
+                "transport": "serial",
+                "port": "/dev/serial/by-id/follower-arm",
+            },
+            "calibration": {"hardware_id": "FOLLOWER-USB-ID"},
+        })
+
+        params = workflow["node_meta"]["robot"]["params"]
+        self.assertEqual(
+            params["serial_port"],
+            "/dev/serial/by-id/follower-arm",
+        )
+        self.assertEqual(
+            params["hardware"]["recommended"]["serial"],
+            "FOLLOWER-USB-ID",
+        )
+        self.assertFalse(params["auto_discover"])
 
     def test_invalid_url_and_unknown_device_are_rejected(self):
         response = self.client.post("/devices", json={
@@ -784,6 +835,12 @@ class EditorDeviceApiTests(unittest.TestCase):
             preflight["workflow"]["hash"],
         )
         self.assertNotIn(hardware.token, response.text)
+        lease_requests = [
+            body
+            for method, path, _auth, body in hardware.requests
+            if method == "POST" and path == "/rpc"
+        ]
+        self.assertIn("release", [body["method"] for body in lease_requests])
 
     def test_staging_rejects_graph_changed_after_validation(self):
         hardware = _HardwareService()


### PR DESCRIPTION
## What changed
- requires an explicit hardware service port in the editor
- suggests 8765, then 8767 and later ports while reserving runtime port 8766
- rejects 8766 in both UI and API pairing paths
- binds one-Robot deployments to the exact serial path reported by the paired service
- releases/resumes the targeted hardware monitor around deployment lifecycle
- documents multi-robot port and serial ownership

## Why
Multi-robot deployments could otherwise select USB index 0 or pair the second robot against the runtime service on 8766.

## Validation
- editor device API: 22 tests passed
- `npm run build`
- both split templates validated against the live node catalog