### PR TITLE
Block calibration activation on the wrong robot

### DIFF
--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -112,7 +112,9 @@ disarmed device. Preflight accepts `joint_group` only when the
 workflow selection, Robot profile, device hardware identity, and device's
 active calibration all match. The staged workflow embeds the same profile and
 calibration so the robot driver applies the reviewed home positions and safe
-joint ranges.
+joint ranges. When the selected calibration belongs to another USB identity,
+preflight identifies both the selected and connected hardware and blocks
+activation instead of offering to upload another robot's calibration.
 
 ### Deployment transport
 

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -2863,6 +2863,15 @@ def activate_device_calibration(device_id: str):
                 409,
                 str(status.get("error") or "Hardware must be connected first."),
             )
+        selection = {
+            "profile_id": str(calibration.get("profile_id") or profile.get("id") or ""),
+            "hardware_id": str(calibration.get("hardware_id") or ""),
+        }
+        if _remote_hardware_identity_match(status, selection["hardware_id"]) is False:
+            raise HTTPException(
+                409,
+                _calibration_hardware_mismatch_message(selection, status),
+            )
         if status.get("armed"):
             raise HTTPException(409, "Disarm the device before activating calibration.")
         result = client.activate_calibration(profile, calibration)
@@ -2917,6 +2926,84 @@ def _workflow_calibration_selection(
     if not profile_id or not hardware_id:
         return None
     return {"profile_id": profile_id, "hardware_id": hardware_id}
+
+
+def _normalized_hardware_identity(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").casefold())
+
+
+def _identity_value_matches(candidate: Any, hardware_id: str) -> bool:
+    candidate_token = _normalized_hardware_identity(candidate)
+    hardware_token = _normalized_hardware_identity(hardware_id)
+    if not candidate_token or not hardware_token:
+        return False
+    if candidate_token == hardware_token:
+        return True
+    # USB serials are commonly embedded in a stable by-id path or an
+    # auto-generated service ID. Avoid substring matching tiny identifiers.
+    return len(hardware_token) >= 6 and hardware_token in candidate_token
+
+
+def _remote_hardware_identity_match(
+    remote_status: dict[str, Any],
+    hardware_id: str,
+) -> bool | None:
+    """Compare a calibration identity with authoritative hardware status.
+
+    Older hardware services expose the stable USB identity only inside their
+    /dev/serial/by-id path or generated device ID. None means the service did
+    not expose enough identity information to make a safe comparison.
+    """
+    connection = (
+        remote_status.get("connection")
+        if isinstance(remote_status.get("connection"), dict)
+        else {}
+    )
+    explicit = [
+        connection.get("hardware_id"),
+        connection.get("serial"),
+        connection.get("serial_number"),
+        remote_status.get("hardware_id"),
+    ]
+    explicit = [value for value in explicit if str(value or "").strip()]
+    if explicit:
+        return any(_identity_value_matches(value, hardware_id) for value in explicit)
+
+    port = str(connection.get("port") or "").strip()
+    device_id = str(remote_status.get("device_id") or "").strip()
+    if _identity_value_matches(port, hardware_id) or _identity_value_matches(
+        device_id,
+        hardware_id,
+    ):
+        return True
+
+    normalized_port = port.replace("\\", "/").casefold()
+    normalized_device_id = device_id.casefold()
+    if "/dev/serial/by-id/" in normalized_port:
+        return False
+    if "usb" in normalized_device_id and "serial" in normalized_device_id:
+        return False
+    return None
+
+
+def _calibration_hardware_mismatch_message(
+    selection: dict[str, str],
+    remote_status: dict[str, Any],
+) -> str:
+    connection = (
+        remote_status.get("connection")
+        if isinstance(remote_status.get("connection"), dict)
+        else {}
+    )
+    device_id = str(remote_status.get("device_id") or "unknown device")
+    port = str(connection.get("port") or "unknown serial port")
+    return (
+        f"Selected calibration {selection['profile_id']} / "
+        f"{selection['hardware_id']} belongs to a different physical robot. "
+        f"Connected device: {device_id} on {port}. Choose a calibration whose "
+        "hardware ID matches this device, or select the paired device that owns "
+        f"{selection['hardware_id']}. Do not activate this calibration here."
+    )
 
 
 def _robot_profiles_root() -> Path:
@@ -3542,6 +3629,15 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
     calibrated = remote_status.get("calibrated")
     if requires_joint_motion:
         selection = _workflow_calibration_selection(workflow)
+        hardware_identity_match = (
+            _remote_hardware_identity_match(
+                remote_status,
+                selection["hardware_id"],
+            )
+            if selection
+            else None
+        )
+        hardware_mismatch = hardware_identity_match is False
         active_calibration = (
             remote_status.get("calibration")
             if isinstance(remote_status.get("calibration"), dict)
@@ -3552,6 +3648,7 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
             and calibrated is True
             and str(active_calibration.get("profile_id") or "") == selection["profile_id"]
             and str(active_calibration.get("hardware_id") or "") == selection["hardware_id"]
+            and not hardware_mismatch
         )
         selection_error = ""
         if selection is not None:
@@ -3583,6 +3680,11 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
                 )
                 if calibration_matches and not selection_error
                 else selection_error
+                or (
+                    _calibration_hardware_mismatch_message(selection, remote_status)
+                    if selection and hardware_mismatch
+                    else ""
+                )
                 or (
                     "Select a saved device calibration, then activate it on this device."
                     if selection is None

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -461,7 +461,12 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertNotIn(hardware.token, response.text)
 
     def test_selected_calibration_can_be_activated_and_satisfies_preflight(self):
-        hardware = _HardwareService()
+        hardware = _HardwareService(status_overrides={
+            "connection": {
+                "transport": "serial",
+                "port": "/dev/serial/by-id/usb-USB-SERIAL-42-if00",
+            },
+        })
         robots_root = Path(self._tmp.name) / "robots"
         profile_dir = robots_root / "arm_profile"
         calibration_dir = profile_dir / "calibrations"
@@ -573,6 +578,133 @@ class EditorDeviceApiTests(unittest.TestCase):
             calibration_requests[0][3]["calibration"]["hardware_id"],
             "USB-SERIAL-42",
         )
+
+    def test_wrong_robot_calibration_is_rejected_before_activation(self):
+        activated: list[dict] = []
+        hardware = SimpleNamespace(
+            status=lambda: {
+                "device_id": (
+                    "alex-desktop-usb-1a86-usb-single-serial-"
+                    "5b41531741-if-03dc3457"
+                ),
+                "connected": True,
+                "armed": False,
+                "calibrated": False,
+                "connection": {
+                    "transport": "serial",
+                    "port": (
+                        "/dev/serial/by-id/"
+                        "usb-1a86_USB_Single_Serial_5B41531741-if00"
+                    ),
+                },
+            },
+            activate_calibration=lambda profile, calibration: activated.append({
+                "profile": profile,
+                "calibration": calibration,
+            }),
+        )
+        profile = {"id": "so_arm101_v002", "joints": []}
+        calibration = {
+            "profile_id": "so_arm101_v002",
+            "hardware_id": "5B41531481",
+            "joints": {},
+        }
+
+        with (
+            patch.object(
+                server,
+                "_selected_local_calibration",
+                return_value=(profile, calibration),
+            ),
+            patch.object(server, "_paired_device_client", return_value=hardware),
+        ):
+            response = self.client.post("/devices/paired/calibration")
+
+        self.assertEqual(response.status_code, 409)
+        message = response.json()["detail"]
+        self.assertIn("different physical robot", message)
+        self.assertIn("5B41531481", message)
+        self.assertIn("5B41531741", message)
+        self.assertIn("Do not activate", message)
+        self.assertEqual(activated, [])
+        self.assertFalse(
+            server._remote_hardware_identity_match(
+                hardware.status(),
+                "5B41531481",
+            ),
+        )
+        self.assertTrue(
+            server._remote_hardware_identity_match(
+                hardware.status(),
+                "5B41531741",
+            ),
+        )
+
+        workflow = _workflow(["joint_group"])
+        workflow["metadata"]["device_calibration"] = {
+            "profile_id": "so_arm101_v002",
+            "hardware_id": "5B41531481",
+        }
+        robot_fn = server._NODE_REGISTRY["Output"]
+        workflow["node_meta"]["robot"] = {
+            "id": "robot",
+            "type": "Robot",
+            "params": {"profile_id": "so_arm101_v002"},
+            "pos": [200, 0],
+            "inputs": list(getattr(robot_fn, "_bn_inputs", [])),
+            "outputs": list(getattr(robot_fn, "_bn_outputs", [])),
+            "input_types": dict(getattr(robot_fn, "_bn_input_types", {})),
+            "output_types": dict(getattr(robot_fn, "_bn_output_types", {})),
+            "input_defaults": dict(getattr(robot_fn, "_bn_input_defaults", {})),
+        }
+        runtime = SimpleNamespace(manifest=lambda: {
+            "service": "blacknode-runtime",
+            "protocol_version": 1,
+            "runtime_version": "0.2.0",
+            "features": [
+                "manifest_v1",
+                "deployment_bundle_v1",
+                "process_supervision_v1",
+                "rollback_v1",
+                "package_sync_v1",
+            ],
+            "python": {"version": "3.12.3"},
+            "blacknode": {"installed": True, "version": "0.3.0"},
+            "packages": [],
+            "node_types": ["Output", "Robot"],
+        })
+        paired_device = {
+            "id": "paired",
+            "name": "Wrong arm",
+            "base_url": "http://192.168.1.87:8765",
+            "runtime_url": "http://192.168.1.87:8766",
+            "remote_device_id": hardware.status()["device_id"],
+        }
+        with (
+            patch.dict(server._NODE_REGISTRY, {"Robot": robot_fn}),
+            patch.object(server._device_registry, "get_public", return_value=paired_device),
+            patch.object(server._device_registry, "runtime_client", return_value=runtime),
+            patch.object(server, "_paired_device_client", return_value=hardware),
+            patch.object(
+                server,
+                "_selected_local_calibration",
+                return_value=(profile, calibration),
+            ),
+        ):
+            preflight = self.client.post(
+                "/devices/paired/deployment-preflight",
+                json={"workflow": workflow},
+            )
+
+        self.assertEqual(preflight.status_code, 200)
+        checks = {item["id"]: item for item in preflight.json()["checks"]}
+        self.assertEqual(checks["calibration"]["status"], "fail")
+        self.assertTrue(checks["calibration"]["blocking"])
+        self.assertIn(
+            "different physical robot",
+            checks["calibration"]["message"],
+        )
+        self.assertIn("Do not activate", checks["calibration"]["message"])
 
     def test_old_device_service_reports_calibration_upgrade_action(self):
         response = io.BytesIO(b'{"ok": false, "error": "not found"}')


### PR DESCRIPTION
## What changed

- Compares the workflow calibration hardware ID with explicit device identity, the stable USB by-id path, and generated hardware service identity.
- Rejects calibration activation before upload when those identities definitely refer to different physical robots.
- Makes deployment preflight explain the selected calibration, connected device, and serial path, and tells the operator to choose the matching calibration or paired device.
- Preserves compatibility when an older service does not expose enough identity information for a definite comparison.
- Documents the cross-robot activation guard.

## Why

Preflight previously reported every inactive calibration as “activate this calibration,” even when the selected calibration hardware ID was visibly different from the connected robot's USB serial. The activation endpoint also relied on the downstream service rather than rejecting that definite mismatch itself.

## Impact

A calibration recorded for robot `5B41531481` cannot be offered or uploaded to a connected robot identified as `5B41531741`. Matching calibrations continue through the existing disarmed-device activation path.

## Validation

- `python -m unittest discover -s tests -p test_editor_devices.py` (23 passed)
- `python -m unittest discover -s tests` (376 passed, 8 skipped)