### PR TITLE
Improve device management and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Workflows stay readable as systems grow: each node has typed ports, each
 connection is validated, and hardware-specific implementations remain behind
 stable robot capabilities.
 
+Robot Hardware can fan timestamped capability telemetry to optional transports.
+Its MQTT adapter publishes versioned robot-state streams for dashboards, fleet
+systems, and third-party consumers while local hardware control remains
+authenticated and independently supervised.
+
 ## A Robot Workflow, Layer by Layer
 
 A Blacknode robot workflow moves from task intent to physical hardware through
@@ -148,14 +153,66 @@ disarmed; previous deployments stay stopped until explicitly started again.
 Each lifecycle action shows stage progress. Each robot also has its own
 **Pause robot** and **Resume robot** controls. Robot Pause still sends the
 direct hardware stop when its deployment runtime is unavailable and reports
-that runtime address as a warning. The robot detail reports physical torque
-only when the hardware provider exposes it; otherwise it shows **Not reported**
-instead of inferring torque state from the motion-armed flag.
+that runtime address as a warning. The robot detail reports physical torque as
+**On**, **Off**, or **Unknown**. Unknown includes the provider's readback reason
+when available and is treated as possibly on; select the **Physical torque**
+fact card to open or close that explanation. Blacknode never infers physical
+torque from the separate motion-armed flag. The last verified Robot Hardware
+version is retained in the paired-device record, so an active workflow or
+temporary version-report outage does not erase it from the robot card.
 For robots on SSH-managed computers, **Restart robot service** asks for the SSH
 password, resolves the exact hardware systemd unit from that robot's saved
 hardware port, and restarts only that unit. Restart is blocked while a
 deployment is active or the robot is armed. Blacknode then verifies that the
 same authenticated robot returned and keeps motion disarmed.
+**Check device** checks the Runtime and every attached Robot Hardware service
+together. SSH-managed computers also expose one **Runtime + Robot Hardware**
+panel.
+Its read-only version check compares installed and latest upstream versions
+and commits for both repositories, includes the version reported by each live
+service, and states whether each service is current or has an update. **Update
+Runtime + Robot Hardware** stops active deployments, stops and disarms attached
+robots, verifies trusted clean Git checkouts, fast-forwards them, reinstalls the
+packages in their existing environments, and restarts only the matched
+services. The report also offers **Update Runtime** and **Update Robot
+Hardware** independently, so a valid Runtime update remains available when a
+Robot Hardware service needs attention. Runtime has its own installation row.
+Robot Hardware has one shared installation row because every robot service on
+that compute device uses the same checkout and environment; a compact status
+line identifies the robot services that were verified. **Restart Robot
+Hardware** remains a per-robot action.
+Unknown versions and service-resolution errors expose **Repair Runtime** or
+**Repair Robot Hardware**. When an authenticated Robot Hardware process was
+started manually from the trusted checkout, Repair Robot Hardware verifies and stops only
+that listener, installs the saved persistent systemd services, and continues
+the update. If an installed unit has drifted to a different HTTP port, Repair
+Hardware matches its saved configuration by stable robot identity, reconciles
+the service manifest to the editor's paired port, and reinstalls the unit.
+An unidentified port owner is never stopped automatically. Local source
+changes remain blocked. When every selected commit is current, the
+matching control becomes **Reinstall
+Runtime + Robot Hardware** and repairs the current package environments before
+restarting and verifying the services. Local source changes block either
+operation and are never overwritten.
+Updating does not switch off physical actuator power; a torque warning remains
+visible when the updated hardware service reads an enabled servo torque
+register. When no deployment is running, the robot card offers an explicitly
+confirmed **Release torque** action. It writes only torque-disable values and
+verifies the reported physical state afterward; support the robot first because
+its joints may move or drop.
+Each robot card also exposes **Monitor live**. Select the robot to view its
+current joint positions, derived joint speeds, torque state, stream freshness,
+and recent per-joint traces. The monitor reads Robot Hardware while the robot
+is idle and automatically switches to the running deployment when that process
+owns the serial bus. MQTT is optional: it remains available for external
+dashboards and fleet consumers, while the editor monitor uses the authenticated
+device connection directly. Deployed monitoring requires Runtime 0.3.9 or
+newer and `blacknode-drivers` 0.2.1 or newer; restart a running deployment after
+updating so it receives the new telemetry channel.
+Devices initially paired manually can use **Enable SSH controls** later.
+Blacknode confirms the SSH host key and enables management only when the
+installed systemd runtime matches the pairing's exact port and runtime device
+identity. The SSH password remains request-only.
 
 The installer detects each computer's current address; it does not hardcode a
 LAN IP. Use a router DHCP reservation or a resolvable hostname for robots that
@@ -203,6 +260,10 @@ cannot be deployed accidentally.
 
 Remote deployments appear below the preflight report. Expand one to view its
 device log and use **Run**, **Stop**, **Stage update**, or **Rollback**.
+The robot card also distinguishes a running deployment from a stopped, staged,
+exited, or failed deployment that remains stored on its Runtime. A stored
+deployment exposes **Restart deployment** and **Deployment details**, so a
+Runtime or Hardware reinstall does not require sending the same workflow again.
 **Stage update** uploads the currently validated graph as another revision of
 that deployment. **Rollback** selects the previous revision without starting
 it; use **Run** after checking its state. A running deployment must be stopped

--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -37,7 +37,12 @@ setup request and is not saved.
 
 For manual setup, install `blacknode-runtime` on the device, run
 `./service.sh pairing`, and enter the printed runtime URL and token under
-**Add device → Pair manually**.
+**Add device → Pair manually**. You can add SSH management later from that
+device's details with **Enable SSH controls**. Blacknode confirms the SSH host
+key, verifies that the installed systemd runtime has the same port and runtime
+device identity as the existing pairing, and then enables device lifecycle and
+robot-service restart actions. The SSH password is used for that request and is
+not saved.
 
 Open the new square device card and choose **Add robot** for each hardware
 service connected to that computer. Enter the robot URL and token printed by
@@ -87,6 +92,9 @@ The Project shows the running deployment and its owning device. Use
 **Deployments** to inspect logs, stop, update, or roll back a revision. Stops
 remain explicit because stopping a hardware workflow may release actuator
 torque.
+The robot card reports stopped and staged deployments that remain stored on the
+Runtime and can restart the latest stored deployment after the robot passes the
+same connected, disarmed, calibration, and ownership checks.
 
 Update the graph, check setup again, and send a new revision to iterate. Project
 artifacts retain evidence from datasets, training runs, policies, evaluations,

--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -19,6 +19,7 @@ class DeviceInstallError(RuntimeError):
 
 _INSTANCE_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 _INSPECTION_MARKER = "__BLACKNODE_RUNTIME_INSPECTION__="
+_UPDATE_REPORT_MARKER = "__BLACKNODE_UPDATE_REPORT__="
 _INSPECTION_SCRIPT = r"""python3 - <<'PY'
 import glob
 import json
@@ -1038,6 +1039,954 @@ progress 96 "Verifying the runtime service"
         connection.close()
 
 
+def update_managed_services(
+    *,
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    host_fingerprint: str,
+    instance_id: str,
+    runtime_port: int,
+    hardware_ports: list[int],
+    hardware_device_ids: dict[int, str] | None = None,
+    include_runtime: bool = True,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Fast-forward and restart selected managed Runtime and Hardware services."""
+
+    def report(percent: int, message: str) -> None:
+        if progress is not None:
+            progress({
+                "progress": max(0, min(100, int(percent))),
+                "message": str(message),
+            })
+
+    selected_instance = _clean_instance_id(instance_id or "default")
+    selected_runtime_port = int(runtime_port)
+    if selected_runtime_port < 1 or selected_runtime_port > 65535:
+        raise DeviceInstallError("The managed runtime port is invalid.")
+    selected_hardware_ports = sorted({int(value) for value in hardware_ports})
+    selected_hardware_targets = [
+        {
+            "port": value,
+            "device_id": str((hardware_device_ids or {}).get(value) or ""),
+        }
+        for value in selected_hardware_ports
+    ]
+    if any(value < 1 or value > 65535 for value in selected_hardware_ports):
+        raise DeviceInstallError("A robot hardware port is invalid.")
+    if not include_runtime and not selected_hardware_ports:
+        raise DeviceInstallError("Choose Runtime, Hardware, or both to update.")
+
+    report(3, "Connecting to the verified device")
+    connection = _connect(
+        host,
+        port,
+        username,
+        password,
+        expected_fingerprint=host_fingerprint,
+        timeout=15.0,
+    )
+    remote_script_path = f"/tmp/blacknode-update-{secrets.token_hex(8)}.sh"
+    script = r"""#!/usr/bin/env bash
+set -euo pipefail
+progress() {
+  echo "__BLACKNODE_UPDATE_PROGRESS__=$1|$2"
+}
+sudo() {
+  command sudo -S -p '' "$@"
+}
+export -f sudo
+
+include_runtime="$1"
+instance="$2"
+runtime_port="$3"
+hardware_targets_payload="$4"
+hardware_ports=()
+hardware_device_ids=()
+while IFS=$'\t' read -r target_port target_device_id; do
+  [[ -n "$target_port" ]] || continue
+  hardware_ports+=("$target_port")
+  hardware_device_ids+=("$target_device_id")
+done < <(
+  python3 - "$hardware_targets_payload" <<'PY'
+import base64
+import json
+import sys
+
+targets = json.loads(base64.urlsafe_b64decode(sys.argv[1]).decode("utf-8"))
+for target in targets:
+    print(f"{int(target['port'])}\t{str(target.get('device_id') or '')}")
+PY
+)
+if [[ "$instance" == "default" ]]; then
+  runtime_dir="$HOME/blacknode-runtime"
+  runtime_service="blacknode-runtime.service"
+else
+  [[ "$instance" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || {
+    echo "Invalid Blacknode runtime instance."
+    exit 2
+  }
+  runtime_dir="$HOME/blacknode-runtimes/$instance"
+  runtime_service="blacknode-runtime-$instance.service"
+fi
+
+package_version() {
+  python3 - "$1" <<'PY'
+import sys
+import tomllib
+from pathlib import Path
+
+path = Path(sys.argv[1]) / "pyproject.toml"
+try:
+    payload = tomllib.loads(path.read_text(encoding="utf-8"))
+    print(str((payload.get("project") or {}).get("version") or "unknown"))
+except Exception:
+    print("unknown")
+PY
+}
+
+validate_checkout() {
+  local directory="$1"
+  local repository="$2"
+  [[ -d "$directory/.git" && -f "$directory/pyproject.toml" ]] || {
+    echo "$repository is not an updateable Git checkout: $directory"
+    exit 3
+  }
+  local origin
+  origin="$(git -C "$directory" remote get-url origin 2>/dev/null || true)"
+  python3 - "$origin" "$repository" <<'PY'
+import re
+import sys
+
+origin = sys.argv[1].strip().lower().removesuffix(".git").rstrip("/")
+repository = sys.argv[2].strip().lower()
+if not re.search(rf"(?:github\.com[:/])temiroff/{re.escape(repository)}$", origin):
+    raise SystemExit(
+        f"Refusing to update {repository}: its origin is not the trusted "
+        f"temiroff/{repository} repository."
+    )
+PY
+  if [[ -n "$(git -C "$directory" status --porcelain --untracked-files=normal)" ]]; then
+    echo "$repository has local changes. Commit, stash, or remove them before remote update."
+    exit 4
+  fi
+  git -C "$directory" rev-parse --verify '@{upstream}' >/dev/null 2>&1 || {
+    echo "$repository does not have an upstream branch configured."
+    exit 5
+  }
+}
+
+resolve_hardware_unit() {
+  local hardware_port="$1"
+  local matches=()
+  local active_matches=()
+  local enabled_matches=()
+  local unit exec_start unit_definition normalized unit_path
+  mapfile -t candidate_units < <(
+    {
+      systemctl list-unit-files 'blacknode-hardware*.service' --no-legend 2>/dev/null
+      systemctl list-units --all --type=service 'blacknode-hardware*.service' \
+        --no-legend 2>/dev/null
+      find /etc/systemd/system /run/systemd/system -maxdepth 1 \
+        -name 'blacknode-hardware*.service' -printf '%f\n' 2>/dev/null
+    } | awk '{print $1}' | sort -u
+  )
+  for unit in "${candidate_units[@]}"; do
+    [[ "$unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\.service$ ]] || continue
+    exec_start="$(systemctl show "$unit" --property=ExecStart --value 2>/dev/null || true)"
+    unit_definition=""
+    for unit_path in "/etc/systemd/system/$unit" "/run/systemd/system/$unit"; do
+      if [[ -f "$unit_path" ]]; then
+        unit_definition+="$(command cat "$unit_path")"
+        unit_definition+=$'\n'
+      fi
+    done
+    normalized="${exec_start//\"/}"$'\n'"${unit_definition//\"/}"
+    if printf '%s\n' "$normalized" \
+      | grep -oE -- '--port(=|[[:space:]])[0-9]+' \
+      | grep -oE '[0-9]+' \
+      | grep -Fxq -- "$hardware_port"; then
+      matches+=("$unit")
+      systemctl is-active --quiet "$unit" 2>/dev/null \
+        && active_matches+=("$unit")
+      systemctl is-enabled --quiet "$unit" 2>/dev/null \
+        && enabled_matches+=("$unit")
+    fi
+  done
+  if [[ "${#matches[@]}" -eq 0 ]]; then
+    echo "No installed or active Blacknode Hardware systemd service matches port $hardware_port. Discovered units: ${candidate_units[*]:-none}." >&2
+    return 60
+  fi
+  if [[ "${#matches[@]}" -eq 1 ]]; then
+    printf '%s\n' "${matches[0]}"
+    return 0
+  fi
+  if [[ "${#active_matches[@]}" -eq 1 ]]; then
+    printf '%s\n' "${active_matches[0]}"
+    return 0
+  fi
+  if [[ "${#active_matches[@]}" -gt 1 ]]; then
+    echo "Multiple active Blacknode Hardware services claim port $hardware_port: ${active_matches[*]}." >&2
+    return 61
+  fi
+  if [[ "${#enabled_matches[@]}" -eq 1 ]]; then
+    printf '%s\n' "${enabled_matches[0]}"
+    return 0
+  fi
+  echo "Could not choose the persistent Hardware service for port $hardware_port. Candidates: ${matches[*]}. Enabled: ${enabled_matches[*]:-none}." >&2
+  return 61
+}
+
+stop_verified_manual_hardware() {
+  local hardware_repo="$1"
+  local hardware_port="$2"
+  local listener_pids=()
+  local pid cmdline
+  if command -v ss >/dev/null 2>&1; then
+    mapfile -t listener_pids < <(
+      ss -H -ltnp "sport = :$hardware_port" 2>/dev/null \
+        | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u
+    )
+  elif command -v lsof >/dev/null 2>&1; then
+    mapfile -t listener_pids < <(
+      lsof -nP -t -iTCP:"$hardware_port" -sTCP:LISTEN 2>/dev/null | sort -u
+    )
+  fi
+  if [[ "${#listener_pids[@]}" -eq 0 ]]; then
+    if (echo >/dev/tcp/127.0.0.1/"$hardware_port") >/dev/null 2>&1; then
+      echo "Port $hardware_port is owned by a process that SSH cannot identify. Stop the manually running Hardware process and retry Repair Hardware." >&2
+      return 1
+    fi
+    return 0
+  fi
+  for pid in "${listener_pids[@]}"; do
+    [[ "$pid" =~ ^[0-9]+$ && -r "/proc/$pid/cmdline" ]] || {
+      echo "Could not verify the process listening on Hardware port $hardware_port." >&2
+      return 1
+    }
+    cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline")"
+    if [[ "$cmdline" != *"$hardware_repo/scripts/hardware_service.py"* ]] \
+      || [[ ! "$cmdline" =~ --port(=|[[:space:]])${hardware_port}([^0-9]|$) ]]; then
+      echo "Refusing to stop unverified process $pid on Hardware port $hardware_port: $cmdline" >&2
+      return 1
+    fi
+  done
+  for pid in "${listener_pids[@]}"; do
+    echo "Stopping verified manually started Hardware process $pid on port $hardware_port."
+    kill -TERM "$pid"
+  done
+  for _attempt in {1..40}; do
+    listening=false
+    for pid in "${listener_pids[@]}"; do
+      kill -0 "$pid" >/dev/null 2>&1 && listening=true
+    done
+    [[ "$listening" == false ]] && return 0
+    sleep 0.25
+  done
+  echo "The manually running Hardware process on port $hardware_port did not stop. Stop it from its terminal and retry Repair Hardware." >&2
+  return 1
+}
+
+install_persistent_hardware_services() {
+  local hardware_repo="$HOME/blacknode-hardware"
+  [[ -x "$hardware_repo/install-service.sh" ]] || {
+    echo "Repair Hardware requires $hardware_repo/install-service.sh." >&2
+    return 1
+  }
+  validate_checkout "$hardware_repo" "blacknode-hardware"
+  if [[ -f "$hardware_repo/.blacknode-hardware/devices.json" ]]; then
+    python3 - "$hardware_repo/.blacknode-hardware/devices.json" \
+      "$hardware_targets_payload" <<'PY'
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+targets = json.loads(base64.urlsafe_b64decode(sys.argv[2]).decode("utf-8"))
+payload = json.loads(path.read_text(encoding="utf-8"))
+devices = payload.get("devices") or []
+by_id = {
+    str(item.get("device_id") or ""): item
+    for item in devices
+    if isinstance(item, dict) and item.get("device_id")
+}
+for target in targets:
+    device_id = str(target.get("device_id") or "")
+    if not device_id:
+        raise SystemExit(
+            f"Cannot reconcile Hardware port {target['port']}: "
+            "the paired robot has no stable device identity."
+        )
+    device = by_id.get(device_id)
+    if device is None:
+        raise SystemExit(
+            f"Cannot reconcile Hardware port {target['port']}: device identity "
+            f"{device_id!r} is not present in {path}."
+        )
+    device["service_port"] = int(target["port"])
+ports = [int(item["service_port"]) for item in devices]
+if len(ports) != len(set(ports)):
+    raise SystemExit(
+        "Cannot reconcile Hardware services because two configured robots "
+        "would use the same HTTP port."
+    )
+temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+temporary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+os.replace(temporary, path)
+PY
+  fi
+  for hardware_port in "${hardware_ports[@]}"; do
+    stop_verified_manual_hardware "$hardware_repo" "$hardware_port"
+  done
+  progress 11 "Installing missing persistent Hardware services"
+  if [[ -f "$hardware_repo/.blacknode-hardware/devices.json" ]]; then
+    (
+      cd "$hardware_repo"
+      ./install-service.sh --all
+    )
+  elif [[ "${#hardware_ports[@]}" -eq 1 ]]; then
+    (
+      cd "$hardware_repo"
+      BLACKNODE_HARDWARE_PORT="${hardware_ports[0]}" ./install-service.sh
+    )
+  else
+    echo "Multiple Hardware ports require a saved multi-robot configuration. Run ./configure.sh --all before Repair Hardware." >&2
+    return 1
+  fi
+}
+
+progress 8 "Resolving selected managed services"
+if [[ "$include_runtime" == "1" ]]; then
+  [[ -d "$runtime_dir" ]] || {
+    echo "The managed runtime directory is missing: $runtime_dir"
+    exit 3
+  }
+fi
+repair_hardware=false
+for hardware_port in "${hardware_ports[@]}"; do
+  if unit="$(resolve_hardware_unit "$hardware_port")"; then
+    :
+  else
+    resolve_status=$?
+    if [[ "$resolve_status" -eq 60 ]]; then
+      repair_hardware=true
+    else
+      exit 6
+    fi
+  fi
+done
+if [[ "$repair_hardware" == true ]]; then
+  install_persistent_hardware_services || exit 6
+fi
+hardware_units=()
+hardware_dirs=()
+for hardware_port in "${hardware_ports[@]}"; do
+  [[ "$hardware_port" =~ ^[0-9]{1,5}$ ]] || exit 2
+  if ! unit="$(resolve_hardware_unit "$hardware_port")"; then
+    echo "Repair Hardware did not create exactly one persistent service for port $hardware_port." >&2
+    exit 6
+  fi
+  directory="$(systemctl show "$unit" --property=WorkingDirectory --value 2>/dev/null || true)"
+  if [[ -z "$directory" ]]; then
+    for unit_path in "/etc/systemd/system/$unit" "/run/systemd/system/$unit"; do
+      if [[ -f "$unit_path" ]]; then
+        directory="$(
+          sed -nE 's/^WorkingDirectory=(.*)$/\1/p' "$unit_path" | tail -n 1
+        )"
+        [[ -n "$directory" ]] && break
+      fi
+    done
+  fi
+  [[ -n "$directory" ]] || {
+    echo "$unit does not report its repository WorkingDirectory." >&2
+    exit 6
+  }
+  hardware_units+=("$unit")
+  hardware_dirs+=("$directory")
+done
+
+progress 15 "Checking trusted clean Git checkouts"
+if [[ "$include_runtime" == "1" ]]; then
+  validate_checkout "$runtime_dir" "blacknode-runtime"
+fi
+unique_hardware_dirs=()
+for directory in "${hardware_dirs[@]}"; do
+  found=false
+  for existing in "${unique_hardware_dirs[@]}"; do
+    [[ "$existing" == "$directory" ]] && found=true
+  done
+  if [[ "$found" == false ]]; then
+    validate_checkout "$directory" "blacknode-hardware"
+    unique_hardware_dirs+=("$directory")
+  fi
+done
+
+runtime_before_version=""
+runtime_before_commit=""
+if [[ "$include_runtime" == "1" ]]; then
+  runtime_before_version="$(package_version "$runtime_dir")"
+  runtime_before_commit="$(git -C "$runtime_dir" rev-parse --short=12 HEAD)"
+fi
+hardware_before_versions=()
+hardware_before_commits=()
+for directory in "${hardware_dirs[@]}"; do
+  hardware_before_versions+=("$(package_version "$directory")")
+  hardware_before_commits+=("$(git -C "$directory" rev-parse --short=12 HEAD)")
+done
+
+if [[ "$include_runtime" == "1" ]]; then
+  progress 25 "Downloading Runtime updates"
+  git -C "$runtime_dir" fetch --prune
+fi
+for directory in "${unique_hardware_dirs[@]}"; do
+  progress 35 "Downloading robot hardware updates"
+  git -C "$directory" fetch --prune
+done
+
+services=()
+if [[ "$include_runtime" == "1" ]]; then
+  services+=("$runtime_service")
+fi
+services+=("${hardware_units[@]}")
+restore_services() {
+  local unit
+  for unit in "${services[@]}"; do
+    sudo systemctl start "$unit" >/dev/null 2>&1 || true
+  done
+}
+trap restore_services EXIT
+
+progress 45 "Stopping managed services"
+for unit in "${hardware_units[@]}"; do
+  sudo systemctl stop "$unit"
+done
+if [[ "$include_runtime" == "1" ]]; then
+  sudo systemctl stop "$runtime_service"
+fi
+
+if [[ "$include_runtime" == "1" ]]; then
+  progress 55 "Fast-forwarding Blacknode Runtime"
+  git -C "$runtime_dir" merge --ff-only '@{upstream}'
+  "$runtime_dir/.venv/bin/python" -m pip install -e "$runtime_dir"
+fi
+
+for directory in "${unique_hardware_dirs[@]}"; do
+  progress 68 "Fast-forwarding Blacknode Hardware"
+  git -C "$directory" merge --ff-only '@{upstream}'
+  "$directory/.venv/bin/python" -m pip install -e "$directory"
+done
+
+progress 80 "Starting the selected updated services"
+if [[ "$include_runtime" == "1" ]]; then
+  sudo systemctl start "$runtime_service"
+fi
+for unit in "${hardware_units[@]}"; do
+  sudo systemctl start "$unit"
+done
+
+for unit in "${services[@]}"; do
+  state=""
+  for _attempt in {1..60}; do
+    state="$(systemctl is-active "$unit" 2>/dev/null || true)"
+    [[ "$state" == "active" ]] && break
+    sleep 0.25
+  done
+  [[ "$state" == "active" ]] || {
+    echo "$unit did not return to the active state."
+    exit 7
+  }
+done
+trap - EXIT
+
+progress 90 "Collecting installed versions"
+report_file="$(mktemp)"
+trap 'rm -f -- "$report_file"' EXIT
+if [[ "$include_runtime" == "1" ]]; then
+  runtime_after_version="$(package_version "$runtime_dir")"
+  runtime_after_commit="$(git -C "$runtime_dir" rev-parse --short=12 HEAD)"
+  printf 'runtime\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$runtime_service" "$runtime_port" "$runtime_before_version" "$runtime_after_version" \
+    "$runtime_before_commit" "$runtime_after_commit" >> "$report_file"
+fi
+for index in "${!hardware_units[@]}"; do
+  directory="${hardware_dirs[$index]}"
+  printf 'hardware\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "${hardware_units[$index]}" "${hardware_ports[$index]}" \
+    "${hardware_before_versions[$index]}" "$(package_version "$directory")" \
+    "${hardware_before_commits[$index]}" "$(git -C "$directory" rev-parse --short=12 HEAD)" \
+    >> "$report_file"
+done
+python3 - "$report_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+components = []
+for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+    kind, service, port, before_version, after_version, before_commit, after_commit = line.split("\t")
+    components.append({
+        "kind": kind,
+        "service_name": service,
+        "port": int(port),
+        "before": {"version": before_version, "commit": before_commit},
+        "after": {"version": after_version, "commit": after_commit},
+        "changed": before_commit != after_commit,
+        "state": "active",
+    })
+print("__BLACKNODE_UPDATE_REPORT__=" + json.dumps({
+    "ok": True,
+    "components": components,
+}, separators=(",", ":")))
+PY
+progress 96 "Managed services updated"
+"""
+    try:
+        sftp = connection.client.open_sftp()
+        try:
+            with sftp.file(remote_script_path, "w") as remote_script:
+                remote_script.write(script)
+            sftp.chmod(remote_script_path, 0o700)
+        finally:
+            sftp.close()
+
+        def remote_output(line: str) -> None:
+            match = re.match(
+                r"^__BLACKNODE_UPDATE_PROGRESS__=(\d{1,3})\|(.*)$",
+                line.strip(),
+            )
+            if match:
+                report(int(match.group(1)), match.group(2).strip())
+
+        targets_payload = base64.urlsafe_b64encode(json.dumps(
+            selected_hardware_targets,
+            separators=(",", ":"),
+        ).encode("utf-8")).decode("ascii")
+        arguments = " ".join([
+            "1" if include_runtime else "0",
+            selected_instance,
+            str(selected_runtime_port),
+            targets_payload,
+        ])
+        output = _run(
+            connection,
+            f"bash {remote_script_path} {arguments}",
+            stdin_text=_sudo_input(password),
+            timeout=900.0,
+            on_output=remote_output,
+        )
+        payload_line = next(
+            (
+                line[len(_UPDATE_REPORT_MARKER):]
+                for line in reversed(output.splitlines())
+                if line.startswith(_UPDATE_REPORT_MARKER)
+            ),
+            "",
+        )
+        if not payload_line:
+            raise DeviceInstallError("The device did not return an update report.")
+        try:
+            result = json.loads(payload_line)
+        except json.JSONDecodeError as exc:
+            raise DeviceInstallError("The device returned an invalid update report.") from exc
+        if not isinstance(result, dict) or not isinstance(result.get("components"), list):
+            raise DeviceInstallError("The device returned an incomplete update report.")
+        result["host_fingerprint"] = connection.fingerprint
+        return result
+    finally:
+        try:
+            _run(connection, f"rm -f -- {remote_script_path}", timeout=10.0)
+        except DeviceInstallError:
+            pass
+        connection.close()
+
+
+def inspect_managed_service_updates(
+    *,
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    host_fingerprint: str,
+    instance_id: str,
+    runtime_port: int,
+    hardware_ports: list[int],
+    hardware_device_ids: dict[int, str] | None = None,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Compare installed managed-service commits with their trusted upstreams."""
+
+    def report(percent: int, message: str) -> None:
+        if progress is not None:
+            progress({
+                "progress": max(0, min(100, int(percent))),
+                "message": str(message),
+            })
+
+    selected_instance = _clean_instance_id(instance_id or "default")
+    selected_runtime_port = int(runtime_port)
+    if selected_runtime_port < 1 or selected_runtime_port > 65535:
+        raise DeviceInstallError("The managed runtime port is invalid.")
+    selected_hardware_ports = sorted({int(value) for value in hardware_ports})
+    if any(value < 1 or value > 65535 for value in selected_hardware_ports):
+        raise DeviceInstallError("A robot hardware port is invalid.")
+
+    report(5, "Connecting to the verified device")
+    connection = _connect(
+        host,
+        port,
+        username,
+        password,
+        expected_fingerprint=host_fingerprint,
+        timeout=15.0,
+    )
+    arguments = base64.urlsafe_b64encode(json.dumps({
+        "instance_id": selected_instance,
+        "runtime_port": selected_runtime_port,
+        "hardware_targets": [
+            {
+                "port": value,
+                "device_id": str((hardware_device_ids or {}).get(value) or ""),
+            }
+            for value in selected_hardware_ports
+        ],
+    }, separators=(",", ":")).encode("utf-8")).decode("ascii")
+    script = rf"""python3 - {arguments} <<'PY'
+import base64
+import json
+import re
+import subprocess
+import sys
+import tomllib
+import urllib.request
+from pathlib import Path
+
+MARKER = "__BLACKNODE_UPDATE_CHECK__="
+request = json.loads(base64.urlsafe_b64decode(sys.argv[1]).decode("utf-8"))
+home = Path.home()
+instance = request["instance_id"]
+if instance == "default":
+    runtime_dir = home / "blacknode-runtime"
+    runtime_service = "blacknode-runtime.service"
+else:
+    runtime_dir = home / "blacknode-runtimes" / instance
+    runtime_service = f"blacknode-runtime-{{instance}}.service"
+
+def command(args, timeout=30):
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(args, 124, "", str(exc))
+
+def project_version(text):
+    try:
+        payload = tomllib.loads(text)
+        return str((payload.get("project") or {{}}).get("version") or "unknown")
+    except Exception:
+        return "unknown"
+
+def package_version(directory):
+    try:
+        return project_version(
+            (Path(directory) / "pyproject.toml").read_text(encoding="utf-8")
+        )
+    except Exception:
+        return "unknown"
+
+def resolve_hardware(port, expected_device_id):
+    installed = command([
+        "systemctl", "list-unit-files", "blacknode-hardware*.service", "--no-legend"
+    ])
+    active = command([
+        "systemctl", "list-units", "--all", "--type=service",
+        "blacknode-hardware*.service", "--no-legend",
+    ])
+    candidate_units = {{
+        line.split()[0]
+        for line in (installed.stdout + "\n" + active.stdout).splitlines()
+        if line.split()
+    }}
+    candidate_units.update(
+        path.name
+        for root in (Path("/etc/systemd/system"), Path("/run/systemd/system"))
+        for path in root.glob("blacknode-hardware*.service")
+    )
+    matches = []
+    states = {{}}
+    definitions = {{}}
+    declared_ports = {{}}
+    device_ids = {{}}
+    for unit in sorted(candidate_units):
+        if not re.fullmatch(r"blacknode-hardware(?:[-.@][A-Za-z0-9_.@-]+)?\.service", unit):
+            continue
+        shown = command(["systemctl", "show", unit, "--property=ExecStart", "--value"])
+        definition = ""
+        for root in (Path("/etc/systemd/system"), Path("/run/systemd/system")):
+            unit_path = root / unit
+            if unit_path.is_file():
+                try:
+                    definition += unit_path.read_text(encoding="utf-8") + "\n"
+                except OSError:
+                    pass
+        definitions[unit] = definition
+        normalized = (shown.stdout + "\n" + definition).replace('"', "")
+        declared_ports[unit] = sorted({{
+            int(value)
+            for value in re.findall(r"--port(?:=|\s+)([0-9]+)", normalized)
+        }})
+        config_match = re.search(r"--config(?:=|\s+)([^\s;]+)", normalized)
+        configured_device_id = ""
+        if config_match:
+            try:
+                configured_device_id = str(
+                    json.loads(
+                        Path(config_match.group(1)).read_text(encoding="utf-8")
+                    ).get("device_id") or ""
+                )
+            except Exception:
+                pass
+        device_ids[unit] = configured_device_id
+        states[unit] = {{
+            "active": command(["systemctl", "is-active", unit]).stdout.strip() or "unknown",
+            "enabled": command(["systemctl", "is-enabled", unit]).stdout.strip() or "unknown",
+        }}
+        if int(port) in declared_ports[unit]:
+            matches.append(unit)
+    resolution_error = ""
+    if not matches:
+        identity_matches = [
+            unit
+            for unit in sorted(candidate_units)
+            if expected_device_id and device_ids.get(unit) == expected_device_id
+        ]
+        if identity_matches:
+            matches = identity_matches
+            configured = sorted({{
+                configured_port
+                for unit in identity_matches
+                for configured_port in declared_ports.get(unit, [])
+            }})
+            resolution_error = (
+                f"The persistent service for robot {{expected_device_id!r}} "
+                f"declares port(s) {{configured or ['unknown']}}, while the editor "
+                f"is paired to port {{port}}. Repair Hardware will reconcile the "
+                "saved service port using this stable robot identity."
+            )
+        else:
+            details = ", ".join(
+                f"{{unit}} (ports={{declared_ports.get(unit) or ['unknown']}}, "
+                f"device_id={{device_ids.get(unit) or 'unknown'}})"
+                for unit in sorted(candidate_units)
+            ) or "none"
+            raise RuntimeError(
+                f"No persistent Hardware service matches port {{port}} or robot "
+                f"identity {{expected_device_id or 'not reported'!r}}. "
+                f"Discovered units: {{details}}."
+            )
+    active_matches = [
+        unit for unit in matches if states[unit]["active"] == "active"
+    ]
+    enabled_matches = [
+        unit for unit in matches if states[unit]["enabled"] == "enabled"
+    ]
+    if len(matches) == 1:
+        unit = matches[0]
+    elif len(active_matches) == 1:
+        unit = active_matches[0]
+    elif len(active_matches) > 1:
+        raise RuntimeError(
+            f"Multiple active Blacknode Hardware services claim port {{port}}: "
+            + ", ".join(active_matches)
+        )
+    elif len(enabled_matches) == 1:
+        unit = enabled_matches[0]
+    else:
+        details = ", ".join(
+            f"{{candidate}} (active={{states[candidate]['active']}}, "
+            f"enabled={{states[candidate]['enabled']}})"
+            for candidate in matches
+        )
+        raise RuntimeError(
+            f"Could not choose the persistent Hardware service for port {{port}}. "
+            f"Candidates: {{details}}."
+        )
+    directory = command([
+        "systemctl", "show", unit, "--property=WorkingDirectory", "--value"
+    ]).stdout.strip()
+    if not directory:
+        working_directory = re.findall(
+            r"^WorkingDirectory=(.+)$",
+            definitions.get(unit, ""),
+            flags=re.MULTILINE,
+        )
+        if working_directory:
+            directory = working_directory[-1].strip().strip('"')
+    if not directory:
+        raise RuntimeError(f"{{unit}} does not report its repository WorkingDirectory.")
+    return unit, Path(directory), resolution_error
+
+def inspect(kind, repository, service, port, directory):
+    component = {{
+        "kind": kind,
+        "service_name": service,
+        "port": int(port),
+        "installed": {{"version": package_version(directory), "commit": ""}},
+        "latest": {{"version": "unknown", "commit": ""}},
+        "update_available": False,
+        "can_update": False,
+        "dirty": False,
+        "state": command(["systemctl", "is-active", service]).stdout.strip() or "unknown",
+        "error": "",
+    }}
+    try:
+        if not (directory / ".git").is_dir():
+            raise RuntimeError(f"{{repository}} is not an updateable Git checkout.")
+        origin = command(["git", "-C", str(directory), "remote", "get-url", "origin"])
+        origin_url = origin.stdout.strip()
+        normalized = origin_url.lower().removesuffix(".git").rstrip("/")
+        if not re.search(
+            rf"(?:github\.com[:/])temiroff/{{re.escape(repository)}}$",
+            normalized,
+        ):
+            raise RuntimeError(
+                f"origin is not the trusted temiroff/{{repository}} repository"
+            )
+        current = command(["git", "-C", str(directory), "rev-parse", "HEAD"])
+        if current.returncode:
+            raise RuntimeError(current.stderr.strip() or "could not read installed commit")
+        component["installed"]["commit"] = current.stdout.strip()[:12]
+        dirty = command([
+            "git", "-C", str(directory), "status", "--porcelain", "--untracked-files=normal"
+        ])
+        component["dirty"] = bool(dirty.stdout.strip())
+        branch = command([
+            "git", "-C", str(directory), "rev-parse", "--abbrev-ref", "HEAD",
+        ]).stdout.strip()
+        upstream = command([
+            "git", "-C", str(directory), "config", "--get",
+            f"branch.{{branch}}.merge",
+        ])
+        upstream_ref = upstream.stdout.strip()
+        if not upstream_ref.startswith("refs/heads/"):
+            raise RuntimeError("the installed branch has no upstream configured")
+        latest = command(["git", "ls-remote", origin_url, upstream_ref], timeout=45)
+        if latest.returncode or not latest.stdout.strip():
+            raise RuntimeError(
+                latest.stderr.strip() or "could not read the latest upstream commit"
+            )
+        latest_commit = latest.stdout.split()[0]
+        component["latest"]["commit"] = latest_commit[:12]
+        component["update_available"] = current.stdout.strip() != latest_commit
+        if not component["update_available"]:
+            component["latest"]["version"] = component["installed"]["version"]
+        else:
+            local_latest = command([
+                "git", "-C", str(directory), "show",
+                f"{{latest_commit}}:pyproject.toml",
+            ])
+            if not local_latest.returncode:
+                component["latest"]["version"] = project_version(local_latest.stdout)
+            if component["latest"]["version"] == "unknown":
+                raw_url = (
+                    f"https://raw.githubusercontent.com/temiroff/{{repository}}/"
+                    f"{{latest_commit}}/pyproject.toml"
+                )
+                try:
+                    with urllib.request.urlopen(raw_url, timeout=15) as response:
+                        component["latest"]["version"] = project_version(
+                            response.read().decode("utf-8")
+                        )
+                except Exception:
+                    pass
+        component["can_update"] = not component["dirty"]
+        if component["dirty"]:
+            component["error"] = (
+                "Local source changes must be committed, stashed, or removed before update."
+            )
+    except Exception as exc:
+        component["error"] = str(exc)
+    return component
+
+components = [
+    inspect(
+        "runtime",
+        "blacknode-runtime",
+        runtime_service,
+        request["runtime_port"],
+        runtime_dir,
+    )
+]
+for target in request["hardware_targets"]:
+    hardware_port = int(target["port"])
+    try:
+        service, directory, resolution_error = resolve_hardware(
+            hardware_port,
+            str(target.get("device_id") or ""),
+        )
+        component = inspect(
+            "hardware",
+            "blacknode-hardware",
+            service,
+            hardware_port,
+            directory,
+        )
+        if resolution_error:
+            component["error"] = resolution_error
+            component["can_update"] = False
+        components.append(component)
+    except Exception as exc:
+        components.append({{
+            "kind": "hardware",
+            "service_name": "unresolved",
+            "port": int(hardware_port),
+            "installed": {{"version": "unknown", "commit": ""}},
+            "latest": {{"version": "unknown", "commit": ""}},
+            "update_available": False,
+            "can_update": False,
+            "dirty": False,
+            "state": "unknown",
+            "error": str(exc),
+        }})
+print(MARKER + json.dumps({{
+    "ok": all(not item["error"] for item in components),
+    "components": components,
+}}, separators=(",", ":")))
+PY"""
+    try:
+        report(25, "Comparing installed Runtime and Hardware commits")
+        output = _run(connection, script, timeout=120.0)
+        payload_line = next(
+            (
+                line[len("__BLACKNODE_UPDATE_CHECK__="):]
+                for line in reversed(output.splitlines())
+                if line.startswith("__BLACKNODE_UPDATE_CHECK__=")
+            ),
+            "",
+        )
+        if not payload_line:
+            raise DeviceInstallError("The device did not return a software version report.")
+        try:
+            result = json.loads(payload_line)
+        except json.JSONDecodeError as exc:
+            raise DeviceInstallError("The device returned an invalid software version report.") from exc
+        if not isinstance(result, dict) or not isinstance(result.get("components"), list):
+            raise DeviceInstallError("The device returned an incomplete software version report.")
+        result["host_fingerprint"] = connection.fingerprint
+        report(90, "Installed and latest versions compared")
+        return result
+    finally:
+        connection.close()
+
+
 def control_runtime(
     *,
     host: str,
@@ -1129,27 +2078,56 @@ hardware_port="$1"
   exit 2
 }
 mapfile -t candidate_units < <(
-  systemctl list-unit-files 'blacknode-hardware*.service' --no-legend 2>/dev/null \
-    | awk '{print $1}'
+  {
+    systemctl list-unit-files 'blacknode-hardware*.service' --no-legend 2>/dev/null
+    systemctl list-units --all --type=service 'blacknode-hardware*.service' \
+      --no-legend 2>/dev/null
+    find /etc/systemd/system /run/systemd/system -maxdepth 1 \
+      -name 'blacknode-hardware*.service' -printf '%f\n' 2>/dev/null
+  } | awk '{print $1}' | sort -u
 )
 matches=()
+active_matches=()
+enabled_matches=()
 for unit in "${candidate_units[@]}"; do
-  [[ "$unit" =~ ^blacknode-hardware([-.][A-Za-z0-9_.@-]+)?\.service$ ]] || continue
+  [[ "$unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\.service$ ]] || continue
   exec_start="$(systemctl show "$unit" --property=ExecStart --value 2>/dev/null || true)"
-  normalized="${exec_start//\"/}"
-  if [[ "$normalized" =~ --port(=|[[:space:]])${hardware_port}([^0-9]|$) ]]; then
+  unit_definition=""
+  for unit_path in "/etc/systemd/system/$unit" "/run/systemd/system/$unit"; do
+    if [[ -f "$unit_path" ]]; then
+      unit_definition+="$(command cat "$unit_path")"
+      unit_definition+=$'\n'
+    fi
+  done
+  normalized="${exec_start//\"/}"$'\n'"${unit_definition//\"/}"
+  if printf '%s\n' "$normalized" \
+    | grep -oE -- '--port(=|[[:space:]])[0-9]+' \
+    | grep -oE '[0-9]+' \
+    | grep -Fxq -- "$hardware_port"; then
     matches+=("$unit")
+    systemctl is-active --quiet "$unit" 2>/dev/null \
+      && active_matches+=("$unit")
+    systemctl is-enabled --quiet "$unit" 2>/dev/null \
+      && enabled_matches+=("$unit")
   fi
 done
 if [[ "${#matches[@]}" -eq 0 ]]; then
-  echo "No Blacknode hardware service owns port $hardware_port."
+  echo "No Blacknode hardware service owns port $hardware_port. Discovered units: ${candidate_units[*]:-none}."
   exit 3
 fi
-if [[ "${#matches[@]}" -ne 1 ]]; then
-  echo "Multiple Blacknode hardware services claim port $hardware_port."
+if [[ "${#matches[@]}" -eq 1 ]]; then
+  service_name="${matches[0]}"
+elif [[ "${#active_matches[@]}" -eq 1 ]]; then
+  service_name="${active_matches[0]}"
+elif [[ "${#active_matches[@]}" -gt 1 ]]; then
+  echo "Multiple active Blacknode hardware services claim port $hardware_port: ${active_matches[*]}."
+  exit 4
+elif [[ "${#enabled_matches[@]}" -eq 1 ]]; then
+  service_name="${enabled_matches[0]}"
+else
+  echo "Could not choose the hardware service for port $hardware_port. Candidates: ${matches[*]}. Enabled: ${enabled_matches[*]:-none}."
   exit 4
 fi
-service_name="${matches[0]}"
 sudo -S -p '' systemctl restart "$service_name"
 state=""
 for _attempt in {1..40}; do

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -272,6 +272,16 @@ class RuntimeDeviceClient(HardwareDeviceClient):
             f"{self._deployment_endpoint(deployment_id)}/logs?limit={safe_limit}",
         )
 
+    def deployment_telemetry(
+        self,
+        deployment_id: str,
+        *,
+        stream: str = "robot-state",
+    ) -> dict[str, Any]:
+        endpoint = self._deployment_endpoint(deployment_id)
+        query = urllib.parse.urlencode({"stream": stream})
+        return self._request("GET", f"{endpoint}/telemetry?{query}")
+
     def delete_deployment(self, deployment_id: str) -> dict[str, Any]:
         return self._request("DELETE", self._deployment_endpoint(deployment_id))
 
@@ -497,6 +507,78 @@ class DeviceRegistry:
             ]
             return public
 
+    def set_host_remote_device_id(
+        self,
+        host_id: str,
+        remote_device_id: str,
+    ) -> dict[str, Any]:
+        clean_remote_id = str(remote_device_id or "").strip()
+        if not clean_remote_id:
+            raise DeviceRegistryError("The runtime manifest has no stable device identity.")
+        with self._lock:
+            hosts, records = self._load_payload()
+            hosts, _changed = self._materialize_hosts(hosts, records)
+            host = hosts.get(host_id)
+            if host is None:
+                raise KeyError(host_id)
+            current_remote_id = str(host.get("remote_device_id") or "").strip()
+            if current_remote_id and current_remote_id != clean_remote_id:
+                raise DeviceRegistryError(
+                    "The paired runtime identity changed. Pair the runtime again "
+                    "before enabling SSH management."
+                )
+            host["remote_device_id"] = clean_remote_id
+            host["updated_at"] = _iso_now()
+            self._save_payload(hosts, records)
+            public = self._public_host(host)
+            public["robots"] = [
+                self._public(record)
+                for record in records.values()
+                if str(record.get("host_id") or "") == host_id
+            ]
+            return public
+
+    def set_host_management(
+        self,
+        host_id: str,
+        managed_runtime: dict[str, Any],
+    ) -> dict[str, Any]:
+        allowed_keys = {
+            "ssh_host",
+            "ssh_port",
+            "ssh_username",
+            "host_fingerprint",
+            "instance_id",
+            "runtime_port",
+            "service_name",
+            "runtime_dir",
+        }
+        management = {
+            key: value
+            for key, value in managed_runtime.items()
+            if key in allowed_keys
+        }
+        if set(management) != allowed_keys:
+            raise DeviceRegistryError(
+                "The verified SSH runtime identity is incomplete."
+            )
+        with self._lock:
+            hosts, records = self._load_payload()
+            hosts, _changed = self._materialize_hosts(hosts, records)
+            host = hosts.get(host_id)
+            if host is None:
+                raise KeyError(host_id)
+            host["managed_runtime"] = management
+            host["updated_at"] = _iso_now()
+            self._save_payload(hosts, records)
+            public = self._public_host(host)
+            public["robots"] = [
+                self._public(record)
+                for record in records.values()
+                if str(record.get("host_id") or "") == host_id
+            ]
+            return public
+
     def rename_host(self, host_id: str, name: str) -> dict[str, Any]:
         clean_name = str(name or "").strip()
         if not clean_name:
@@ -665,6 +747,10 @@ class DeviceRegistry:
                 "runtime_token_fingerprint": token_fingerprint(clean_runtime_token),
                 "runtime_token_explicit": runtime_token_explicit,
                 "remote_device_id": remote_device_id,
+                "software_version": (
+                    str(status.get("software_version") or "").strip()
+                    or str((existing or {}).get("software_version") or "").strip()
+                ),
                 "paused": False,
                 "created_at": created_at,
                 "updated_at": now,
@@ -688,6 +774,25 @@ class DeviceRegistry:
                         other["updated_at"] = now
             self._save_payload(hosts, records)
             return self._public(record)
+
+    def remember_device_software_version(
+        self,
+        device_id: str,
+        software_version: str,
+    ) -> None:
+        clean_version = str(software_version or "").strip()
+        if not clean_version or clean_version.casefold() == "unknown":
+            return
+        with self._lock:
+            hosts, records = self._load_payload()
+            record = records.get(device_id)
+            if record is None:
+                raise KeyError(device_id)
+            if str(record.get("software_version") or "") == clean_version:
+                return
+            record["software_version"] = clean_version
+            record["updated_at"] = _iso_now()
+            self._save_payload(hosts, records)
 
     def delete(self, device_id: str) -> bool:
         with self._lock:

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -1,6 +1,6 @@
 """Blacknode editor backend — FastAPI server the React editor talks to."""
 from __future__ import annotations
-import uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex, hashlib
+import asyncio, uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex, hashlib
 import urllib.error, urllib.parse, urllib.request
 from datetime import datetime
 from pathlib import Path
@@ -56,11 +56,13 @@ from blacknode.workflow import validate_workflow as validate_bn_workflow
 from device_installer import (
     control_runtime,
     DeviceInstallError,
+    inspect_managed_service_updates,
     inspect_runtime,
     install_runtime,
     probe_device,
     restart_hardware_service,
     uninstall_runtime,
+    update_managed_services,
 )
 from device_registry import (
     DeviceRegistry,
@@ -436,12 +438,19 @@ class InstallDeviceHostReq(InspectDeviceHostReq):
     action: str = "install"
     instance_id: str = ""
 
+class ConfigureDeviceHostManagementReq(InspectDeviceHostReq):
+    pass
+
 class UninstallDeviceHostReq(BaseModel):
     password: str
 
 class RuntimeLifecycleReq(BaseModel):
     action: str
     password: str
+
+class UpdateManagedDeviceReq(BaseModel):
+    password: str
+    scope: str = "all"
 
 class RobotLifecycleReq(BaseModel):
     action: str
@@ -3086,6 +3095,137 @@ def get_device_host_runtime_status(host_id: str):
     return _device_host_runtime_status(host_id)
 
 
+@app.post("/device-hosts/{host_id}/management")
+def configure_device_host_management(
+    host_id: str,
+    req: ConfigureDeviceHostManagementReq,
+):
+    try:
+        host = _device_registry.get_host_public(host_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    if host is None:
+        raise HTTPException(404, "Device not found")
+    if isinstance(host.get("managed_runtime"), dict):
+        raise HTTPException(409, "SSH management is already configured for this device.")
+
+    try:
+        runtime_port = urllib.parse.urlsplit(
+            str(host.get("runtime_url") or "")
+        ).port
+    except ValueError as exc:
+        raise HTTPException(409, "The paired runtime URL has an invalid port.") from exc
+    if not runtime_port:
+        raise HTTPException(
+            409,
+            "The paired runtime URL must include its service port before SSH "
+            "management can be enabled.",
+        )
+
+    try:
+        inspection = inspect_runtime(
+            host=req.host,
+            port=req.port,
+            username=req.username,
+            password=req.password,
+            host_fingerprint=req.host_fingerprint,
+        )
+    except DeviceInstallError as exc:
+        raise HTTPException(400, str(exc)) from exc
+
+    expected_device_id = str(host.get("remote_device_id") or "").strip()
+    if not expected_device_id:
+        try:
+            manifest = _device_registry.host_client(host_id).manifest()
+            if (
+                manifest.get("service") != "blacknode-runtime"
+                or manifest.get("protocol_version") != 1
+            ):
+                raise DeviceRegistryError(
+                    "Runtime service identity or protocol is incompatible."
+                )
+            expected_device_id = str(manifest.get("device_id") or "").strip()
+            _device_registry.set_host_remote_device_id(
+                host_id,
+                expected_device_id,
+            )
+        except KeyError as exc:
+            raise HTTPException(404, "Device not found") from exc
+        except DeviceRegistryError as exc:
+            raise HTTPException(
+                409,
+                "Blacknode could not recover a stable identity from this paired "
+                f"runtime. Pair the runtime again first. {exc}",
+            ) from exc
+    matches = [
+        instance
+        for instance in inspection.get("instances", [])
+        if (
+            isinstance(instance, dict)
+            and int(instance.get("port") or 0) == runtime_port
+            and bool(instance.get("service_installed"))
+            and str(instance.get("device_id") or "") == expected_device_id
+        )
+    ]
+    if not matches:
+        raise HTTPException(
+            409,
+            f"SSH connected, but no installed Blacknode runtime service on port "
+            f"{runtime_port} matches this paired device ({expected_device_id or 'unknown ID'}).",
+        )
+    if len(matches) != 1:
+        raise HTTPException(
+            409,
+            f"Multiple installed runtime services match port {runtime_port}; "
+            "resolve the duplicate services before enabling SSH management.",
+        )
+    instance = matches[0]
+    management = {
+        "ssh_host": str(req.host or "").strip(),
+        "ssh_port": int(req.port),
+        "ssh_username": str(req.username or "").strip(),
+        "host_fingerprint": str(inspection.get("host_fingerprint") or ""),
+        "instance_id": str(instance.get("instance_id") or ""),
+        "runtime_port": runtime_port,
+        "service_name": str(instance.get("service_name") or ""),
+        "runtime_dir": str(instance.get("runtime_dir") or ""),
+    }
+    if not all(
+        management.get(key)
+        for key in (
+            "ssh_host",
+            "ssh_username",
+            "host_fingerprint",
+            "instance_id",
+            "service_name",
+            "runtime_dir",
+        )
+    ):
+        raise HTTPException(
+            409,
+            "The matching runtime service does not expose a complete management identity.",
+        )
+    try:
+        device = _device_registry.set_host_management(host_id, management)
+    except KeyError as exc:
+        raise HTTPException(404, "Device not found") from exc
+    except DeviceRegistryError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    return {
+        "ok": True,
+        "device": device,
+        "instance": {
+            key: value
+            for key, value in instance.items()
+            if not str(key).startswith("_")
+        },
+        "summary": (
+            f"SSH management enabled for {management['service_name']} on "
+            f"runtime port {runtime_port}."
+        ),
+    }
+
+
 def _raise_rpc_error(result: dict[str, Any], *, action: str) -> None:
     error = result.get("error") if isinstance(result, dict) else None
     if not error:
@@ -3281,6 +3421,454 @@ def _lifecycle_stream(worker: Callable[[Callable[[dict[str, Any]], None]], dict[
 def stream_device_host_lifecycle(host_id: str, req: RuntimeLifecycleReq):
     return _lifecycle_stream(
         lambda progress: _control_device_host_lifecycle_payload(host_id, req, progress)
+    )
+
+
+def _update_device_host_payload(
+    host_id: str,
+    req: UpdateManagedDeviceReq,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    def report(percent: int, message: str) -> None:
+        if progress is not None:
+            progress({
+                "progress": max(0, min(100, int(percent))),
+                "message": str(message),
+            })
+
+    if not str(req.password or ""):
+        raise HTTPException(400, "Enter the SSH password to update this device.")
+    scope = str(req.scope or "all").strip().lower()
+    if scope not in {"all", "runtime", "hardware"}:
+        raise HTTPException(400, "Update scope must be all, runtime, or hardware.")
+    host = _device_registry.get_host_public(host_id)
+    if host is None:
+        raise HTTPException(404, "Device not found")
+    managed = host.get("managed_runtime")
+    if not isinstance(managed, dict):
+        raise HTTPException(
+            409,
+            "Enable SSH controls for this device before updating its services.",
+        )
+
+    robots = list(host.get("robots") or [])
+    hardware_ports: list[int] = []
+    hardware_device_ids: dict[int, str] = {}
+    for robot in robots:
+        try:
+            hardware_port = urllib.parse.urlsplit(
+                str(robot.get("base_url") or "")
+            ).port
+        except ValueError as exc:
+            raise HTTPException(
+                409,
+                f"{robot.get('name') or 'A robot'} has an invalid hardware URL.",
+            ) from exc
+        if not hardware_port:
+            raise HTTPException(
+                409,
+                f"{robot.get('name') or 'A robot'} has no hardware service port.",
+            )
+        hardware_ports.append(hardware_port)
+        hardware_device_ids[hardware_port] = str(
+            robot.get("remote_device_id") or ""
+        )
+    include_runtime = scope in {"all", "runtime"}
+    selected_hardware_ports = (
+        hardware_ports if scope in {"all", "hardware"} else []
+    )
+    if scope == "hardware" and not selected_hardware_ports:
+        raise HTTPException(409, "This device has no attached Hardware services to update.")
+
+    stopped_deployments: list[str] = []
+    controlled_robots: list[str] = []
+    warnings: list[str] = []
+    runtime_api_unavailable = False
+    report(5, "Stopping running deployments")
+    if not host.get("paused"):
+        last_runtime_error = ""
+        for attempt in range(3):
+            try:
+                runtime_client = _device_registry.host_client(host_id)
+                for deployment in runtime_client.list_deployments().get("deployments") or []:
+                    if (
+                        isinstance(deployment, dict)
+                        and str(deployment.get("state") or "") == "running"
+                        and str(deployment.get("id") or "")
+                    ):
+                        deployment_id = str(deployment["id"])
+                        runtime_client.stop_deployment(deployment_id)
+                        stopped_deployments.append(deployment_id)
+                last_runtime_error = ""
+                break
+            except (DeviceRegistryError, KeyError) as exc:
+                last_runtime_error = str(exc)
+                if attempt < 2:
+                    time.sleep(0.35)
+        if last_runtime_error:
+            runtime_api_unavailable = True
+            warnings.append(
+                "The Runtime API could not stop deployments directly. Blacknode "
+                "used the verified SSH service identity to stop the Runtime and its "
+                "deployment process group before updating. "
+                f"API error: {last_runtime_error}"
+            )
+
+    report(12, "Stopping and disarming attached robots")
+    for robot in robots:
+        robot_id = str(robot.get("id") or "")
+        if not robot_id:
+            continue
+        try:
+            result = _paired_device_client(robot_id).rpc({
+                "jsonrpc": "2.0",
+                "id": f"device-update-stop-{robot_id}",
+                "method": "stop",
+                "params": {},
+            })
+            _raise_rpc_error(result, action="prepare update for")
+            _device_registry.set_device_paused(robot_id, True)
+            controlled_robots.append(robot_id)
+        except (DeviceRegistryError, HTTPException, KeyError) as exc:
+            detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
+            raise DeviceRegistryError(
+                f"Robot {robot.get('name') or robot_id} could not be stopped "
+                f"before update: {detail}"
+            ) from exc
+
+    runtime_paused_for_fallback = False
+    try:
+        if runtime_api_unavailable and not host.get("paused"):
+            report(14, "Stopping the unreachable Runtime safely over SSH")
+            control_runtime(
+                host=str(managed.get("ssh_host") or ""),
+                port=int(managed.get("ssh_port") or 22),
+                username=str(managed.get("ssh_username") or ""),
+                password=req.password,
+                host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                instance_id=str(managed.get("instance_id") or "default"),
+                action="pause",
+            )
+            runtime_paused_for_fallback = True
+        update = update_managed_services(
+            host=str(managed.get("ssh_host") or ""),
+            port=int(managed.get("ssh_port") or 22),
+            username=str(managed.get("ssh_username") or ""),
+            password=req.password,
+            host_fingerprint=str(managed.get("host_fingerprint") or ""),
+            instance_id=str(managed.get("instance_id") or "default"),
+            runtime_port=int(managed.get("runtime_port") or 0),
+            hardware_ports=selected_hardware_ports,
+            hardware_device_ids={
+                hardware_port: hardware_device_ids.get(hardware_port, "")
+                for hardware_port in selected_hardware_ports
+            },
+            include_runtime=include_runtime,
+            progress=lambda value: report(
+                15 + int(int(value.get("progress") or 0) * 0.75),
+                str(value.get("message") or "Updating managed services"),
+            ),
+        )
+    except Exception:
+        if runtime_paused_for_fallback:
+            try:
+                control_runtime(
+                    host=str(managed.get("ssh_host") or ""),
+                    port=int(managed.get("ssh_port") or 22),
+                    username=str(managed.get("ssh_username") or ""),
+                    password=req.password,
+                    host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                    instance_id=str(managed.get("instance_id") or "default"),
+                    action="resume",
+                )
+            except DeviceInstallError:
+                pass
+        for robot_id in controlled_robots:
+            try:
+                result = _paired_device_client(robot_id).rpc({
+                    "jsonrpc": "2.0",
+                    "id": f"device-update-recover-{robot_id}",
+                    "method": "resume",
+                    "params": {},
+                })
+                _raise_rpc_error(result, action="recover after update failure for")
+                _device_registry.set_device_paused(robot_id, False)
+            except (DeviceRegistryError, HTTPException, KeyError):
+                pass
+        raise
+
+    report(92, "Verifying reported runtime and hardware versions")
+    runtime_manifest: dict[str, Any] | None = None
+    runtime_error = ""
+    for _attempt in range(40):
+        try:
+            candidate = _device_registry.host_client(host_id).manifest()
+            if (
+                candidate.get("service") == "blacknode-runtime"
+                and candidate.get("protocol_version") == 1
+            ):
+                runtime_manifest = candidate
+                break
+        except (DeviceRegistryError, KeyError) as exc:
+            runtime_error = str(exc)
+            time.sleep(0.25)
+    if runtime_manifest is None:
+        raise DeviceRegistryError(
+            f"The runtime service updated but did not pass verification: {runtime_error}"
+        )
+
+    verified_robots: list[dict[str, Any]] = []
+    for robot in robots:
+        robot_id = str(robot.get("id") or "")
+        expected_id = str(robot.get("remote_device_id") or "")
+        verified_status: dict[str, Any] | None = None
+        last_error = ""
+        for _attempt in range(40):
+            try:
+                candidate = _paired_device_client(robot_id).status()
+                actual_id = str(candidate.get("device_id") or "")
+                if expected_id and actual_id != expected_id:
+                    raise DeviceRegistryError(
+                        f"returned robot '{actual_id}', expected '{expected_id}'"
+                    )
+                verified_status = candidate
+                break
+            except (DeviceRegistryError, HTTPException) as exc:
+                last_error = exc.detail if isinstance(exc, HTTPException) else str(exc)
+                time.sleep(0.25)
+        if verified_status is None:
+            raise DeviceRegistryError(
+                f"{robot.get('name') or robot_id} did not pass verification: {last_error}"
+            )
+        if verified_status.get("armed"):
+            raise DeviceRegistryError(
+                f"{robot.get('name') or robot_id} returned armed after its update."
+            )
+        if verified_status.get("torque_enabled") is True:
+            warnings.append(
+                f"{robot.get('name') or robot_id} reports physical servo torque enabled. "
+                "The software update did not turn off actuator power."
+            )
+        verified_status["paused"] = False
+        _device_registry.set_device_paused(robot_id, False)
+        verified_robots.append({
+            "id": robot_id,
+            "name": str(robot.get("name") or robot_id),
+            "port": urllib.parse.urlsplit(str(robot.get("base_url") or "")).port,
+            "software_version": str(
+                verified_status.get("software_version") or "not reported"
+            ),
+            "status": verified_status,
+        })
+
+    for component in update.get("components") or []:
+        if not isinstance(component, dict):
+            continue
+        if component.get("kind") == "runtime":
+            component["reported_version"] = str(
+                runtime_manifest.get("runtime_version") or "not reported"
+            )
+            continue
+        component_port = int(component.get("port") or 0)
+        robot_report = next(
+            (
+                item for item in verified_robots
+                if int(item.get("port") or 0) == component_port
+            ),
+            None,
+        )
+        if robot_report:
+            component["reported_version"] = robot_report["software_version"]
+
+    device = _device_registry.set_host_paused(host_id, False)
+    changed = sum(
+        1
+        for component in update.get("components") or []
+        if isinstance(component, dict) and component.get("changed")
+    )
+    service_count = len(update.get("components") or [])
+    current_reinstalled = service_count - changed
+    if changed:
+        summary = (
+            f"Updated {changed} managed service"
+            f"{'s' if changed != 1 else ''}"
+            + (
+                f" and reinstalled {current_reinstalled} current service"
+                f"{'s' if current_reinstalled != 1 else ''}"
+                if current_reinstalled
+                else ""
+            )
+            + ". "
+        )
+    else:
+        summary = (
+            f"Reinstalled {service_count} current managed service"
+            f"{'s' if service_count != 1 else ''}. "
+        )
+    summary += (
+        "The runtime and robot monitoring are online, and Blacknode motion remains disarmed."
+    )
+    if warnings:
+        summary += (
+            f" Completed with {len(warnings)} warning"
+            f"{'s' if len(warnings) != 1 else ''}; check the report."
+        )
+    report(100, summary)
+    return {
+        "ok": True,
+        "scope": scope,
+        "device": device,
+        "update": update,
+        "runtime": runtime_manifest,
+        "robots": verified_robots,
+        "stopped_deployments": stopped_deployments,
+        "controlled_robots": controlled_robots,
+        "warnings": warnings,
+        "summary": summary,
+    }
+
+
+@app.post("/device-hosts/{host_id}/update-stream")
+def stream_device_host_update(host_id: str, req: UpdateManagedDeviceReq):
+    return _lifecycle_stream(
+        lambda progress: _update_device_host_payload(host_id, req, progress)
+    )
+
+
+def _check_device_host_updates_payload(
+    host_id: str,
+    req: UpdateManagedDeviceReq,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    def report(percent: int, message: str) -> None:
+        if progress is not None:
+            progress({
+                "progress": max(0, min(100, int(percent))),
+                "message": str(message),
+            })
+
+    if not str(req.password or ""):
+        raise HTTPException(400, "Enter the SSH password to check software versions.")
+    host = _device_registry.get_host_public(host_id)
+    if host is None:
+        raise HTTPException(404, "Device not found")
+    managed = host.get("managed_runtime")
+    if not isinstance(managed, dict):
+        raise HTTPException(
+            409,
+            "Enable SSH controls for this device before checking upstream versions.",
+        )
+
+    robots = list(host.get("robots") or [])
+    hardware_ports: list[int] = []
+    hardware_device_ids: dict[int, str] = {}
+    for robot in robots:
+        try:
+            hardware_port = urllib.parse.urlsplit(
+                str(robot.get("base_url") or "")
+            ).port
+        except ValueError as exc:
+            raise HTTPException(
+                409,
+                f"{robot.get('name') or 'A robot'} has an invalid hardware URL.",
+            ) from exc
+        if not hardware_port:
+            raise HTTPException(
+                409,
+                f"{robot.get('name') or 'A robot'} has no hardware service port.",
+            )
+        hardware_ports.append(hardware_port)
+        hardware_device_ids[hardware_port] = str(
+            robot.get("remote_device_id") or ""
+        )
+
+    report(8, "Checking installed Runtime and Hardware software")
+    checked = inspect_managed_service_updates(
+        host=str(managed.get("ssh_host") or ""),
+        port=int(managed.get("ssh_port") or 22),
+        username=str(managed.get("ssh_username") or ""),
+        password=req.password,
+        host_fingerprint=str(managed.get("host_fingerprint") or ""),
+        instance_id=str(managed.get("instance_id") or "default"),
+        runtime_port=int(managed.get("runtime_port") or 0),
+        hardware_ports=hardware_ports,
+        hardware_device_ids=hardware_device_ids,
+        progress=lambda value: report(
+            10 + int(int(value.get("progress") or 0) * 0.75),
+            str(value.get("message") or "Comparing software versions"),
+        ),
+    )
+
+    warnings: list[str] = []
+    runtime_version = "not reported"
+    try:
+        manifest = _device_registry.host_client(host_id).manifest()
+        runtime_version = str(manifest.get("runtime_version") or "not reported")
+    except (DeviceRegistryError, KeyError) as exc:
+        warnings.append(f"Runtime live-version check failed: {exc}")
+
+    hardware_versions: dict[int, str] = {}
+    for robot in robots:
+        robot_id = str(robot.get("id") or "")
+        try:
+            robot_port = urllib.parse.urlsplit(str(robot.get("base_url") or "")).port
+            status = _paired_device_client(robot_id).status()
+            if robot_port:
+                hardware_versions[robot_port] = str(
+                    status.get("software_version") or "not reported"
+                )
+        except (DeviceRegistryError, HTTPException, ValueError) as exc:
+            detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
+            warnings.append(
+                f"{robot.get('name') or robot_id} live-version check failed: {detail}"
+            )
+
+    for component in checked.get("components") or []:
+        if not isinstance(component, dict):
+            continue
+        if component.get("kind") == "runtime":
+            component["reported_version"] = runtime_version
+        else:
+            component["reported_version"] = hardware_versions.get(
+                int(component.get("port") or 0),
+                "not reported",
+            )
+
+    components = [
+        item for item in checked.get("components") or []
+        if isinstance(item, dict)
+    ]
+    available = sum(1 for item in components if item.get("update_available"))
+    blockers = sum(1 for item in components if item.get("error"))
+    if blockers:
+        summary = (
+            f"Checked {len(components)} services; {blockers} need attention before "
+            "Runtime + Hardware can be updated."
+        )
+    elif available:
+        summary = (
+            f"{available} of {len(components)} services have updates available."
+        )
+    else:
+        summary = f"Runtime + Hardware are current across {len(components)} services."
+    if warnings:
+        summary += (
+            f" {len(warnings)} live service check"
+            f"{'s' if len(warnings) != 1 else ''} could not be completed."
+        )
+    report(100, summary)
+    return {
+        "ok": blockers == 0,
+        "check": checked,
+        "warnings": warnings,
+        "summary": summary,
+    }
+
+
+@app.post("/device-hosts/{host_id}/update-check-stream")
+def stream_device_host_update_check(host_id: str, req: UpdateManagedDeviceReq):
+    return _lifecycle_stream(
+        lambda progress: _check_device_host_updates_payload(host_id, req, progress)
     )
 
 
@@ -3622,6 +4210,16 @@ def rename_device(device_id: str, req: RenameDeviceReq):
 def get_device_status(device_id: str):
     try:
         return _deployment_aware_device_status(device_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+
+
+@app.get("/devices/{device_id}/monitor")
+def get_device_monitor(device_id: str):
+    try:
+        return _device_monitor_snapshot(device_id)
+    except KeyError as exc:
+        raise HTTPException(404, "Device not found") from exc
     except DeviceRegistryError as exc:
         raise HTTPException(502, str(exc)) from exc
 
@@ -4857,25 +5455,39 @@ def _set_device_deployment_lease(device_id: str, *, leased: bool) -> None:
 
 
 def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
-    """Recover an orphaned hardware lease, or explain the active owner."""
+    """Report running deployments separately from physical motion ownership."""
     client = _paired_device_client(device_id)
     status = client.status()
     saved_device = _device_registry.get_public(device_id)
-    if saved_device and saved_device.get("paused"):
-        result = dict(status)
-        result["paused"] = True
-        result["notice"] = (
-            "Robot is paused and disarmed. Resume it before starting a workflow."
-        )
-        return result
+    reported_version = str(status.get("software_version") or "").strip()
+    saved_version = str((saved_device or {}).get("software_version") or "").strip()
+    if reported_version and reported_version.casefold() != "unknown":
+        try:
+            _device_registry.remember_device_software_version(
+                device_id,
+                reported_version,
+            )
+        except KeyError:
+            pass
+    elif saved_version:
+        status = {
+            **status,
+            "software_version": saved_version,
+            "software_version_cached": True,
+        }
+    paused = bool(saved_device and saved_device.get("paused"))
+    if paused:
+        status = {**status, "paused": True}
     error = str(status.get("error") or "")
     folded_error = error.casefold()
-    if "leased" not in folded_error or "deployment" not in folded_error:
-        return status
+    hardware_is_leased = (
+        "leased" in folded_error
+        and "deployment" in folded_error
+    )
 
     try:
         payload = _device_registry.runtime_client(device_id).list_deployments()
-    except (DeviceRegistryError, KeyError):
+    except (DeviceRegistryError, KeyError, AttributeError, TypeError):
         return status
     deployments = [
         item
@@ -4893,32 +5505,274 @@ def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
     if active:
         owner = active[0]
         result = dict(status)
-        result["deployment_lease"] = {
+        deployment = {
             "id": str(owner.get("id") or ""),
             "name": str(owner.get("name") or owner.get("id") or "Deployment"),
             "state": str(owner.get("state") or "running"),
         }
-        result.pop("error", None)
+        if hardware_is_leased:
+            result["deployment_lease"] = deployment
+            result.pop("error", None)
+            result["notice"] = (
+                f"Running deployment '{owner.get('name') or owner.get('id')}' "
+                "controls this robot. Device checks are paused here to prevent "
+                "another process from opening the same hardware connection."
+            )
+        else:
+            result["running_deployment"] = deployment
+            result["notice"] = (
+                f"Deployment '{owner.get('name') or owner.get('id')}' is running, "
+                "but the hardware service does not report that it owns motion control."
+            )
+        return result
+
+    if hardware_is_leased:
+        try:
+            _set_device_deployment_lease(device_id, leased=False)
+            status = client.status()
+            if paused:
+                status = {**status, "paused": True}
+        except HTTPException:
+            pass
+
+    stored = sorted(
+        (
+            item
+            for item in deployments
+            if (
+                str(item.get("state") or "") != "running"
+                and str(item.get("target_device_id") or "") in {"", device_id}
+                and str(item.get("id") or "")
+            )
+        ),
+        key=lambda item: (
+            str(item.get("updated_at") or ""),
+            str(item.get("created_at") or ""),
+        ),
+        reverse=True,
+    )
+    if stored:
+        deployment = stored[0]
+        result = dict(status)
+        result["stored_deployment"] = {
+            "id": str(deployment.get("id") or ""),
+            "name": str(
+                deployment.get("name")
+                or deployment.get("id")
+                or "Deployment"
+            ),
+            "state": str(deployment.get("state") or "stopped"),
+        }
         result["notice"] = (
-            f"Running deployment '{owner.get('name') or owner.get('id')}' "
-            "controls this robot. Device checks are paused here to prevent "
-            "another process from opening the same hardware connection."
+            f"Deployment '{deployment.get('name') or deployment.get('id')}' "
+            f"is stored on the Runtime in the "
+            f"{deployment.get('state') or 'stopped'} state"
+            + (
+                ". Resume this robot before restarting it."
+                if paused
+                else " and can be restarted."
+            )
         )
         return result
 
+    if paused:
+        result = dict(status)
+        result["notice"] = (
+            "Robot is paused and disarmed. Resume it before starting a workflow."
+        )
+        return result
+    return status
+
+
+def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
+    """Return one normalized robot-state sample from the current bus owner."""
+    device = _device_registry.get_public(device_id)
+    if device is None:
+        raise KeyError(device_id)
+    status = _deployment_aware_device_status(device_id)
+    deployment = status.get("deployment_lease") or status.get("running_deployment")
+    now = datetime.now().astimezone().isoformat(timespec="milliseconds")
+    if isinstance(deployment, dict) and deployment.get("id"):
+        deployment_id = str(deployment["id"])
+        try:
+            telemetry = _device_registry.runtime_client(device_id).deployment_telemetry(
+                deployment_id,
+            )
+        except (DeviceRegistryError, AttributeError, TypeError) as exc:
+            detail = str(exc)
+            endpoint_missing = "HTTP 404" in detail or "not found" in detail.casefold()
+            return {
+                "type": "robot_telemetry",
+                "robot_id": device_id,
+                "robot_name": str(device.get("name") or device_id),
+                "source": "deployment",
+                "source_label": str(deployment.get("name") or deployment_id),
+                "deployment": deployment,
+                "available": False,
+                "stale": True,
+                "received_at": now,
+                "message": (
+                    (
+                        "This device Runtime does not support deployed monitoring yet. "
+                        "Update Runtime to 0.3.9 or newer; Robot Hardware does not "
+                        "need to be reinstalled. Then stage the workflow again to sync "
+                        "blacknode-drivers 0.2.1 or newer and restart the deployment."
+                    )
+                    if endpoint_missing
+                    else (
+                        "The running deployment has not exposed live telemetry yet. "
+                        "Update Runtime and the robot driver package, then restart the "
+                        f"deployment. Details: {detail}"
+                    )
+                ),
+            }
+        payload = telemetry.get("payload")
+        available = bool(telemetry.get("available") and isinstance(payload, dict))
+        return {
+            "type": "robot_telemetry",
+            "robot_id": device_id,
+            "robot_name": str(device.get("name") or device_id),
+            "source": "deployment",
+            "source_label": str(deployment.get("name") or deployment_id),
+            "deployment": deployment,
+            "available": available,
+            "stale": bool(telemetry.get("stale", not available)),
+            "sequence": int(telemetry.get("sequence") or 0),
+            "sent_at": str(telemetry.get("sent_at") or ""),
+            "received_at": str(telemetry.get("received_at") or now),
+            "age_seconds": telemetry.get("age_seconds"),
+            "payload": payload if available else None,
+            "message": str(
+                telemetry.get("message")
+                or (
+                    "Receiving state from the running deployment."
+                    if available
+                    else "Waiting for the running deployment to publish robot state."
+                )
+            ),
+        }
+
+    positions = {
+        str(name): float(value)
+        for name, value in dict(status.get("positions") or {}).items()
+        if isinstance(value, (int, float))
+    }
+    reported_joint_names = [
+        str(name)
+        for name in (status.get("joint_names") or [])
+        if str(name) in positions
+    ]
+    joint_names = reported_joint_names + [
+        name for name in positions if name not in reported_joint_names
+    ]
+    available = bool(status.get("connected") and positions)
+    return {
+        "type": "robot_telemetry",
+        "robot_id": device_id,
+        "robot_name": str(device.get("name") or device_id),
+        "source": "hardware",
+        "source_label": "Robot Hardware",
+        "available": available,
+        "stale": not available,
+        "sequence": int(time.time() * 1000),
+        "sent_at": now,
+        "received_at": now,
+        "payload": {
+            "connected": bool(status.get("connected")),
+            "armed": bool(status.get("armed")),
+            "torque_enabled": status.get("torque_enabled"),
+            "position_unit": "degree",
+            "velocity_unit": "degree/s",
+            "joints": [
+                {
+                    "name": name,
+                    "position": positions[name],
+                    "velocity": 0.0,
+                }
+                for name in joint_names
+                if name in positions
+            ],
+            "error": str(status.get("error") or ""),
+        },
+        "message": (
+            "Receiving state from Robot Hardware."
+            if available
+            else str(
+                status.get("error")
+                or "Robot Hardware is connected but has not reported joint positions."
+            )
+        ),
+    }
+
+
+@app.websocket("/api/devices/{device_id}/monitor/ws")
+@app.websocket("/devices/{device_id}/monitor/ws")
+async def device_monitor_socket(websocket: WebSocket, device_id: str):
+    await websocket.accept()
     try:
-        _set_device_deployment_lease(device_id, leased=False)
-    except HTTPException:
-        return status
-    return client.status()
+        while True:
+            try:
+                snapshot = await asyncio.to_thread(_device_monitor_snapshot, device_id)
+            except KeyError:
+                await websocket.send_json({
+                    "type": "robot_telemetry",
+                    "robot_id": device_id,
+                    "available": False,
+                    "stale": True,
+                    "message": "Robot is no longer paired with this editor.",
+                })
+                await websocket.close(code=1008)
+                return
+            except Exception as exc:  # keep a transient device outage visible
+                snapshot = {
+                    "type": "robot_telemetry",
+                    "robot_id": device_id,
+                    "available": False,
+                    "stale": True,
+                    "received_at": datetime.now().astimezone().isoformat(
+                        timespec="milliseconds"
+                    ),
+                    "message": f"Monitoring temporarily unavailable: {exc}",
+                }
+            await websocket.send_json(snapshot)
+            await asyncio.sleep(0.1)
+    except (WebSocketDisconnect, RuntimeError):
+        return
 
 
 @app.get("/devices/{device_id}/deployments")
 def list_device_deployments(device_id: str):
     try:
-        return _runtime_client_or_404(device_id).list_deployments()
+        payload = _runtime_client_or_404(device_id).list_deployments()
     except DeviceRegistryError as exc:
         raise HTTPException(502, str(exc)) from exc
+    deployments = [
+        deployment
+        for deployment in (payload.get("deployments") or [])
+        if (
+            isinstance(deployment, dict)
+            and str(deployment.get("target_device_id") or "").strip()
+            in {"", device_id}
+        )
+    ]
+    return {**payload, "deployments": deployments}
+
+
+def _require_targeted_deployment(
+    device_id: str,
+    deployment_id: str,
+) -> dict[str, Any]:
+    try:
+        deployment = _runtime_client_or_404(device_id).get_deployment(deployment_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+    target_device_id = str(deployment.get("target_device_id") or "").strip()
+    if target_device_id and target_device_id != device_id:
+        raise HTTPException(
+            404,
+            f"Deployment '{deployment_id}' does not belong to this robot.",
+        )
+    return deployment
 
 
 def _remote_deployment_owner(
@@ -5093,14 +5947,12 @@ def stage_device_deployment(device_id: str, req: RemoteDeployReq):
 
 @app.get("/devices/{device_id}/deployments/{deployment_id}")
 def get_device_deployment(device_id: str, deployment_id: str):
-    try:
-        return _runtime_client_or_404(device_id).get_deployment(deployment_id)
-    except DeviceRegistryError as exc:
-        raise HTTPException(502, str(exc)) from exc
+    return _require_targeted_deployment(device_id, deployment_id)
 
 
 @app.post("/devices/{device_id}/deployments/{deployment_id}/start")
 def start_device_deployment(device_id: str, deployment_id: str):
+    _require_targeted_deployment(device_id, deployment_id)
     _require_device_safe_to_start(device_id)
     _set_device_deployment_lease(device_id, leased=True)
     try:
@@ -5114,6 +5966,7 @@ def start_device_deployment(device_id: str, deployment_id: str):
 
 @app.post("/devices/{device_id}/deployments/{deployment_id}/stop")
 def stop_device_deployment(device_id: str, deployment_id: str):
+    _require_targeted_deployment(device_id, deployment_id)
     try:
         deployment = _runtime_client_or_404(device_id).stop_deployment(deployment_id)
     except DeviceRegistryError as exc:
@@ -5128,6 +5981,7 @@ def rollback_device_deployment(
     deployment_id: str,
     req: RemoteRollbackReq,
 ):
+    _require_targeted_deployment(device_id, deployment_id)
     if req.start:
         _require_device_safe_to_start(device_id)
         _set_device_deployment_lease(device_id, leased=True)
@@ -5153,6 +6007,7 @@ def get_device_deployment_logs(
     deployment_id: str,
     limit: int = 20000,
 ):
+    _require_targeted_deployment(device_id, deployment_id)
     try:
         return _runtime_client_or_404(device_id).deployment_logs(
             deployment_id,
@@ -5164,6 +6019,7 @@ def get_device_deployment_logs(
 
 @app.delete("/devices/{device_id}/deployments/{deployment_id}")
 def delete_device_deployment(device_id: str, deployment_id: str):
+    _require_targeted_deployment(device_id, deployment_id)
     try:
         return _runtime_client_or_404(device_id).delete_deployment(deployment_id)
     except DeviceRegistryError as exc:
@@ -5185,6 +6041,51 @@ def call_device_rpc(device_id: str, req: DeviceRpcReq):
         return _paired_device_client(device_id).rpc(payload)
     except DeviceRegistryError as exc:
         raise HTTPException(502, str(exc)) from exc
+
+
+@app.post("/devices/{device_id}/release-torque")
+def release_device_torque(device_id: str):
+    status = _deployment_aware_device_status(device_id)
+    if status.get("deployment_lease") or status.get("running_deployment"):
+        raise HTTPException(
+            409,
+            "Stop the robot deployment before releasing physical torque.",
+        )
+    if status.get("paused"):
+        raise HTTPException(
+            409,
+            "Resume the robot hardware monitor before releasing physical torque.",
+        )
+    if status.get("torque_enabled") is False:
+        return {"ok": True, "status": status, "already_released": True}
+    result = _paired_device_client(device_id).rpc({
+        "jsonrpc": "2.0",
+        "id": f"release-torque-{device_id}",
+        "method": "disable_torque",
+        "params": {},
+    })
+    _raise_rpc_error(result, action="release physical torque for")
+    verified = _paired_device_client(device_id).status()
+    if verified.get("torque_enabled") is True:
+        raise HTTPException(
+            409,
+            "The Hardware service accepted the request but still reports physical torque on.",
+        )
+    verification_warning = ""
+    if verified.get("torque_enabled") is None:
+        verification_warning = str(
+            verified.get("torque_report_error")
+            or (
+                "Robot Hardware sent the torque-off command successfully, but could "
+                "not read every servo torque-enable register to verify the result."
+            )
+        )
+    return {
+        "ok": True,
+        "status": verified,
+        "already_released": False,
+        "verification_warning": verification_warning,
+    }
 
 
 @app.delete("/devices/{device_id}")

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -101,6 +101,7 @@ export interface HardwareDevice {
   token_fingerprint: string
   runtime_token_fingerprint?: string
   runtime_token_configured?: boolean
+  software_version?: string
   paused?: boolean
   created_at: string
   updated_at: string
@@ -216,13 +217,43 @@ export interface DeviceRuntimeStatus {
 
 export interface HardwareDeviceStatus {
   device_id: string
+  software_version?: string
+  software_version_cached?: boolean
+  service_features?: string[]
   connected: boolean
   armed: boolean
   torque_enabled?: boolean
+  torque_report_error?: string
+  telemetry?: {
+    enabled: boolean
+    streams: string[]
+    sinks: Array<{
+      name: string
+      configured?: boolean
+      connected?: boolean
+      broker?: string
+      tls?: boolean
+      topic_prefix?: string
+      qos?: number
+      published?: number
+      last_published_at?: number | null
+      error?: string
+    }>
+  }
   calibrated?: boolean
   leased_to_deployment?: boolean
   paused?: boolean
   deployment_lease?: {
+    id: string
+    name: string
+    state: string
+  }
+  running_deployment?: {
+    id: string
+    name: string
+    state: string
+  }
+  stored_deployment?: {
     id: string
     name: string
     state: string
@@ -244,6 +275,58 @@ export interface HardwareDeviceStatus {
   }
 }
 
+export interface RobotTelemetryJoint {
+  name: string
+  position: number
+  velocity: number
+}
+
+export interface RobotTelemetrySample {
+  type: 'robot_telemetry'
+  robot_id: string
+  robot_name?: string
+  source?: 'hardware' | 'deployment'
+  source_label?: string
+  deployment?: {
+    id: string
+    name: string
+    state: string
+  }
+  available: boolean
+  stale: boolean
+  sequence?: number
+  sent_at?: string
+  received_at?: string
+  age_seconds?: number
+  payload?: {
+    connected: boolean
+    armed?: boolean
+    torque_enabled?: boolean | null
+    position_unit: string
+    velocity_unit: string
+    joints: RobotTelemetryJoint[]
+    error?: string
+    battery?: {
+      level?: number
+      voltage?: number
+      charging?: boolean
+    }
+    camera_streams?: Array<{
+      id: string
+      label?: string
+      url?: string
+    }>
+  } | null
+  message?: string
+}
+
+export function deviceMonitorSocketUrl(id: string): string {
+  const path = `${BASE}/devices/${encodeURIComponent(id)}/monitor/ws`
+  const url = new URL(path, window.location.href)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  return url.toString()
+}
+
 export interface DeviceInstallProgress {
   progress: number
   message: string
@@ -257,6 +340,64 @@ export interface ComputeDeviceLifecycleResult {
   device: ComputeDevice
   stopped_deployments: string[]
   controlled_robots: string[]
+  warnings: string[]
+  summary: string
+}
+
+export interface ManagedServiceUpdateResult {
+  ok: boolean
+  scope: 'all' | 'runtime' | 'hardware'
+  device: ComputeDevice
+  update: {
+    ok: boolean
+    host_fingerprint: string
+    components: Array<{
+      kind: 'runtime' | 'hardware'
+      service_name: string
+      port: number
+      before: { version: string; commit: string }
+      after: { version: string; commit: string }
+      reported_version?: string
+      changed: boolean
+      state: string
+    }>
+  }
+  runtime: {
+    runtime_version?: string
+    [key: string]: unknown
+  }
+  robots: Array<{
+    id: string
+    name: string
+    port: number
+    software_version: string
+    status: HardwareDeviceStatus
+  }>
+  stopped_deployments: string[]
+  controlled_robots: string[]
+  warnings: string[]
+  summary: string
+}
+
+export interface ManagedServiceUpdateCheckResult {
+  ok: boolean
+  check: {
+    ok: boolean
+    host_fingerprint: string
+    components: Array<{
+      kind: 'runtime' | 'hardware'
+      service_name: string
+      port: number
+      installed: { version: string; commit: string }
+      latest: { version: string; commit: string }
+      reported_version?: string
+      update_available: boolean
+      can_update: boolean
+      dirty: boolean
+      state: string
+      error: string
+    }>
+  }
   warnings: string[]
   summary: string
 }
@@ -995,6 +1136,31 @@ export const api = {
       },
       60000,
     ),
+  configureComputeDeviceSsh: (
+    id: string,
+    host: string,
+    port: number,
+    username: string,
+    password: string,
+    hostFingerprint: string,
+  ) =>
+    req<{
+      ok: boolean
+      device: ComputeDevice
+      instance: SshRuntimeInstance
+      summary: string
+    }>(
+      'POST',
+      `/device-hosts/${encodeURIComponent(id)}/management`,
+      {
+        host,
+        port,
+        username,
+        password,
+        host_fingerprint: hostFingerprint,
+      },
+      60000,
+    ),
   installComputeDevice: (
     name: string,
     host: string,
@@ -1064,6 +1230,27 @@ export const api = {
     streamDeviceAction<ComputeDeviceLifecycleResult>(
       `/device-hosts/${encodeURIComponent(id)}/lifecycle-stream`,
       { action, password },
+      onProgress,
+    ),
+  updateComputeDevice: (
+    id: string,
+    password: string,
+    scope: 'all' | 'runtime' | 'hardware',
+    onProgress: (progress: DeviceActionProgress) => void,
+  ) =>
+    streamDeviceAction<ManagedServiceUpdateResult>(
+      `/device-hosts/${encodeURIComponent(id)}/update-stream`,
+      { password, scope },
+      onProgress,
+    ),
+  checkComputeDeviceUpdates: (
+    id: string,
+    password: string,
+    onProgress: (progress: DeviceActionProgress) => void,
+  ) =>
+    streamDeviceAction<ManagedServiceUpdateCheckResult>(
+      `/device-hosts/${encodeURIComponent(id)}/update-check-stream`,
+      { password },
       onProgress,
     ),
   listDevices:      () => req<{ devices: HardwareDevice[] }>('GET', '/devices'),
@@ -1195,6 +1382,18 @@ export const api = {
       `/devices/${encodeURIComponent(id)}/rpc`,
       { jsonrpc: '2.0', id: requestId, method, params },
       10000,
+    ),
+  releaseDeviceTorque: (id: string) =>
+    req<{
+      ok: boolean
+      status: HardwareDeviceStatus
+      already_released: boolean
+      verification_warning?: string
+    }>(
+      'POST',
+      `/devices/${encodeURIComponent(id)}/release-torque`,
+      {},
+      15000,
     ),
   deleteDevice:     (id: string) =>
     req<{ ok: boolean; id: string }>('DELETE', `/devices/${encodeURIComponent(id)}`),

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type CSSProperties } from 'react'
 import {
   api,
+  type ComputeDevice,
   type DeviceCalibrationCandidate,
   type DeviceRobotProfile,
   type Deployment,
@@ -52,6 +53,16 @@ function deviceForHardwareIdentity(
   return matches.length === 1 ? matches[0] : null
 }
 
+function deploymentsForRobot(
+  deployments: RemoteDeployment[],
+  deviceId: string,
+): RemoteDeployment[] {
+  return deployments.filter(deployment => (
+    !deployment.target_device_id
+    || deployment.target_device_id === deviceId
+  ))
+}
+
 const STATE_COLOR: Record<DeploymentState, string> = {
   running: 'var(--ok)',
   stopped: 'var(--tx3)',
@@ -84,15 +95,22 @@ const REMOTE_STATE_LABEL: Record<RemoteDeploymentState, string> = {
 
 interface DeploymentsPanelProps {
   onOpenTemplates: (query: string) => void
+  targetDeviceId?: string
+  onBackToDevices?: () => void
 }
 
-export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelProps) {
+export default function DeploymentsPanel({
+  onOpenTemplates,
+  targetDeviceId = '',
+  onBackToDevices,
+}: DeploymentsPanelProps) {
   const [deployments, setDeployments] = useState<Deployment[]>([])
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [openId, setOpenId] = useState<string | null>(null)
   const [logs, setLogs] = useState<Record<string, string>>({})
   const [devices, setDevices] = useState<HardwareDevice[]>([])
+  const [computeDevices, setComputeDevices] = useState<ComputeDevice[]>([])
   const [selectedDeviceId, setSelectedDeviceId] = useState('')
   const [preflight, setPreflight] = useState<DeploymentPreflight | null>(null)
   const [remoteDeployments, setRemoteDeployments] = useState<RemoteDeployment[]>([])
@@ -106,6 +124,12 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
   const activeTabId = useStore(s => s.activeTabId)
   const activeTab = tabs.find(tab => tab.id === activeTabId)
   const activeDeploymentName = deploymentNameFromTab(activeTab?.name)
+  const selectedRobot = devices.find(device => device.id === selectedDeviceId) ?? null
+  const selectedComputeDevice = computeDevices.find(device => (
+    device.id === selectedRobot?.host_id
+    || device.robots.some(robot => robot.id === selectedDeviceId)
+  )) ?? null
+  const isRobotContext = Boolean(targetDeviceId)
   const activeProject = useStore(s => s.activeProject)
   const deploymentProject = (
     activeProject
@@ -321,7 +345,12 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
     const pull = async () => {
       try {
         const result = await api.listRemoteDeployments(selectedDeviceId)
-        if (!cancelled) setRemoteDeployments(result.deployments)
+        if (!cancelled) {
+          setRemoteDeployments(deploymentsForRobot(
+            result.deployments,
+            selectedDeviceId,
+          ))
+        }
       } catch {
         if (!cancelled) setRemoteDeployments([])
       }
@@ -332,17 +361,21 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
   }, [selectedDeviceId])
 
   useEffect(() => {
-    api.listDevices()
-      .then(result => {
-        setDevices(result.devices)
+    Promise.all([api.listDevices(), api.listComputeDevices()])
+      .then(([robotResult, computeResult]) => {
+        setDevices(robotResult.devices)
+        setComputeDevices(computeResult.devices)
         setSelectedDeviceId(current => (
-          current && result.devices.some(device => device.id === current)
+          targetDeviceId
+          && robotResult.devices.some(device => device.id === targetDeviceId)
+            ? targetDeviceId
+            : current && robotResult.devices.some(device => device.id === current)
             ? current
-            : result.devices[0]?.id ?? ''
+            : robotResult.devices[0]?.id ?? ''
         ))
       })
       .catch(err => setError(err instanceof Error ? err.message : String(err)))
-  }, [])
+  }, [targetDeviceId])
 
   useEffect(() => {
     if (!calibrationMatchedDevice) return
@@ -470,7 +503,7 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
   const refreshRemote = async () => {
     if (!selectedDeviceId) return
     const result = await api.listRemoteDeployments(selectedDeviceId)
-    setRemoteDeployments(result.deployments)
+    setRemoteDeployments(deploymentsForRobot(result.deployments, selectedDeviceId))
   }
 
   const actRemote = async (fn: () => Promise<unknown>) => {
@@ -541,8 +574,8 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
       await refreshRemote()
       setRemoteNotice(
         start
-          ? `"${name}" was sent to the device and started.`
-          : `"${name}" was sent to the device and is ready to start.`,
+          ? `"${name}" was sent to ${selectedComputeDevice?.name || 'the compute device'} and started for ${selectedRobot?.name || 'the selected robot'}.`
+          : `"${name}" was sent to ${selectedComputeDevice?.name || 'the compute device'} for ${selectedRobot?.name || 'the selected robot'} and is ready to start.`,
       )
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -559,56 +592,133 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
     setRemoteOpenId(current => current === deployment.id ? null : current)
   }
 
-  const running = deployments.filter(d => d.state === 'running').length
   const remoteRunning = remoteDeployments.filter(d => d.state === 'running').length
 
   return (
     <div className="bn-runs-panel bn-deploy-panel">
-      <div className="bn-runs-toolbar">
-        <div>
-          <div className="bn-runs-title">Deployments</div>
-          <div className="bn-runs-subtitle">
-            {deployments.length} total · {running} running
+      {isRobotContext ? (
+        <div className="bn-deploy-nav">
+          {onBackToDevices && (
+            <button type="button" className="bn-deploy-nav-button" onClick={onBackToDevices}>
+              <span aria-hidden="true">←</span>
+              <span>All devices</span>
+            </button>
+          )}
+          <button
+            type="button"
+            className="bn-deploy-nav-button bn-deploy-refresh"
+            onClick={refresh}
+            title="Refresh deployment status"
+          >
+            <span aria-hidden="true">↻</span>
+            <span>Refresh</span>
+          </button>
+        </div>
+      ) : (
+        <div className="bn-runs-toolbar">
+          <div>
+            <div className="bn-runs-title">Robot deployment</div>
+            <div className="bn-runs-subtitle">Choose a robot for the current workflow</div>
+          </div>
+          <div className="bn-runs-actions">
+            <button onClick={refresh} style={miniButton}>Refresh</button>
+            <button onClick={() => handleDeploy(false)} disabled={busy} style={miniButton} title="Save the runnable script on this computer without running it">Save local</button>
+            <button onClick={() => handleDeploy(true)} disabled={busy} style={primaryButton} title="Stop the live graph, then run it on this computer">Run local</button>
           </div>
         </div>
-        <div className="bn-runs-actions">
-          <button onClick={refresh} style={miniButton}>Refresh</button>
-          <button onClick={() => handleDeploy(false)} disabled={busy} style={miniButton} title="Save the runnable script on this computer without running it">Save local</button>
-          <button onClick={() => handleDeploy(true)} disabled={busy} style={primaryButton} title="Stop the live graph, then run it on this computer">Run local</button>
-        </div>
-      </div>
+      )}
 
       {error && <div className="bn-runs-error">{error}</div>}
 
       <div className="bn-deploy-target">
         <div className="bn-deploy-target-head">
           <div>
-            <div className="bn-deploy-target-title">Deploy one robot</div>
-            <div className="bn-runs-subtitle">
-              Choose the computer physically connected to this robot. Use a separate
-              deployment workflow for each additional robot.
+            <div className="bn-deploy-target-title">
+              {selectedRobot ? `Deploy to ${selectedRobot.name}` : 'Choose a robot'}
+            </div>
+            <div className="bn-deploy-target-copy">
+              Review where the current workflow will run, then deploy it.
             </div>
           </div>
         </div>
-        {devices.length > 0 ? (
-          <select
-            className="bn-deploy-device-select"
-            value={selectedDeviceId}
-            onChange={event => {
-              setSelectedDeviceId(event.target.value)
-              setPreflight(null)
-              setRemoteNotice(null)
-            }}
-          >
-            {devices.map(device => (
-              <option key={device.id} value={device.id}>
-                {device.name} · {device.base_url}
-              </option>
-            ))}
-          </select>
-        ) : (
-          <div className="bn-device-help">Pair a Raspberry Pi in the Devices tab first.</div>
-        )}
+
+        <div className="bn-deploy-route" aria-label="Deployment route">
+          <article>
+            <span>Workflow</span>
+            <strong>{activeDeploymentName}</strong>
+            <small>Current editor tab</small>
+          </article>
+          <i aria-hidden="true">→</i>
+          <article>
+            <span>Robot</span>
+            <strong>{selectedRobot?.name || 'No robot selected'}</strong>
+            <small>
+              {selectedComputeDevice
+                ? `Connected through ${selectedComputeDevice.name}`
+                : 'Attach a robot in Devices first'}
+            </small>
+          </article>
+        </div>
+
+        {devices.length > 0 && !isRobotContext ? (
+          <label className="bn-deploy-target-picker">
+            <span>Target robot</span>
+            <select
+              className="bn-deploy-device-select"
+              value={selectedDeviceId}
+              onChange={event => {
+                setSelectedDeviceId(event.target.value)
+                setPreflight(null)
+                setRemoteNotice(null)
+                setRemoteOpenId(null)
+              }}
+            >
+              {computeDevices.map(computeDevice => {
+                const attachedRobots = devices.filter(device => (
+                  device.host_id === computeDevice.id
+                  || computeDevice.robots.some(robot => robot.id === device.id)
+                ))
+                if (attachedRobots.length === 0) return null
+                return (
+                  <optgroup
+                    key={computeDevice.id}
+                    label={`${computeDevice.name} — compute device`}
+                  >
+                    {attachedRobots.map(robot => (
+                      <option key={robot.id} value={robot.id}>
+                        {robot.name} — {robot.remote_device_id}
+                      </option>
+                    ))}
+                  </optgroup>
+                )
+              })}
+              {devices.some(device => !computeDevices.some(computeDevice => (
+                device.host_id === computeDevice.id
+                || computeDevice.robots.some(robot => robot.id === device.id)
+              ))) && (
+                <optgroup label="Other registered robots">
+                  {devices.filter(device => !computeDevices.some(computeDevice => (
+                    device.host_id === computeDevice.id
+                    || computeDevice.robots.some(robot => robot.id === device.id)
+                  ))).map(robot => (
+                    <option key={robot.id} value={robot.id}>
+                      {robot.name} — {robot.remote_device_id}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+            </select>
+            <small>
+              {selectedComputeDevice
+                ? `Attached under ${selectedComputeDevice.name}. The deployment runs on ${selectedComputeDevice.runtime_url}.`
+                : 'Select a robot already registered in Devices.'}
+            </small>
+          </label>
+        ) : devices.length === 0 ? (
+          <div className="bn-device-help">
+            Open Devices, add a compute device, then attach the physical robot to it.
+          </div>
+        ) : null}
         <div className={`bn-robot-step-status ${deploymentProject ? 'is-success' : ''}`}>
           <strong>Deployment ownership:</strong>{' '}
           {deploymentProject
@@ -627,9 +737,10 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
           <section className={`bn-robot-deploy-step${robotNodes.length > 0 ? ' is-complete' : ' is-needed'}`}>
             <div className="bn-robot-step-number">1</div>
             <div className="bn-robot-step-content">
-              <div className="bn-robot-step-title">Choose one robot profile</div>
+              <div className="bn-robot-step-title">Confirm the workflow’s robot profile</div>
               <div className="bn-robot-step-help">
-                The profile describes this robot’s model, joints, servo IDs, and driver.
+                This configures how the workflow controls the selected physical robot.
+                The physical robot remains registered under its compute device.
               </div>
 
               {robotNodes.length === 0 ? (
@@ -945,10 +1056,10 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
                 {preflight?.ready && (
                   <>
                     <button onClick={() => stageRemote(false)} disabled={busy} style={miniButton}>
-                      {remoteAction === 'send' ? 'Sending…' : 'Send to device'}
+                      {remoteAction === 'send' ? 'Sending…' : 'Send to robot'}
                     </button>
                     <button onClick={() => stageRemote(true)} disabled={busy} style={primaryButton}>
-                      {remoteAction === 'send-run' ? 'Sending & starting…' : 'Send & run'}
+                      {remoteAction === 'send-run' ? 'Sending & starting…' : 'Send & run on robot'}
                     </button>
                   </>
                 )}
@@ -971,8 +1082,15 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
 
       <div className="bn-deployment-section-head">
         <div>
-          <strong>Remote deployments</strong>
-          <span>{remoteDeployments.length} total · {remoteRunning} running</span>
+          <strong>
+            {selectedRobot
+              ? `Deployments for ${selectedRobot.name}`
+              : 'Robot deployments'}
+          </strong>
+          <span>
+            {selectedComputeDevice ? `Stored on ${selectedComputeDevice.name} · ` : ''}
+            {remoteDeployments.length} total · {remoteRunning} running
+          </span>
         </div>
         <button onClick={() => actRemote(refreshRemote)} disabled={busy || !selectedDeviceId} style={miniButton}>
           Refresh
@@ -981,8 +1099,8 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
       <div className="bn-runs-list bn-card-list bn-remote-deployment-list">
         {selectedDeviceId && remoteDeployments.length === 0 && (
           <div className="bn-runs-empty">
-            No deployment has been sent to this device. Check the setup, then choose
-            <strong> Send to device</strong> or <strong>Send &amp; run</strong>.
+            No deployment has been sent to this robot. Check the setup, then choose
+            <strong> Send to robot</strong> or <strong>Send &amp; run on robot</strong>.
           </div>
         )}
         {remoteDeployments.map(deployment => (
@@ -1015,34 +1133,38 @@ export default function DeploymentsPanel({ onOpenTemplates }: DeploymentsPanelPr
         ))}
       </div>
 
-      <div className="bn-deployment-section-head">
-        <div>
-          <strong>Local deployments</strong>
-          <span>Run by this editor computer</span>
-        </div>
-      </div>
-      <div className="bn-runs-list">
-        {deployments.length === 0 && !error && (
-          <div className="bn-runs-empty">
-            Nothing deployed. <strong>Deploy graph</strong> snapshots the current graph and runs
-            it in the background, so it keeps running while you edit something else.
+      {!isRobotContext && (
+        <>
+          <div className="bn-deployment-section-head">
+            <div>
+              <strong>Local deployments</strong>
+              <span>Run by this editor computer</span>
+            </div>
           </div>
-        )}
-        {deployments.map(deployment => (
-          <DeploymentRow
-            key={deployment.id}
-            deployment={deployment}
-            busy={busy}
-            expanded={openId === deployment.id}
-            log={logs[deployment.id] ?? ''}
-            onToggle={() => setOpenId(prev => (prev === deployment.id ? null : deployment.id))}
-            onStart={() => act(() => api.startDeployment(deployment.id))}
-            onStop={() => act(() => api.stopDeployment(deployment.id))}
-            onExport={() => handleExport(deployment)}
-            onDelete={() => handleDelete(deployment)}
-          />
-        ))}
-      </div>
+          <div className="bn-runs-list">
+            {deployments.length === 0 && !error && (
+              <div className="bn-runs-empty">
+                Nothing deployed. <strong>Deploy graph</strong> snapshots the current graph and runs
+                it in the background, so it keeps running while you edit something else.
+              </div>
+            )}
+            {deployments.map(deployment => (
+              <DeploymentRow
+                key={deployment.id}
+                deployment={deployment}
+                busy={busy}
+                expanded={openId === deployment.id}
+                log={logs[deployment.id] ?? ''}
+                onToggle={() => setOpenId(prev => (prev === deployment.id ? null : deployment.id))}
+                onStart={() => act(() => api.startDeployment(deployment.id))}
+                onStop={() => act(() => api.stopDeployment(deployment.id))}
+                onExport={() => handleExport(deployment)}
+                onDelete={() => handleDelete(deployment)}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useState, type CSSProperties, type FormEvent } from 'react'
+import { useEffect, useRef, useState, type CSSProperties, type FormEvent } from 'react'
 import {
   api,
+  deviceMonitorSocketUrl,
   type ComputeDevice,
   type DeviceActionProgress,
   type DeviceInstallProgress,
   type DeviceRuntimeStatus,
   type HardwareDevice,
   type HardwareDeviceStatus,
+  type ManagedServiceUpdateCheckResult,
+  type ManagedServiceUpdateResult,
+  type RobotTelemetryJoint,
+  type RobotTelemetrySample,
   type SshDeviceProbe,
   type SshRuntimeInspection,
 } from '../api'
@@ -79,12 +84,37 @@ function hardwareUrlError(value: string, runtimeUrl = DEFAULT_RUNTIME_URL): stri
   return null
 }
 
+function runtimeHostname(runtimeUrl: string): string {
+  try {
+    return new URL(runtimeUrl).hostname
+  } catch {
+    return ''
+  }
+}
+
+function urlPort(url: string): number | null {
+  try {
+    const parsed = new URL(url)
+    const value = parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
+    const port = Number(value)
+    return Number.isInteger(port) && port > 0 ? port : null
+  } catch {
+    return null
+  }
+}
+
+function formatVersion(value?: string): string {
+  const version = value?.trim()
+  return version && version !== 'unknown' ? `v${version}` : 'version unavailable'
+}
+
 export default function DevicesPanel() {
   const activeProject = useStore(state => state.activeProject)
   const setActiveProject = useStore(state => state.setActiveProject)
   const [devices, setDevices] = useState<ComputeDevice[]>([])
   const [deviceStates, setDeviceStates] = useState<Record<string, DeviceState>>({})
   const [robotStates, setRobotStates] = useState<Record<string, RobotState>>({})
+  const [knownHardwareVersions, setKnownHardwareVersions] = useState<Record<string, string>>({})
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
   const [showDeviceForm, setShowDeviceForm] = useState(false)
   const [setupMode, setSetupMode] = useState<'automatic' | 'manual'>('automatic')
@@ -103,8 +133,18 @@ export default function DevicesPanel() {
   const [actionProgress, setActionProgress] = useState<Record<string, DeviceActionProgress>>({})
   const [showRuntimeControl, setShowRuntimeControl] = useState(false)
   const [runtimeControlPassword, setRuntimeControlPassword] = useState('')
+  const [showUpdateForm, setShowUpdateForm] = useState(false)
+  const [updatePassword, setUpdatePassword] = useState('')
+  const [updateCheckReport, setUpdateCheckReport] = useState<ManagedServiceUpdateCheckResult | null>(null)
+  const [updateReport, setUpdateReport] = useState<ManagedServiceUpdateResult | null>(null)
   const [showUninstallForm, setShowUninstallForm] = useState(false)
   const [uninstallPassword, setUninstallPassword] = useState('')
+  const [showSshManagement, setShowSshManagement] = useState(false)
+  const [managementHost, setManagementHost] = useState('')
+  const [managementPort, setManagementPort] = useState(22)
+  const [managementUsername, setManagementUsername] = useState('')
+  const [managementPassword, setManagementPassword] = useState('')
+  const [managementProbe, setManagementProbe] = useState<SshDeviceProbe | null>(null)
   const [showRobotForm, setShowRobotForm] = useState(false)
   const [robotName, setRobotName] = useState('')
   const [robotUrl, setRobotUrl] = useState('')
@@ -117,6 +157,106 @@ export default function DevicesPanel() {
   const selectedDeviceState = selectedDevice
     ? deviceStates[selectedDevice.id]
     : undefined
+  const selectedRobotChecks = selectedDevice
+    ? selectedDevice.robots.map(robot => ({
+      robot,
+      state: robotStates[robot.id],
+    }))
+    : []
+  const selectedDeviceChecking = Boolean(
+    selectedDeviceState?.loading
+    || selectedRobotChecks.some(item => item.state?.loading),
+  )
+  const selectedHardwareReady = selectedRobotChecks.every(item => Boolean(
+    item.state?.status
+    && !item.state.error
+    && (
+      item.state.status.connected
+      || item.state.status.leased_to_deployment
+      || item.state.status.deployment_lease
+    ),
+  ))
+  const selectedDeviceReady = Boolean(
+    selectedDeviceState?.runtime?.ok
+    && selectedHardwareReady,
+  )
+  const selectedServiceVersions = selectedDevice
+    ? [
+      `Runtime ${
+        selectedDeviceState?.runtime?.manifest?.runtime_version
+          ? `v${selectedDeviceState.runtime.manifest.runtime_version}`
+          : 'version not reported'
+      }`,
+      ...selectedRobotChecks.map(({ robot, state }) => (
+        `${robot.name} Hardware ${
+          state?.status?.software_version
+            ? `v${state.status.software_version}`
+            : robot.software_version
+              ? `v${robot.software_version} (last verified)`
+            : 'version not reported'
+        }`
+      )),
+    ]
+    : []
+  const selectedLastChecked = Math.max(
+    selectedDeviceState?.checkedAt ?? 0,
+    ...selectedRobotChecks.map(item => item.state?.checkedAt ?? 0),
+  )
+  const checkedSoftwareComponents = updateCheckReport?.check.components ?? []
+  const checkedHardwareComponents = checkedSoftwareComponents.filter(
+    component => component.kind === 'hardware',
+  )
+  const checkedHardwareNeedsRepair = checkedHardwareComponents.some(component => (
+    Boolean(component.error)
+    || component.installed.version === 'unknown'
+    || component.latest.version === 'unknown'
+  ))
+  const checkedHardwareHasUpdate = checkedHardwareComponents.some(
+    component => component.update_available,
+  )
+  const checkedHardwareIsDirty = checkedHardwareComponents.some(
+    component => component.dirty,
+  )
+  const checkedRuntimeComponents = checkedSoftwareComponents.filter(
+    component => component.kind === 'runtime',
+  )
+  const checkedHardwareInstallation = checkedHardwareComponents.find(component => (
+    component.installed.version !== 'unknown'
+    && component.latest.version !== 'unknown'
+  )) ?? checkedHardwareComponents[0]
+  const updatedSoftwareComponents = updateReport?.update.components ?? []
+  const updatedRuntimeComponents = updatedSoftwareComponents.filter(
+    component => component.kind === 'runtime',
+  )
+  const updatedHardwareComponents = updatedSoftwareComponents.filter(
+    component => component.kind === 'hardware',
+  )
+  const updatedHardwareInstallation = updatedHardwareComponents[0]
+  const robotNameForPort = (port: number): string => (
+    selectedDevice?.robots.find(robot => urlPort(robot.base_url) === port)?.name
+    ?? `Robot on port ${port}`
+  )
+  const installedHardwareVersionForPort = (port: number | null): string => {
+    if (port == null) return ''
+    const checked = updateCheckReport?.check.components.find(component => (
+      component.kind === 'hardware' && component.port === port
+    ))
+    if (checked?.installed.version && checked.installed.version !== 'unknown') {
+      return checked.installed.version
+    }
+    const updated = updateReport?.update.components.find(component => (
+      component.kind === 'hardware' && component.port === port
+    ))
+    if (updated?.after.version && updated.after.version !== 'unknown') {
+      return updated.after.version
+    }
+    const robot = selectedDevice?.robots.find(
+      item => urlPort(item.base_url) === port,
+    )
+    return robot
+      ? knownHardwareVersions[robot.id] ?? robot.software_version ?? ''
+      : ''
+  }
 
   const refreshRobot = async (robot: HardwareDevice) => {
     setRobotStates(previous => ({
@@ -125,6 +265,13 @@ export default function DevicesPanel() {
     }))
     try {
       const status = await api.deviceStatus(robot.id)
+      const reportedVersion = status.software_version
+      if (reportedVersion) {
+        setKnownHardwareVersions(previous => ({
+          ...previous,
+          [robot.id]: reportedVersion,
+        }))
+      }
       setRobotStates(previous => ({
         ...previous,
         [robot.id]: { status, loading: false, checkedAt: Date.now() },
@@ -190,6 +337,25 @@ export default function DevicesPanel() {
   useEffect(() => {
     void refresh()
   }, [])
+
+  useEffect(() => {
+    const timers = Object.entries(actionProgress).flatMap(([id, value]) => {
+      const failed = (
+        value.progress <= 0
+        && value.message.toLowerCase().includes('failed')
+      )
+      if (value.progress < 100 && !failed) return []
+      return [window.setTimeout(() => {
+        setActionProgress(previous => {
+          if (previous[id] !== value) return previous
+          const next = { ...previous }
+          delete next[id]
+          return next
+        })
+      }, failed ? 10000 : 3500)]
+    })
+    return () => timers.forEach(timer => window.clearTimeout(timer))
+  }, [actionProgress])
 
   const resetDeviceForm = () => {
     setShowDeviceForm(false)
@@ -390,7 +556,9 @@ export default function DevicesPanel() {
       setError('Remove the robots from this device first. Saved deployment targets stay intact until you choose to remove them.')
       return
     }
-    if (!window.confirm(`Remove "${device.name}" from this Blacknode editor?`)) return
+    if (!window.confirm(
+      `Forget "${device.name}"? This removes only Blacknode's saved connection. Runtime and Hardware stay installed and running on the computer.`,
+    )) return
     setBusy(true)
     setError(null)
     try {
@@ -421,6 +589,81 @@ export default function DevicesPanel() {
       await refresh()
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const checkDevice = async (device: ComputeDevice) => {
+    setShowUpdateForm(false)
+    setUpdatePassword('')
+    setUpdateCheckReport(null)
+    setUpdateReport(null)
+    setBusy(true)
+    setError(null)
+    try {
+      await Promise.all([
+        refreshDevice(device),
+        ...device.robots.map(refreshRobot),
+      ])
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const openSshManagement = (device: ComputeDevice) => {
+    setShowSshManagement(current => !current)
+    setShowRuntimeControl(false)
+    setShowUninstallForm(false)
+    setManagementHost(runtimeHostname(device.runtime_url))
+    setManagementPort(22)
+    setManagementUsername('')
+    setManagementPassword('')
+    setManagementProbe(null)
+    setError(null)
+  }
+
+  const configureSshManagement = async (
+    event: FormEvent,
+    device: ComputeDevice,
+  ) => {
+    event.preventDefault()
+    setBusy(true)
+    setError(null)
+    try {
+      if (!managementProbe) {
+        const probe = await api.probeComputeDeviceSsh(
+          managementHost.trim(),
+          managementPort,
+        )
+        setManagementProbe(probe)
+        return
+      }
+      const result = await api.configureComputeDeviceSsh(
+        device.id,
+        managementHost.trim(),
+        managementPort,
+        managementUsername.trim(),
+        managementPassword,
+        managementProbe.host_fingerprint,
+      )
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 100, message: result.summary },
+      }))
+      setShowSshManagement(false)
+      setManagementPassword('')
+      setManagementProbe(null)
+      await refresh()
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      if (
+        message.toLowerCase().includes('authentication failed')
+        || message.toLowerCase().includes('ssh login was rejected')
+      ) {
+        setManagementPassword('')
+      }
+      setError(message)
     } finally {
       setBusy(false)
     }
@@ -470,6 +713,174 @@ export default function DevicesPanel() {
       setActionProgress(previous => ({
         ...previous,
         [device.id]: { progress: 0, message: `Device action failed: ${message}` },
+      }))
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const updateDevice = async (
+    device: ComputeDevice,
+    scope: 'all' | 'runtime' | 'hardware',
+  ) => {
+    if (!updatePassword) {
+      setError('Enter the SSH password to update this managed device.')
+      return
+    }
+    const selectedComponents = checkedSoftwareComponents.filter(component => (
+      scope === 'all' || component.kind === scope
+    ))
+    const selectedUpdatesAvailable = selectedComponents.some(
+      component => component.update_available,
+    )
+    const operation = selectedUpdatesAvailable ? 'Update' : 'Reinstall'
+    const hardwareServiceCount = device.robots.length
+    const targetLabel = scope === 'all'
+      ? 'Runtime + Robot Hardware'
+      : scope === 'runtime'
+        ? 'Runtime'
+        : `shared Robot Hardware installation used by ${hardwareServiceCount} robot service${
+          hardwareServiceCount === 1 ? '' : 's'
+        }`
+    if (!window.confirm(
+      `${operation} ${targetLabel} on "${device.name}"? Running deployments will stop and robots will return with Blacknode motion disarmed. This action does not switch off physical actuator power.`,
+    )) return
+    setBusy(true)
+    setError(null)
+    setUpdateReport(null)
+    setActionProgress(previous => ({
+      ...previous,
+      [device.id]: {
+        progress: 1,
+        message: scope === 'runtime'
+          ? 'Preparing Runtime update'
+          : scope === 'hardware'
+            ? `Preparing shared Robot Hardware update for ${hardwareServiceCount} robot service${
+              hardwareServiceCount === 1 ? '' : 's'
+            }`
+            : 'Preparing Runtime + Robot Hardware update',
+      },
+    }))
+    try {
+      const result = await api.updateComputeDevice(
+        device.id,
+        updatePassword,
+        scope,
+        progress => setActionProgress(previous => ({
+          ...previous,
+          [device.id]: progress,
+        })),
+      )
+      setUpdateReport(result)
+      setKnownHardwareVersions(previous => {
+        const next = { ...previous }
+        result.update.components.forEach(component => {
+          if (component.kind !== 'hardware' || component.after.version === 'unknown') return
+          const robot = device.robots.find(
+            item => urlPort(item.base_url) === component.port,
+          )
+          if (robot) next[robot.id] = component.after.version
+        })
+        return next
+      })
+      await refresh()
+      try {
+        const refreshedCheck = await api.checkComputeDeviceUpdates(
+          device.id,
+          updatePassword,
+          progress => setActionProgress(previous => ({
+            ...previous,
+            [device.id]: progress,
+          })),
+        )
+        setUpdateCheckReport(refreshedCheck)
+        setKnownHardwareVersions(previous => {
+          const next = { ...previous }
+          refreshedCheck.check.components.forEach(component => {
+            if (component.kind !== 'hardware' || component.installed.version === 'unknown') return
+            const robot = device.robots.find(
+              item => urlPort(item.base_url) === component.port,
+            )
+            if (robot) next[robot.id] = component.installed.version
+          })
+          return next
+        })
+        setActionProgress(previous => ({
+          ...previous,
+          [device.id]: { progress: 100, message: result.summary },
+        }))
+      } catch (checkReason) {
+        const checkMessage = checkReason instanceof Error
+          ? checkReason.message
+          : String(checkReason)
+        setUpdateCheckReport(null)
+        setActionProgress(previous => ({
+          ...previous,
+          [device.id]: {
+            progress: 100,
+            message: `${result.summary} Version report refresh failed: ${checkMessage}`,
+          },
+        }))
+        setError(
+          `The update completed, but the version report could not refresh: ${checkMessage}`,
+        )
+      }
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 0, message: `${targetLabel} update failed: ${message}` },
+      }))
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const checkDeviceSoftware = async (device: ComputeDevice) => {
+    if (!updatePassword) {
+      setError('Enter the SSH password to compare installed and latest versions.')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    setUpdateReport(null)
+    setUpdateCheckReport(null)
+    setActionProgress(previous => ({
+      ...previous,
+      [device.id]: { progress: 1, message: 'Checking Runtime + Robot Hardware versions' },
+    }))
+    try {
+      const result = await api.checkComputeDeviceUpdates(
+        device.id,
+        updatePassword,
+        progress => setActionProgress(previous => ({
+          ...previous,
+          [device.id]: progress,
+        })),
+      )
+      setUpdateCheckReport(result)
+      setKnownHardwareVersions(previous => {
+        const next = { ...previous }
+        result.check.components.forEach(component => {
+          if (component.kind !== 'hardware' || component.installed.version === 'unknown') return
+          const robot = device.robots.find(
+            item => urlPort(item.base_url) === component.port,
+          )
+          if (robot) next[robot.id] = component.installed.version
+        })
+        return next
+      })
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 100, message: result.summary },
+      }))
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 0, message: `Version check failed: ${message}` },
       }))
       setError(message)
     } finally {
@@ -583,6 +994,75 @@ export default function DevicesPanel() {
     }
   }
 
+  const restartStoredDeployment = async (
+    robot: HardwareDevice,
+    deploymentId: string,
+    deploymentName: string,
+  ) => {
+    if (!window.confirm(
+      `Restart stored deployment "${deploymentName}" on "${robot.name}"? Blacknode will recheck the robot safety state before starting it.`,
+    )) return
+    setBusy(true)
+    setError(null)
+    setActionProgress(previous => ({
+      ...previous,
+      [robot.id]: { progress: 10, message: 'Restarting stored deployment' },
+    }))
+    try {
+      await api.startRemoteDeployment(robot.id, deploymentId)
+      setActionProgress(previous => ({
+        ...previous,
+        [robot.id]: { progress: 100, message: `"${deploymentName}" restarted` },
+      }))
+      await refreshRobot(robot)
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [robot.id]: { progress: 0, message: `Deployment restart failed: ${message}` },
+      }))
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const releaseRobotTorque = async (robot: HardwareDevice) => {
+    if (!window.confirm(
+      `Release physical holding torque on "${robot.name}"? Support the robot first: its joints may move or drop as soon as torque is disabled.`,
+    )) return
+    setBusy(true)
+    setError(null)
+    setActionProgress(previous => ({
+      ...previous,
+      [robot.id]: { progress: 10, message: 'Releasing physical servo torque' },
+    }))
+    try {
+      const result = await api.releaseDeviceTorque(robot.id)
+      setActionProgress(previous => ({
+        ...previous,
+        [robot.id]: {
+          progress: 100,
+          message: result.verification_warning
+            ? `Torque-off command sent. ${result.verification_warning}`
+            : result.already_released
+              ? 'Physical servo torque was already off'
+              : 'Physical servo torque released and verified off',
+        },
+      }))
+      await refreshRobot(robot)
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [robot.id]: { progress: 0, message: `Torque release failed: ${message}` },
+      }))
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="bn-runs-panel bn-devices-panel">
       <div className="bn-runs-toolbar">
@@ -594,7 +1074,9 @@ export default function DevicesPanel() {
           </div>
         </div>
         <div className="bn-runs-actions">
-          <button onClick={refresh} disabled={busy} style={miniButton}>Refresh</button>
+          <button onClick={refresh} disabled={busy} className="bn-device-action-button">
+            Refresh
+          </button>
           <button
             onClick={() => {
               setSelectedDeviceId(null)
@@ -603,7 +1085,7 @@ export default function DevicesPanel() {
               setError(null)
             }}
             disabled={busy}
-            style={primaryButton}
+            className="bn-device-action-button is-primary"
           >
             Add device
           </button>
@@ -1035,7 +1517,11 @@ export default function DevicesPanel() {
               Install or pair Blacknode Runtime first. Then attach one or more robots
               and deploy a workflow to the robot you choose.
             </p>
-            <button type="button" onClick={() => setShowDeviceForm(true)} style={primaryButton}>
+            <button
+              type="button"
+              onClick={() => setShowDeviceForm(true)}
+              className="bn-device-action-button is-primary"
+            >
               Add first device
             </button>
           </div>
@@ -1049,6 +1535,8 @@ export default function DevicesPanel() {
                 selected={false}
                 onSelect={() => {
                   setSelectedDeviceId(device.id)
+                  setUpdateCheckReport(null)
+                  setUpdateReport(null)
                   setShowDeviceForm(false)
                   setShowRobotForm(false)
                 }}
@@ -1060,76 +1548,286 @@ export default function DevicesPanel() {
 
       {selectedDevice && (
         <section className="bn-compute-device-detail">
+          <div className="bn-compute-device-detail-nav">
+            <button
+              type="button"
+              className="bn-device-back-button"
+              onClick={() => {
+                setSelectedDeviceId(null)
+                setUpdateCheckReport(null)
+                setUpdateReport(null)
+                setShowRobotForm(false)
+                setShowUninstallForm(false)
+                setShowRuntimeControl(false)
+                setShowUpdateForm(false)
+                setUninstallPassword('')
+                setRuntimeControlPassword('')
+                setUpdatePassword('')
+                setShowSshManagement(false)
+                setManagementPassword('')
+                setManagementProbe(null)
+                setError(null)
+              }}
+            >
+              <span className="bn-device-back-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <path d="M15 5 8 12l7 7" />
+                </svg>
+              </span>
+              <span className="bn-device-back-label">Back to all devices</span>
+            </button>
+          </div>
           <div className="bn-compute-device-detail-head">
-            <div>
-              <button
-                type="button"
-                className="bn-device-back-button"
-                onClick={() => {
-                  setSelectedDeviceId(null)
-                  setShowRobotForm(false)
-                  setShowUninstallForm(false)
-                  setShowRuntimeControl(false)
-                  setUninstallPassword('')
-                  setRuntimeControlPassword('')
-                  setError(null)
-                }}
-              >
-                <span className="bn-device-back-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false">
-                    <path d="M15 5 8 12l7 7" />
-                  </svg>
-                </span>
-                Back to all devices
-              </button>
-              <span>Compute device</span>
+            <div className="bn-compute-device-identity">
               <strong>{selectedDevice.name}</strong>
               <code>{selectedDevice.runtime_url}</code>
             </div>
-            <div className="bn-run-detail-actions">
+            <div className="bn-run-detail-actions bn-device-header-actions">
               <button
-                onClick={() => refreshDevice(selectedDevice)}
+                onClick={() => void checkDevice(selectedDevice)}
                 disabled={busy || selectedDeviceState?.loading}
-                className={`bn-runtime-check-button${selectedDeviceState?.loading ? ' is-checking' : ''}`}
+                className={`bn-device-action-button bn-runtime-check-button${selectedDeviceState?.loading ? ' is-checking' : ''}`}
+                title="Check the runtime and every attached robot hardware service"
               >
-                {selectedDeviceState?.loading ? 'Checking runtime…' : 'Check runtime'}
+                {selectedDeviceState?.loading ? 'Checking device…' : 'Check device'}
               </button>
-              <button onClick={() => renameDevice(selectedDevice)} disabled={busy} style={miniButton}>
+              <button
+                onClick={() => renameDevice(selectedDevice)}
+                disabled={busy}
+                className="bn-device-action-button"
+              >
                 Rename
               </button>
+              {!selectedDevice.managed_runtime && (
+                <button
+                  onClick={() => openSshManagement(selectedDevice)}
+                  disabled={busy}
+                  className={`bn-device-action-button bn-ssh-enable-button${showSshManagement ? ' is-active' : ''}`}
+                  title="Verify this paired runtime over SSH to enable lifecycle controls"
+                  aria-expanded={showSshManagement}
+                >
+                  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <rect x="3.5" y="5" width="17" height="14" rx="3" />
+                    <path d="m7.5 9 2.5 2.5L7.5 14M12.5 14H16" />
+                  </svg>
+                  Enable SSH controls
+                </button>
+              )}
               {selectedDevice.managed_runtime && (
                 <>
                   <button
                     onClick={() => {
                       setShowRuntimeControl(current => !current)
+                      setShowUpdateForm(false)
                       setShowUninstallForm(false)
                       setRuntimeControlPassword('')
                       setError(null)
                     }}
                     disabled={busy}
-                    style={selectedDevice.paused ? primaryButton : miniButton}
+                    className={`bn-device-action-button${selectedDevice.paused ? ' is-primary' : ''}`}
                   >
                     {selectedDevice.paused ? 'Resume device' : 'Pause device'}
                   </button>
                   <button
                     onClick={() => {
+                      setShowUpdateForm(current => !current)
+                      setShowRuntimeControl(false)
+                      setShowUninstallForm(false)
+                      setUpdatePassword('')
+                      setError(null)
+                    }}
+                    disabled={busy}
+                    className={`bn-device-action-button${showUpdateForm ? ' is-active' : ''}`}
+                  >
+                    Runtime + Robot Hardware
+                  </button>
+                  <button
+                    onClick={() => {
                       setShowUninstallForm(current => !current)
                       setShowRuntimeControl(false)
+                      setShowUpdateForm(false)
                       setUninstallPassword('')
                       setError(null)
                     }}
                     disabled={busy}
-                    style={dangerButton}
+                    className="bn-device-action-button is-danger"
                   >
                     Uninstall runtime
                   </button>
                 </>
               )}
-              <button onClick={() => removeDevice(selectedDevice)} disabled={busy} style={dangerButton}>
-                Remove from editor
+              <button
+                onClick={() => removeDevice(selectedDevice)}
+                disabled={busy}
+                className="bn-device-action-button is-danger"
+                title="Remove only Blacknode's saved connection; do not uninstall Runtime or Hardware"
+              >
+                Forget device
               </button>
             </div>
           </div>
+
+          {showSshManagement && !selectedDevice.managed_runtime && (
+            <form
+              className="bn-runtime-uninstall bn-ssh-management-form"
+              onSubmit={event => void configureSshManagement(event, selectedDevice)}
+            >
+              <div className="bn-ssh-management-head">
+                <span className="bn-ssh-management-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false">
+                    <path d="M7 10V8a5 5 0 0 1 10 0v2" />
+                    <rect x="4" y="10" width="16" height="11" rx="3" />
+                    <path d="M12 14v3" />
+                  </svg>
+                </span>
+                <div>
+                  <strong>Enable SSH lifecycle controls</strong>
+                  <span>
+                    Securely connect this paired computer so Blacknode can pause,
+                    resume, and maintain its runtime.
+                  </span>
+                </div>
+                <span className="bn-ssh-private-badge">
+                  <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                    <path d="M4.75 7V5.5a3.25 3.25 0 0 1 6.5 0V7" />
+                    <rect x="3" y="7" width="10" height="7" rx="2" />
+                  </svg>
+                  Password not saved
+                </span>
+              </div>
+
+              <div className="bn-ssh-management-progress" aria-label="SSH setup progress">
+                <span className="is-active">
+                  <i>1</i>
+                  Connection
+                </span>
+                <b aria-hidden="true" />
+                <span className={managementProbe ? 'is-active' : ''}>
+                  <i>2</i>
+                  Verify & enable
+                </span>
+              </div>
+
+              <div className="bn-ssh-runtime-target">
+                <div>
+                  <span>Paired runtime</span>
+                  <code>{selectedDevice.runtime_url}</code>
+                </div>
+                <span className={`bn-ssh-identity-state${selectedDevice.remote_device_id ? ' is-known' : ''}`}>
+                  <i aria-hidden="true" />
+                  {selectedDevice.remote_device_id
+                    ? `Identity ${selectedDevice.remote_device_id}`
+                    : 'Identity verified during setup'}
+                </span>
+              </div>
+
+              <div className="bn-ssh-management-fields">
+                <label>
+                  <span>Device IP address or hostname</span>
+                  <input
+                    value={managementHost}
+                    onChange={event => {
+                      setManagementHost(event.target.value)
+                      setManagementProbe(null)
+                    }}
+                    placeholder="192.168.1.87"
+                    autoComplete="off"
+                    required
+                  />
+                  <small>The address used to reach this computer from Blacknode.</small>
+                </label>
+                <label className="bn-ssh-port-field">
+                  <span>SSH port</span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={65535}
+                    value={managementPort}
+                    onChange={event => {
+                      setManagementPort(Number(event.target.value))
+                      setManagementProbe(null)
+                    }}
+                    required
+                  />
+                  <small>Usually 22</small>
+                </label>
+              </div>
+
+              {managementProbe && (
+                <>
+                  <div className="bn-device-fingerprint bn-ssh-host-card">
+                    <div>
+                      <span className="bn-ssh-host-check" aria-hidden="true">
+                        <svg viewBox="0 0 16 16" focusable="false">
+                          <path d="m3.5 8.5 3 3 6-7" />
+                        </svg>
+                      </span>
+                      <div>
+                        <strong>SSH connection verified</strong>
+                        <p>{managementProbe.hostname} · {managementProbe.os} · {managementProbe.architecture}</p>
+                      </div>
+                      <span className="bn-ssh-verified-badge">Host verified</span>
+                    </div>
+                    <span>Confirm the host key before entering your credentials.</span>
+                    <code>{managementProbe.host_fingerprint}</code>
+                  </div>
+                  <div className="bn-ssh-management-fields is-auth">
+                    <label>
+                      <span>SSH username</span>
+                      <input
+                        value={managementUsername}
+                        onChange={event => setManagementUsername(event.target.value)}
+                        autoComplete="username"
+                        placeholder="robot"
+                        required
+                      />
+                    </label>
+                    <label>
+                      <span>SSH password</span>
+                      <input
+                        type="password"
+                        value={managementPassword}
+                        onChange={event => setManagementPassword(event.target.value)}
+                        autoComplete="current-password"
+                        placeholder="Enter password"
+                        required
+                      />
+                    </label>
+                  </div>
+                </>
+              )}
+
+              <div className="bn-device-form-actions bn-ssh-management-actions">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowSshManagement(false)
+                    setManagementPassword('')
+                    setManagementProbe(null)
+                  }}
+                  disabled={busy}
+                  className="bn-ssh-cancel-button"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={
+                    busy
+                    || !managementHost.trim()
+                    || (Boolean(managementProbe)
+                      && (!managementUsername.trim() || !managementPassword))
+                  }
+                  style={primaryButton}
+                  className="bn-ssh-submit-button"
+                >
+                  {busy
+                    ? managementProbe ? 'Verifying runtime…' : 'Checking SSH…'
+                    : managementProbe ? 'Confirm and enable' : 'Check SSH connection'}
+                </button>
+              </div>
+            </form>
+          )}
 
           {showRuntimeControl && selectedDevice.managed_runtime && (
             <form
@@ -1186,6 +1884,385 @@ export default function DevicesPanel() {
             <LifecycleProgress value={actionProgress[selectedDevice.id]} />
           )}
 
+          {showUpdateForm && selectedDevice.managed_runtime && (
+            <form
+              className="bn-runtime-uninstall bn-device-update-form"
+              onSubmit={event => {
+                event.preventDefault()
+                void checkDeviceSoftware(selectedDevice)
+              }}
+            >
+              <div>
+                <strong>Runtime + Robot Hardware</strong>
+                <span>
+                  Checks the Blacknode Runtime repository and every Blacknode Hardware
+                  repository used by this device. Installed, latest, and live-reported
+                  versions are shown together first. Current versions can also be
+                  reinstalled when you want to repair the environments and restart services.
+                </span>
+              </div>
+              <label className="bn-device-update-password">
+                <span>
+                  <strong>SSH password</strong>
+                  <small>
+                    {selectedDevice.managed_runtime.ssh_username} · verified device · never saved
+                  </small>
+                </span>
+                <input
+                  type="password"
+                  value={updatePassword}
+                  onChange={event => setUpdatePassword(event.target.value)}
+                  autoComplete="current-password"
+                  placeholder="Enter SSH password"
+                  spellCheck={false}
+                  required
+                />
+              </label>
+              <div className="bn-device-update-caution">
+                Checking versions is read-only. Updating stops deployments and restarts
+                robot monitoring disarmed. Physical servo torque may remain enabled.
+              </div>
+              <div className="bn-device-form-actions">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowUpdateForm(false)
+                    setUpdatePassword('')
+                  }}
+                  className="bn-device-action-button"
+                >
+                  Cancel
+                </button>
+                <button type="submit" disabled={busy} className="bn-device-action-button">
+                  {busy ? 'Checking versions…' : 'Check installed vs latest'}
+                </button>
+              </div>
+            </form>
+          )}
+
+          {updateCheckReport && (
+            <section className="bn-device-update-report" aria-label="Runtime and Robot Hardware version report">
+              <div className="bn-device-update-report-head">
+                <div>
+                  <strong>Runtime + Robot Hardware version report</strong>
+                  <span>{updateCheckReport.summary}</span>
+                </div>
+                <span>{updateCheckReport.check.components.length} services checked</span>
+              </div>
+              <div className="bn-device-update-components">
+                {checkedRuntimeComponents.map(component => (
+                  <div
+                    className="bn-device-update-component"
+                    key={`check-${component.kind}-${component.service_name}-${component.port}`}
+                  >
+                    <div>
+                      <strong>Runtime</strong>
+                      <code>{component.service_name} · port {component.port}</code>
+                    </div>
+                    <div className="bn-device-update-version">
+                      <span>Installed → latest</span>
+                      <strong>
+                        {component.installed.version}
+                        <i aria-hidden="true">→</i>
+                        {component.latest.version}
+                      </strong>
+                      <code>
+                        {component.installed.commit || 'unknown'}
+                        {' → '}
+                        {component.latest.commit || 'unknown'}
+                      </code>
+                    </div>
+                    <div className="bn-device-update-row-actions">
+                      <span
+                        className={`bn-device-update-state${
+                          component.error
+                            ? ' is-blocked'
+                            : component.update_available
+                              ? ' is-changed'
+                              : ''
+                        }`}
+                      >
+                        {component.error
+                          ? 'ATTENTION'
+                          : component.update_available
+                            ? 'UPDATE AVAILABLE'
+                            : 'CURRENT'}
+                      </span>
+                      <button
+                        type="button"
+                        className={`bn-device-action-button${
+                          component.update_available ? ' is-primary' : ''
+                        }`}
+                        disabled={busy || component.dirty || !updatePassword}
+                        title={component.dirty
+                          ? 'Local source changes must be resolved before reinstalling'
+                          : component.error
+                            ? 'Attempt to repair and reinstall Runtime'
+                            : component.update_available
+                              ? 'Update Runtime'
+                              : 'Reinstall current Runtime'}
+                        onClick={() => void updateDevice(selectedDevice, 'runtime')}
+                      >
+                        {busy
+                          ? 'Working…'
+                          : component.error
+                            || component.installed.version === 'unknown'
+                            || component.latest.version === 'unknown'
+                            ? 'Repair Runtime'
+                            : component.update_available
+                              ? 'Update Runtime'
+                              : 'Reinstall Runtime'}
+                      </button>
+                    </div>
+                    <small>
+                      Live service reports {component.reported_version || 'version unavailable'}
+                    </small>
+                    {component.error && (
+                      <small className="bn-device-update-component-error">
+                        {component.error}
+                      </small>
+                    )}
+                  </div>
+                ))}
+                {checkedHardwareInstallation && (
+                  <div className="bn-device-update-component" key="check-hardware-shared">
+                    <div>
+                      <strong>Robot Hardware</strong>
+                      <code>
+                        Shared installation · {checkedHardwareComponents.length} robot
+                        {' '}service{checkedHardwareComponents.length === 1 ? '' : 's'}
+                      </code>
+                    </div>
+                    <div className="bn-device-update-version">
+                      <span>Installed → latest</span>
+                      <strong>
+                        {checkedHardwareInstallation.installed.version}
+                        <i aria-hidden="true">→</i>
+                        {checkedHardwareInstallation.latest.version}
+                      </strong>
+                      <code>
+                        {checkedHardwareInstallation.installed.commit || 'unknown'}
+                        {' → '}
+                        {checkedHardwareInstallation.latest.commit || 'unknown'}
+                      </code>
+                    </div>
+                    <div className="bn-device-update-row-actions">
+                      <span
+                        className={`bn-device-update-state${
+                          checkedHardwareNeedsRepair
+                            ? ' is-blocked'
+                            : checkedHardwareHasUpdate
+                              ? ' is-changed'
+                              : ''
+                        }`}
+                      >
+                        {checkedHardwareNeedsRepair
+                          ? 'ATTENTION'
+                          : checkedHardwareHasUpdate
+                            ? 'UPDATE AVAILABLE'
+                            : 'CURRENT'}
+                      </span>
+                      <button
+                        type="button"
+                        className={`bn-device-action-button${
+                          checkedHardwareHasUpdate ? ' is-primary' : ''
+                        }`}
+                        disabled={busy || !updatePassword || checkedHardwareIsDirty}
+                        title={`Updates the shared Robot Hardware installation and restarts ${
+                          checkedHardwareComponents.length
+                        } robot service${checkedHardwareComponents.length === 1 ? '' : 's'}`}
+                        onClick={() => void updateDevice(selectedDevice, 'hardware')}
+                      >
+                        {busy
+                          ? 'Working…'
+                          : checkedHardwareNeedsRepair
+                            ? 'Repair Robot Hardware'
+                            : checkedHardwareHasUpdate
+                              ? 'Update Robot Hardware'
+                              : 'Reinstall Robot Hardware'}
+                      </button>
+                    </div>
+                    <small>
+                      Robot services:{' '}
+                      {checkedHardwareComponents.map(component => (
+                        `${robotNameForPort(component.port)} (port ${component.port}) — ${
+                          component.error
+                            ? 'attention'
+                            : formatVersion(
+                              component.reported_version || component.installed.version,
+                            )
+                        }`
+                      )).join(' · ')}
+                    </small>
+                    {checkedHardwareComponents
+                      .filter(component => Boolean(component.error))
+                      .map(component => (
+                        <small
+                          className="bn-device-update-component-error"
+                          key={`hardware-error-${component.port}`}
+                        >
+                          {robotNameForPort(component.port)}: {component.error}
+                        </small>
+                      ))}
+                  </div>
+                )}
+              </div>
+              {updateCheckReport.warnings.length > 0 && (
+                <div className="bn-device-update-warnings">
+                  {updateCheckReport.warnings.map(warning => (
+                    <span key={warning}>{warning}</span>
+                  ))}
+                </div>
+              )}
+              <div className="bn-device-update-report-actions">
+                <button
+                  type="button"
+                  className="bn-device-action-button"
+                  disabled={
+                    busy
+                    || !updatePassword
+                    || checkedSoftwareComponents.some(
+                      component => component.dirty || Boolean(component.error),
+                    )
+                  }
+                  title="Update or reinstall Runtime and the shared Robot Hardware installation together"
+                  onClick={() => void updateDevice(selectedDevice, 'all')}
+                >
+                  {checkedSoftwareComponents.some(component => component.update_available)
+                    ? 'Update all'
+                    : 'Reinstall all'}
+                </button>
+              </div>
+            </section>
+          )}
+
+          {updateReport && (
+            <section className="bn-device-update-report" aria-label="Runtime and Hardware update report">
+              <div className="bn-device-update-report-head">
+                <div>
+                  <strong>Runtime + Robot Hardware update report</strong>
+                  <span>{updateReport.summary}</span>
+                </div>
+                <span>{updateReport.update.components.length} services checked</span>
+              </div>
+              <div className="bn-device-update-components">
+                {updatedRuntimeComponents.map(component => (
+                  <div
+                    className="bn-device-update-component"
+                    key={`${component.kind}-${component.service_name}-${component.port}`}
+                  >
+                    <div>
+                      <strong>Runtime</strong>
+                      <code>{component.service_name} · port {component.port}</code>
+                    </div>
+                    <div className="bn-device-update-version is-result">
+                      <span>
+                        {component.changed
+                          ? 'Before update → Installed now'
+                          : 'Reinstalled version'}
+                      </span>
+                      {component.changed ? (
+                        <>
+                          <strong>
+                            <span>{component.before.version}</span>
+                            <i aria-hidden="true">→</i>
+                            <span className="is-current">{component.after.version}</span>
+                          </strong>
+                          <code>
+                            {component.before.commit}
+                            {' → '}
+                            <b>{component.after.commit}</b>
+                          </code>
+                        </>
+                      ) : (
+                        <>
+                          <strong>
+                            <span className="is-current">{component.after.version}</span>
+                          </strong>
+                          <code><b>{component.after.commit}</b></code>
+                        </>
+                      )}
+                    </div>
+                    <span className={`bn-device-update-state${component.changed ? ' is-changed' : ''}`}>
+                      {component.changed ? 'UPDATE COMPLETE' : 'REINSTALLED'}
+                    </span>
+                    <small>
+                      Running service confirms{' '}
+                      <strong>{component.reported_version || 'version unavailable'}</strong>
+                    </small>
+                  </div>
+                ))}
+                {updatedHardwareInstallation && (
+                  <div className="bn-device-update-component" key="hardware-shared-result">
+                    <div>
+                      <strong>Robot Hardware</strong>
+                      <code>
+                        Shared installation · {updatedHardwareComponents.length} robot
+                        {' '}service{updatedHardwareComponents.length === 1 ? '' : 's'}
+                      </code>
+                    </div>
+                    <div className="bn-device-update-version is-result">
+                      <span>
+                        {updatedHardwareComponents.some(component => component.changed)
+                          ? 'Before update → Installed now'
+                          : 'Reinstalled version'}
+                      </span>
+                      {updatedHardwareComponents.some(component => component.changed) ? (
+                        <>
+                          <strong>
+                            <span>{updatedHardwareInstallation.before.version}</span>
+                            <i aria-hidden="true">→</i>
+                            <span className="is-current">
+                              {updatedHardwareInstallation.after.version}
+                            </span>
+                          </strong>
+                          <code>
+                            {updatedHardwareInstallation.before.commit}
+                            {' → '}
+                            <b>{updatedHardwareInstallation.after.commit}</b>
+                          </code>
+                        </>
+                      ) : (
+                        <>
+                          <strong>
+                            <span className="is-current">
+                              {updatedHardwareInstallation.after.version}
+                            </span>
+                          </strong>
+                          <code><b>{updatedHardwareInstallation.after.commit}</b></code>
+                        </>
+                      )}
+                    </div>
+                    <span className={`bn-device-update-state${
+                      updatedHardwareComponents.some(component => component.changed)
+                        ? ' is-changed'
+                        : ''
+                    }`}>
+                      {updatedHardwareComponents.some(component => component.changed)
+                        ? 'UPDATE COMPLETE'
+                        : 'REINSTALLED'}
+                    </span>
+                    <small>
+                      Robot services:{' '}
+                      {updatedHardwareComponents.map(component => (
+                        `${robotNameForPort(component.port)} (port ${component.port}) — ${
+                          formatVersion(component.reported_version)
+                        }`
+                      )).join(' · ')}
+                    </small>
+                  </div>
+                )}
+              </div>
+              {updateReport.warnings.length > 0 && (
+                <div className="bn-device-update-warnings">
+                  {updateReport.warnings.map(warning => (
+                    <span key={warning}>{warning}</span>
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
+
           {showUninstallForm && selectedDevice.managed_runtime && (
             <form
               className="bn-runtime-uninstall"
@@ -1233,11 +2310,11 @@ export default function DevicesPanel() {
 
           <div
             className={`bn-runtime-check-result${
-              selectedDeviceState?.loading
+              selectedDeviceChecking
                 ? ' is-checking'
                 : selectedDevice.paused || selectedDeviceState?.runtime?.paused
                   ? ' is-paused'
-                : selectedDeviceState?.runtime?.ok
+                : selectedDeviceReady
                   ? ' is-ready'
                   : ' is-error'
             }`}
@@ -1247,48 +2324,52 @@ export default function DevicesPanel() {
             <span className="bn-runtime-check-dot" aria-hidden="true" />
             <div>
               <strong>
-                {selectedDeviceState?.loading
-                  ? 'Checking runtime…'
+                {selectedDeviceChecking
+                  ? 'Checking device services…'
                   : selectedDevice.paused || selectedDeviceState?.runtime?.paused
-                    ? 'Runtime paused'
-                  : selectedDeviceState?.runtime?.ok
-                    ? 'Runtime connected'
-                    : 'Runtime unavailable'}
+                    ? 'Device paused'
+                  : selectedDeviceReady
+                    ? 'Device services connected'
+                    : 'Device needs attention'}
               </strong>
               <span>
-                {selectedDeviceState?.loading
-                  ? `Contacting ${selectedDevice.runtime_url}`
+                {selectedDeviceChecking
+                  ? `Checking Runtime and ${selectedDevice.robots.length} Robot Hardware service${selectedDevice.robots.length === 1 ? '' : 's'}`
                   : selectedDevice.paused || selectedDeviceState?.runtime?.paused
                     ? 'Deployments are stopped and attached robots are disarmed.'
-                  : selectedDeviceState?.runtime?.ok
-                    ? `Last checked ${formatCheckedAt(selectedDeviceState.checkedAt)}`
-                    : selectedDeviceState?.runtime?.error || 'The runtime has not been checked yet.'}
+                  : selectedDeviceReady
+                    ? `${selectedServiceVersions.join(' · ')} · Last checked ${formatCheckedAt(selectedLastChecked)}`
+                    : selectedDeviceState?.runtime?.error
+                      || selectedRobotChecks.find(item => item.state?.error)?.state?.error
+                      || 'Run Check device to verify Runtime and attached Robot Hardware services.'}
               </span>
             </div>
           </div>
 
           <div className="bn-compute-robots-head">
             <div>
-              <strong>Robots</strong>
+              <strong>Attached robots</strong>
               <span>
                 {selectedDevice.robots.length
                   ? `${selectedDevice.robots.length} attached to this device`
-                  : 'Add the robot hardware connected to this device'}
+                  : 'Attach the robot hardware physically connected to this device'}
               </span>
             </div>
             <button
               type="button"
               onClick={() => openRobotForm(selectedDevice)}
               disabled={busy}
-              style={primaryButton}
+              className="bn-device-action-button is-primary"
             >
-              Add robot
+              Attach robot
             </button>
           </div>
 
           {showRobotForm && (
             <form className="bn-device-form bn-robot-form" onSubmit={addRobot}>
-              <div className="bn-device-form-title">Add robot to {selectedDevice.name}</div>
+              <div className="bn-device-form-title">
+                Attach existing robot to {selectedDevice.name}
+              </div>
               <label>
                 <span>Robot name</span>
                 <input
@@ -1299,7 +2380,7 @@ export default function DevicesPanel() {
                 />
               </label>
               <label>
-                <span>Hardware service URL</span>
+                <span>Robot Hardware service URL</span>
                 <input
                   value={robotUrl}
                   onChange={event => setRobotUrl(event.target.value)}
@@ -1326,8 +2407,8 @@ export default function DevicesPanel() {
                 />
               </label>
               <div className="bn-device-help">
-                This pairs hardware only. Deployments automatically use the runtime on{' '}
-                {selectedDevice.name}.
+                This registers existing hardware under {selectedDevice.name}. After
+                attaching, expand the robot card and choose Deploy workflow.
               </div>
               <div className="bn-device-form-actions">
                 <button
@@ -1341,7 +2422,7 @@ export default function DevicesPanel() {
                   Cancel
                 </button>
                 <button type="submit" disabled={busy} style={primaryButton}>
-                  {busy ? 'Adding…' : 'Add and verify robot'}
+                  {busy ? 'Attaching…' : 'Attach and verify robot'}
                 </button>
               </div>
             </form>
@@ -1350,7 +2431,8 @@ export default function DevicesPanel() {
           <div className="bn-device-robot-list">
             {selectedDevice.robots.length === 0 && !showRobotForm && (
               <div className="bn-device-robot-empty">
-                This device is ready. Add a robot to create a deployment target.
+                This compute device is ready. Attach its physical robot to create a
+                deployment target.
               </div>
             )}
             {selectedDevice.robots.map(robot => (
@@ -1360,13 +2442,24 @@ export default function DevicesPanel() {
                 state={robotStates[robot.id]}
                 runtimeReady={deviceStates[selectedDevice.id]?.runtime?.ok === true}
                 actionProgress={actionProgress[robot.id]}
+                installedSoftwareVersion={installedHardwareVersionForPort(
+                  urlPort(robot.base_url),
+                )}
                 canRestartService={Boolean(selectedDevice.managed_runtime)}
                 sshUsername={selectedDevice.managed_runtime?.ssh_username}
                 busy={busy}
                 onRefresh={() => refreshRobot(robot)}
                 onRename={() => renameRobot(robot)}
                 onRemove={() => removeRobot(robot)}
+                onDeploy={() => window.dispatchEvent(new CustomEvent(
+                  'blacknode:open-panel',
+                  { detail: { tab: 'deployments', deviceId: robot.id } },
+                ))}
                 onStopDeployment={deploymentId => stopDeployment(robot, deploymentId)}
+                onStartDeployment={(deploymentId, deploymentName) => (
+                  restartStoredDeployment(robot, deploymentId, deploymentName)
+                )}
+                onReleaseTorque={() => releaseRobotTorque(robot)}
                 onControl={action => controlRobot(robot, action)}
                 onRestartService={password => controlRobot(robot, 'restart', password)}
               />
@@ -1417,13 +2510,17 @@ function RobotRow({
   state,
   runtimeReady,
   actionProgress,
+  installedSoftwareVersion,
   canRestartService,
   sshUsername,
   busy,
   onRefresh,
   onRename,
   onRemove,
+  onDeploy,
   onStopDeployment,
+  onStartDeployment,
+  onReleaseTorque,
   onControl,
   onRestartService,
 }: {
@@ -1431,21 +2528,37 @@ function RobotRow({
   state?: RobotState
   runtimeReady: boolean
   actionProgress?: DeviceActionProgress
+  installedSoftwareVersion: string
   canRestartService: boolean
   sshUsername?: string
   busy: boolean
   onRefresh: () => void
   onRename: () => void
   onRemove: () => void
+  onDeploy: () => void
   onStopDeployment: (deploymentId: string) => void
+  onStartDeployment: (deploymentId: string, deploymentName: string) => void
+  onReleaseTorque: () => void
   onControl: (action: 'pause' | 'resume') => void
   onRestartService: (password: string) => Promise<boolean>
 }) {
   const [expanded, setExpanded] = useState(false)
   const [showRestart, setShowRestart] = useState(false)
+  const [showMonitor, setShowMonitor] = useState(false)
+  const [showTorqueDetails, setShowTorqueDetails] = useState(false)
   const [restartPassword, setRestartPassword] = useState('')
   const status = state?.status
   const deploymentLease = status?.deployment_lease
+  const runningDeployment = deploymentLease ?? status?.running_deployment
+  const storedDeployment = runningDeployment ? undefined : status?.stored_deployment
+  const torqueReleaseSupported = Boolean(
+    status?.service_features?.includes('torque_release_v1'),
+  )
+  const torqueUnknownReason = status?.torque_report_error
+    || (runningDeployment
+      ? 'The running deployment owns the robot connection, so the monitoring service cannot read the servo torque registers.'
+      : 'Robot Hardware did not receive a valid torque-register reading from every configured servo.')
+  const mqttTelemetry = status?.telemetry?.sinks.find(sink => sink.name === 'mqtt')
   const paused = Boolean(robot.paused || status?.paused)
   const leased = Boolean(status?.leased_to_deployment || deploymentLease)
   const connected = Boolean(status?.connected)
@@ -1466,8 +2579,12 @@ function RobotRow({
       ? 'PAUSED'
     : deploymentLease
       ? 'ACTIVE'
+      : runningDeployment
+        ? 'RUNNING'
       : armed
         ? 'ARMED'
+      : storedDeployment
+        ? 'STORED'
       : ready
         ? 'CONNECTED'
         : 'OFF'
@@ -1477,13 +2594,17 @@ function RobotRow({
       ? 'Stopped and disarmed'
     : deploymentLease
       ? `Deployment “${deploymentLease.name}” is running`
+      : runningDeployment
+        ? `Deployment “${runningDeployment.name}” is running · motion control not held`
       : armed
         ? 'Robot motion is armed'
+      : storedDeployment
+        ? `Deployment “${storedDeployment.name}” is stored · ${storedDeployment.state}`
       : ready
         ? 'Hardware monitoring connected · Blacknode motion disarmed'
         : status
           ? 'Robot needs attention'
-          : 'Hardware service unavailable'
+          : 'Robot Hardware service unavailable'
 
   return (
     <div
@@ -1519,48 +2640,191 @@ function RobotRow({
             <div className="bn-run-error-line bn-device-error" role="alert">{state.error}</div>
           )}
           {actionProgress && <LifecycleProgress value={actionProgress} compact />}
-          {deploymentLease && (
-            <div className="bn-device-lease-notice" role="status">
-              <strong>Deployment controls this robot</strong>
-              <span>{status?.notice || `“${deploymentLease.name}” is running.`}</span>
-            </div>
-          )}
+          <div
+            className={`bn-device-lease-notice${
+              deploymentLease
+                ? ' is-active'
+                : runningDeployment
+                  ? ' is-running'
+                  : storedDeployment
+                    ? ' is-stored'
+                    : ''
+            }`}
+            role="status"
+          >
+            <strong>Deployment</strong>
+            <span>
+              {deploymentLease
+                ? status?.notice || `“${deploymentLease.name}” is running.`
+                : runningDeployment
+                  ? status?.notice || `“${runningDeployment.name}” is running without motion control.`
+                : storedDeployment
+                  ? status?.notice || `“${storedDeployment.name}” remains stored on the Runtime and can be restarted.`
+                : 'No deployment currently controls this robot.'}
+            </span>
+          </div>
           <div className="bn-device-facts">
             <DeviceFact
-              label={deploymentLease ? 'Motion control' : 'Armed'}
-              value={deploymentLease ? `Deployment · ${deploymentLease.name}` : status ? (status.armed ? 'Yes' : 'No') : '—'}
+              label="Motion"
+              value={deploymentLease
+                ? `Workflow · ${deploymentLease.name}`
+                : runningDeployment
+                  ? `Running · ${runningDeployment.name}`
+                : status
+                  ? status.armed ? 'Armed' : 'Disarmed'
+                  : 'Unknown'}
               warn={!deploymentLease && Boolean(status?.armed)}
             />
             <DeviceFact
-              label="Torque"
-              value={status?.torque_enabled == null ? 'Not reported' : status.torque_enabled ? 'On' : 'Off'}
-              warn={status?.torque_enabled === true}
+              label="Physical torque"
+              value={status?.torque_enabled == null ? 'Unknown' : status.torque_enabled ? 'On' : 'Off'}
+              warn={Boolean(status && status.torque_enabled !== false)}
+              title={status?.torque_enabled == null
+                ? `${showTorqueDetails ? 'Hide' : 'Show'} why physical torque is unknown`
+                : undefined}
+              onClick={status && status.torque_enabled == null
+                ? () => setShowTorqueDetails(value => !value)
+                : undefined}
+              expanded={showTorqueDetails}
             />
             <DeviceFact
               label="Calibrated"
               value={status?.calibrated == null ? '—' : status.calibrated ? 'Yes' : 'No'}
             />
-            <DeviceFact label="Hardware" value={connected || leased ? 'Connected' : 'Unavailable'} />
+            <DeviceFact
+              label="Robot Hardware version"
+              value={status?.software_version
+                ? `v${status.software_version}${
+                  status.software_version_cached ? ' (last verified)' : ''
+                }`
+                : installedSoftwareVersion
+                  ? `v${installedSoftwareVersion} (installed)`
+                  : 'Not reported'}
+            />
+            <DeviceFact label="Connection" value={connected || leased ? 'Connected' : 'Unavailable'} />
+            {mqttTelemetry && (
+              <DeviceFact
+                label="MQTT telemetry"
+                value={mqttTelemetry.connected
+                  ? 'Connected'
+                  : mqttTelemetry.error
+                    ? 'Attention'
+                    : 'Connecting'}
+                warn={!mqttTelemetry.connected}
+                title={
+                  mqttTelemetry.error
+                  || `${mqttTelemetry.broker || 'MQTT broker'} · ${
+                    mqttTelemetry.published ?? 0
+                  } samples published`
+                }
+              />
+            )}
             <DeviceFact label="Last check" value={formatCheckedAt(state?.checkedAt)} />
           </div>
-          <div className="bn-run-detail-actions">
+          {status
+            && status.torque_enabled !== false
+            && (status.torque_enabled === true || showTorqueDetails)
+            && (
+            <div
+              className={`bn-device-torque-warning${
+                status.torque_enabled == null ? ' is-unknown' : ''
+              }`}
+              role={status.torque_enabled === true ? 'alert' : 'status'}
+            >
+              <div>
+                <strong>
+                  {status.torque_enabled === true
+                    ? 'Physical torque is on'
+                    : 'Physical torque state is unknown'}
+                </strong>
+                <span>
+                  {status.torque_enabled === true
+                    ? 'Motion is disarmed, but the servos are still holding.'
+                    : torqueUnknownReason}
+                  {' '}Treat the servos as possibly holding torque. Support the robot
+                  before releasing it because its joints may move or drop.
+                  {!runningDeployment && !torqueReleaseSupported
+                    ? ' Update Robot Hardware to enable the remote torque-off action.'
+                    : ''}
+                </span>
+              </div>
+              {!runningDeployment && (
+                <button
+                  type="button"
+                  onClick={onReleaseTorque}
+                  disabled={busy || state?.loading || paused || !torqueReleaseSupported}
+                  title={torqueReleaseSupported
+                    ? 'Send torque-off to every configured servo, then verify when register reads are available'
+                    : 'Update Robot Hardware before releasing torque remotely'}
+                  className="bn-device-action-button is-danger"
+                >
+                  Release torque
+                </button>
+              )}
+            </div>
+          )}
+          <div className="bn-run-detail-actions bn-robot-card-actions is-primary">
+            <button
+              onClick={() => {
+                if (storedDeployment?.id) {
+                  onStartDeployment(storedDeployment.id, storedDeployment.name)
+                } else {
+                  onDeploy()
+                }
+              }}
+              disabled={busy || state?.loading || paused}
+              className="bn-device-action-button is-primary"
+              title={paused
+                ? `Resume this robot before ${
+                  storedDeployment ? 'restarting its stored deployment' : 'deploying a workflow'
+                }`
+                : storedDeployment
+                  ? `Start the stored ${storedDeployment.state} deployment`
+                  : 'Open deployment setup and history for this robot'}
+            >
+              {storedDeployment ? 'Restart deployment' : 'Deploy workflow'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowMonitor(value => !value)}
+              className={`bn-device-action-button${showMonitor ? ' is-primary' : ''}`}
+              aria-pressed={showMonitor}
+            >
+              {showMonitor ? 'Close monitor' : 'Monitor live'}
+            </button>
             <button
               onClick={() => onControl(paused ? 'resume' : 'pause')}
               disabled={busy || state?.loading}
-              style={paused ? primaryButton : miniButton}
+              className={`bn-device-action-button${paused ? ' is-primary' : ''}`}
             >
               {paused ? 'Resume robot' : 'Pause robot'}
             </button>
-            {deploymentLease?.id && (
-              <button
-                onClick={() => onStopDeployment(deploymentLease.id)}
-                disabled={busy || state?.loading}
-                style={miniButton}
-              >
-                Stop deployment
-              </button>
-            )}
-            <button onClick={onRefresh} disabled={busy || state?.loading} style={miniButton}>
+            <button
+              onClick={() => {
+                if (runningDeployment?.id) {
+                  onStopDeployment(runningDeployment.id)
+                } else if (storedDeployment) {
+                  onDeploy()
+                }
+              }}
+              disabled={busy || state?.loading || (!runningDeployment?.id && !storedDeployment)}
+              title={runningDeployment?.id
+                ? 'Stop the workflow running on this robot'
+                : storedDeployment
+                  ? 'Open this robot’s stored deployment and revision history'
+                  : 'No deployment is stored on this robot'}
+              className="bn-device-action-button"
+            >
+              {storedDeployment ? 'Deployment details' : 'Stop deployment'}
+            </button>
+          </div>
+          {showMonitor && <RobotMonitor robot={robot} />}
+          <div className="bn-run-detail-actions bn-robot-card-actions is-secondary">
+            <button
+              onClick={onRefresh}
+              disabled={busy || state?.loading}
+              className="bn-device-action-button"
+            >
               Refresh
             </button>
             <button
@@ -1572,13 +2836,17 @@ function RobotRow({
               disabled={busy || state?.loading || !canRestartService}
               title={canRestartService
                 ? 'Restart the exact remote blacknode-hardware systemd service for this port'
-                : 'Automatic restart requires a compute device installed through SSH'}
-              style={miniButton}
+                : 'Open the compute device and choose Enable SSH controls first'}
+              className="bn-device-action-button"
             >
-              Restart robot service
+              Restart Robot Hardware
             </button>
-            <button onClick={onRename} disabled={busy} style={miniButton}>Rename</button>
-            <button onClick={onRemove} disabled={busy} style={dangerButton}>Remove</button>
+            <button onClick={onRename} disabled={busy} className="bn-device-action-button">
+              Rename
+            </button>
+            <button onClick={onRemove} disabled={busy} className="bn-device-action-button is-danger">
+              Remove
+            </button>
           </div>
           {showRestart && canRestartService && (
             <form
@@ -1597,7 +2865,7 @@ function RobotRow({
               }}
             >
               <div>
-                <strong>Restart this robot service</strong>
+                  <strong>Restart Robot Hardware for this robot</strong>
                 <span>
                   Blacknode resolves the exact systemd unit from hardware port
                   {' '}{new URL(robot.base_url).port}, restarts only that unit, and verifies
@@ -1638,6 +2906,228 @@ function RobotRow({
   )
 }
 
+type JointTrace = {
+  position: number[]
+  velocity: number[]
+}
+
+function RobotMonitor({ robot }: { robot: HardwareDevice }) {
+  const [sample, setSample] = useState<RobotTelemetrySample | null>(null)
+  const [connection, setConnection] = useState<'connecting' | 'live' | 'offline'>('connecting')
+  const [traces, setTraces] = useState<Record<string, JointTrace>>({})
+  const previous = useRef<Record<string, { position: number; at: number }>>({})
+  const activeSource = useRef('')
+
+  useEffect(() => {
+    let stopped = false
+    let socket: WebSocket | null = null
+    let reconnectTimer: number | undefined
+
+    const connect = () => {
+      if (stopped) return
+      setConnection('connecting')
+      socket = new WebSocket(deviceMonitorSocketUrl(robot.id))
+      socket.onopen = () => setConnection('live')
+      socket.onmessage = event => {
+        let next: RobotTelemetrySample
+        try {
+          next = JSON.parse(String(event.data)) as RobotTelemetrySample
+        } catch {
+          return
+        }
+        const sourceKey = `${next.source || 'unknown'}:${next.source_label || ''}`
+        if (activeSource.current && activeSource.current !== sourceKey) {
+          previous.current = {}
+          setTraces({})
+        }
+        activeSource.current = sourceKey
+        const receivedAt = Date.now()
+        if (next.available && next.payload?.joints) {
+          const normalized = next.payload.joints.map(joint => {
+            const prior = previous.current[joint.name]
+            const elapsed = prior ? (receivedAt - prior.at) / 1000 : 0
+            const derivedVelocity = elapsed > 0
+              ? (joint.position - prior.position) / elapsed
+              : 0
+            previous.current[joint.name] = {
+              position: joint.position,
+              at: receivedAt,
+            }
+            return {
+              ...joint,
+              velocity: next.source === 'hardware'
+                ? derivedVelocity
+                : Number.isFinite(joint.velocity) ? joint.velocity : derivedVelocity,
+            }
+          })
+          next = {
+            ...next,
+            payload: {
+              ...next.payload,
+              joints: normalized,
+            },
+          }
+          setTraces(current => {
+            const updated = { ...current }
+            for (const joint of normalized) {
+              const trace = updated[joint.name] || { position: [], velocity: [] }
+              updated[joint.name] = {
+                position: [...trace.position, joint.position].slice(-80),
+                velocity: [...trace.velocity, joint.velocity].slice(-80),
+              }
+            }
+            return updated
+          })
+        }
+        setSample(next)
+      }
+      socket.onerror = () => socket?.close()
+      socket.onclose = () => {
+        if (stopped) return
+        setConnection('offline')
+        reconnectTimer = window.setTimeout(connect, 1200)
+      }
+    }
+
+    connect()
+    return () => {
+      stopped = true
+      if (reconnectTimer !== undefined) window.clearTimeout(reconnectTimer)
+      socket?.close()
+    }
+  }, [robot.id])
+
+  const joints = sample?.payload?.joints || []
+  const sourceLabel = sample?.source === 'deployment'
+    ? `Deployed · ${sample.source_label || 'workflow'}`
+    : 'Local · Robot Hardware'
+  const torque = sample?.payload?.torque_enabled
+  const stateLabel = connection !== 'live'
+    ? connection
+    : sample?.stale
+      ? 'stale'
+      : sample?.available
+        ? 'live'
+        : 'waiting'
+
+  return (
+    <section className="bn-robot-monitor" aria-label={`Live monitoring for ${robot.name}`}>
+      <div className="bn-robot-monitor-head">
+        <div>
+          <span className={`bn-robot-monitor-pulse is-${stateLabel}`} aria-hidden="true" />
+          <div>
+            <strong>Live robot state</strong>
+            <span>{sourceLabel}</span>
+          </div>
+        </div>
+        <div className="bn-robot-monitor-status">
+          <span className={`is-${stateLabel}`}>{stateLabel.toUpperCase()}</span>
+          <span>
+            Torque {torque == null ? 'unknown' : torque ? 'on' : 'off'}
+          </span>
+        </div>
+      </div>
+
+      {!sample?.available || joints.length === 0 ? (
+        <div className="bn-robot-monitor-empty" role="status">
+          <strong>
+            {connection === 'connecting'
+              ? 'Connecting to robot…'
+              : connection === 'offline'
+                ? 'Reconnecting…'
+                : 'Waiting for joint state'}
+          </strong>
+          <span>
+            {sample?.message
+              || 'The monitor will start as soon as this robot reports joint positions.'}
+          </span>
+        </div>
+      ) : (
+        <>
+          <div className="bn-robot-monitor-meta">
+            <span>{joints.length} joints</span>
+            <span>{sample.payload?.position_unit || 'degree'}</span>
+            <span>
+              Updated {sample.received_at
+                ? new Date(sample.received_at).toLocaleTimeString()
+                : 'now'}
+            </span>
+          </div>
+          <div className="bn-robot-monitor-grid">
+            {joints.map(joint => (
+              <JointMonitorCard
+                key={joint.name}
+                joint={joint}
+                trace={traces[joint.name]}
+                positionUnit={sample.payload?.position_unit || 'degree'}
+                velocityUnit={sample.payload?.velocity_unit || 'degree/s'}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </section>
+  )
+}
+
+function JointMonitorCard({
+  joint,
+  trace,
+  positionUnit,
+  velocityUnit,
+}: {
+  joint: RobotTelemetryJoint
+  trace?: JointTrace
+  positionUnit: string
+  velocityUnit: string
+}) {
+  return (
+    <article className="bn-joint-monitor-card">
+      <div className="bn-joint-monitor-title">
+        <strong title={joint.name}>{joint.name.replace(/_/g, ' ')}</strong>
+        <span>{joint.position.toFixed(2)} {shortUnit(positionUnit)}</span>
+      </div>
+      <TelemetrySparkline values={trace?.position || []} />
+      <div className="bn-joint-monitor-speed">
+        <span>Speed</span>
+        <strong>{joint.velocity.toFixed(2)} {shortUnit(velocityUnit)}</strong>
+      </div>
+    </article>
+  )
+}
+
+function TelemetrySparkline({ values }: { values: number[] }) {
+  const width = 180
+  const height = 44
+  const finite = values.filter(Number.isFinite)
+  const minimum = finite.length ? Math.min(...finite) : 0
+  const maximum = finite.length ? Math.max(...finite) : 0
+  const range = Math.max(maximum - minimum, 0.001)
+  const points = finite.map((value, index) => {
+    const x = finite.length <= 1 ? width : index * width / (finite.length - 1)
+    const y = height - 4 - ((value - minimum) / range) * (height - 8)
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  }).join(' ')
+  return (
+    <svg
+      className="bn-joint-monitor-chart"
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="Recent joint position"
+    >
+      <line x1="0" y1={height / 2} x2={width} y2={height / 2} />
+      {points && <polyline points={points} />}
+    </svg>
+  )
+}
+
+function shortUnit(unit: string): string {
+  return unit
+    .replace('degree', '°')
+    .replace('/s', '/s')
+}
+
 function LifecycleProgress({
   value,
   compact = false,
@@ -1670,12 +3160,42 @@ function formatCheckedAt(checkedAt?: number): string {
   return checkedAt ? new Date(checkedAt).toLocaleTimeString() : '—'
 }
 
-function DeviceFact({ label, value, warn = false }: { label: string; value: string; warn?: boolean }) {
-  return (
-    <div className="bn-device-fact">
-      <span>{label}</span>
+function DeviceFact({
+  label,
+  value,
+  warn = false,
+  title,
+  onClick,
+  expanded = false,
+}: {
+  label: string
+  value: string
+  warn?: boolean
+  title?: string
+  onClick?: () => void
+  expanded?: boolean
+}) {
+  const content = (
+    <>
+      <span>
+        {label}
+        {onClick && <i aria-hidden="true">›</i>}
+      </span>
       <strong style={warn ? { color: 'var(--warn)' } : undefined}>{value}</strong>
-    </div>
+    </>
+  )
+  return onClick ? (
+    <button
+      type="button"
+      className="bn-device-fact is-interactive"
+      title={title}
+      onClick={onClick}
+      aria-expanded={expanded}
+    >
+      {content}
+    </button>
+  ) : (
+    <div className="bn-device-fact" title={title}>{content}</div>
   )
 }
 

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -34,7 +34,6 @@ const PANEL_DEFAULT_W = 240
 const PANEL_MIN_W = 188
 const PANEL_PROJECT_W = 420
 const PANEL_DEPLOY_W = 460
-const PANEL_EXPANDED_W = 760
 const PANEL_MAX_W = 860
 const welcomeButtonStyle: React.CSSProperties = {
   border: '1px solid var(--line2)',
@@ -116,15 +115,6 @@ const ICON_RUNTIME = (
   </svg>
 )
 
-const ICON_DEPLOYMENTS = (
-  <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-    <rect x="2.5" y="3" width="13" height="4" rx="1.2" stroke="currentColor" strokeWidth="1.3"/>
-    <rect x="2.5" y="11" width="13" height="4" rx="1.2" stroke="currentColor" strokeWidth="1.3"/>
-    <circle cx="5.5" cy="5" r=".9" fill="currentColor"/>
-    <circle cx="5.5" cy="13" r=".9" fill="currentColor"/>
-  </svg>
-)
-
 const ICON_DEVICES = (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
     <rect x="3" y="2.5" width="12" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.3"/>
@@ -148,7 +138,6 @@ const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
   { id: 'workflows', label: 'Workflows', icon: ICON_WORKFLOWS },
   { id: 'script',    label: 'Script',    icon: ICON_SCRIPT    },
   { id: 'runs',      label: 'Runs',      icon: ICON_RUNS      },
-  { id: 'deployments', label: 'Deploy',  icon: ICON_DEPLOYMENTS },
   { id: 'devices',   label: 'Devices',   icon: ICON_DEVICES   },
   { id: 'runtime',   label: 'Runtime',   icon: ICON_RUNTIME   },
   { id: 'console',   label: 'Console',   icon: ICON_CONSOLE   },
@@ -171,12 +160,11 @@ export default function NodePalette() {
   const [activeTab, setActiveTab] = useState<Tab | null>('templates')
   const [showPackageWelcome, setShowPackageWelcome] = useState(false)
   const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_W)
-  const [panelExpanded, setPanelExpanded] = useState(false)
+  const [deploymentTargetId, setDeploymentTargetId] = useState('')
   const [templateSearch, setTemplateSearch] = useState('')
   const [templateOpenInNewTab, setTemplateOpenInNewTab] = useState(false)
   const [openGroups, setOpenGroups] = useState<Set<string>>(() => new Set())
   const dragRef = useRef<{ startX: number; startW: number } | null>(null)
-  const compactWidthRef = useRef(PANEL_DEPLOY_W)
 
   const clampPanelWidth = (width: number) => {
     const viewportMax = Math.max(PANEL_MIN_W, window.innerWidth - RAIL_W - 220)
@@ -194,11 +182,9 @@ export default function NodePalette() {
         setPanelWidth(clampPanelWidth(PANEL_DEPLOY_W))
       }
     } else {
-      const compactWidth = panelExpanded ? compactWidthRef.current : panelWidth
       setPanelWidth(clampPanelWidth(
-        tab === 'projects' ? Math.max(compactWidth, PANEL_PROJECT_W) : compactWidth,
+        tab === 'projects' ? Math.max(panelWidth, PANEL_PROJECT_W) : panelWidth,
       ))
-      if (panelExpanded) setPanelExpanded(false)
     }
   }
 
@@ -210,25 +196,10 @@ export default function NodePalette() {
     openPanel(tab)
   }
 
-  const togglePanelExpanded = () => {
-    if (panelExpanded) {
-      setPanelWidth(clampPanelWidth(compactWidthRef.current))
-      setPanelExpanded(false)
-      return
-    }
-    compactWidthRef.current = panelWidth
-    setPanelWidth(clampPanelWidth(PANEL_EXPANDED_W))
-    setPanelExpanded(true)
-  }
-
   const openTemplateGuide = (query: string) => {
     setTemplateSearch(query)
     setTemplateOpenInNewTab(true)
     setActiveTab('templates')
-    if (panelExpanded) {
-      setPanelWidth(clampPanelWidth(compactWidthRef.current))
-      setPanelExpanded(false)
-    }
   }
 
   useEffect(() => {
@@ -244,8 +215,12 @@ export default function NodePalette() {
 
   useEffect(() => {
     const handleOpenPanel = (event: Event) => {
-      const tab = (event as CustomEvent<{ tab?: Tab }>).detail?.tab
-      if (!tab || !TABS.some(item => item.id === tab)) return
+      const detail = (event as CustomEvent<{ tab?: Tab; deviceId?: string }>).detail
+      const tab = detail?.tab
+      if (!tab || (tab !== 'deployments' && !TABS.some(item => item.id === tab))) return
+      if (tab === 'deployments') {
+        setDeploymentTargetId(String(detail?.deviceId || ''))
+      }
       openPanel(tab)
     }
     window.addEventListener('blacknode:open-panel', handleOpenPanel)
@@ -292,7 +267,6 @@ export default function NodePalette() {
       setPanelWidth(clampPanelWidth(
         dragRef.current.startW + ev.clientX - dragRef.current.startX,
       ))
-      setPanelExpanded(false)
     }
     const onUp = () => {
       dragRef.current = null
@@ -705,7 +679,9 @@ export default function NodePalette() {
           height: `calc(100% - ${TOP_BAR_H}px)`,
           marginTop: TOP_BAR_H,
           background: 'var(--panel)',
-          borderRight: '1px solid var(--line)',
+          borderRight: activeTab === 'deployments'
+            ? '1px solid #00d2ff'
+            : '1px solid var(--line)',
           display: 'flex',
           flexDirection: 'column',
           flexShrink: 0,
@@ -746,29 +722,10 @@ export default function NodePalette() {
               textTransform: 'uppercase',
               color: 'var(--tx2)',
             }}>
-              {TABS.find(t => t.id === activeTab)?.label}
+              {activeTab === 'deployments'
+                ? 'Deploy to robot'
+                : TABS.find(t => t.id === activeTab)?.label}
             </span>
-            {activeTab === 'deployments' && (
-              <button
-                type="button"
-                onClick={togglePanelExpanded}
-                title={panelExpanded ? 'Return the deployment panel to its previous width' : 'Expand the deployment panel'}
-                aria-label={panelExpanded ? 'Compact deployment panel' : 'Expand deployment panel'}
-                style={{
-                  padding: '4px 7px',
-                  border: '1px solid var(--line2)',
-                  borderRadius: 4,
-                  background: 'transparent',
-                  color: 'var(--tx2)',
-                  cursor: 'pointer',
-                  fontFamily: 'var(--font-ui)',
-                  fontSize: 11,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {panelExpanded ? 'Compact' : 'Expand'}
-              </button>
-            )}
           </div>
 
           <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
@@ -828,7 +785,11 @@ export default function NodePalette() {
             {activeTab === 'runs' && <RunsPanel />}
 
             {activeTab === 'deployments' && (
-              <DeploymentsPanel onOpenTemplates={openTemplateGuide} />
+              <DeploymentsPanel
+                onOpenTemplates={openTemplateGuide}
+                targetDeviceId={deploymentTargetId}
+                onBackToDevices={() => openPanel('devices')}
+              />
             )}
 
             {activeTab === 'devices' && <DevicesPanel />}

--- a/editor/src/components/ProjectPanel.tsx
+++ b/editor/src/components/ProjectPanel.tsx
@@ -1146,8 +1146,8 @@ export default function ProjectPanel() {
               ))}
               {deployments.length === 0 && (
                 <div className="bn-project-empty">
-                  No deployments are assigned to this project. Older unassigned
-                  deployments remain available in Deployments.
+                  No deployments are assigned to this project. Open a robot in
+                  Devices to deploy the current workflow directly to it.
                 </div>
               )}
             </div>

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -1246,6 +1246,388 @@ html[data-theme="dark"] .bn-brand-logo {
   background: color-mix(in srgb, var(--err) 5%, var(--panel));
 }
 
+.bn-runtime-uninstall.bn-ssh-management-form {
+  position: relative;
+  gap: 14px;
+  overflow: hidden;
+  padding: 16px;
+  border-color: color-mix(in srgb, var(--action) 32%, var(--line2));
+  border-radius: 10px;
+  background:
+    radial-gradient(
+      circle at 0 0,
+      color-mix(in srgb, var(--action) 12%, transparent) 0,
+      transparent 38%
+    ),
+    linear-gradient(145deg, var(--panel), color-mix(in srgb, var(--lift) 88%, var(--action)));
+  box-shadow:
+    0 10px 30px color-mix(in srgb, var(--bg) 26%, transparent),
+    inset 0 1px color-mix(in srgb, #fff 36%, transparent);
+}
+
+.bn-runtime-uninstall.bn-ssh-management-form::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--action), color-mix(in srgb, var(--action) 18%, transparent));
+  content: "";
+}
+
+.bn-ssh-enable-button {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid color-mix(in srgb, var(--action) 58%, var(--line2));
+  border-radius: var(--control-radius);
+  background: color-mix(in srgb, var(--action) 9%, var(--lift));
+  color: color-mix(in srgb, var(--action) 72%, var(--tx1));
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 720;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--bg) 22%, transparent);
+}
+
+.bn-ssh-enable-button:hover:not(:disabled),
+.bn-ssh-enable-button.is-active {
+  border-color: var(--action);
+  background: color-mix(in srgb, var(--action) 15%, var(--lift));
+  color: var(--tx1);
+}
+
+.bn-ssh-enable-button svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.bn-runtime-uninstall > div:first-child.bn-ssh-management-head {
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 11px;
+}
+
+.bn-ssh-management-head > div {
+  min-width: 0;
+}
+
+.bn-runtime-uninstall > div:first-child.bn-ssh-management-head strong {
+  font-size: 14px;
+  font-weight: 750;
+}
+
+.bn-runtime-uninstall > div:first-child.bn-ssh-management-head span {
+  max-width: 560px;
+}
+
+.bn-ssh-management-icon {
+  display: grid !important;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--action) 34%, var(--line));
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--action) 12%, var(--lift));
+  color: var(--action) !important;
+  box-shadow: inset 0 1px color-mix(in srgb, #fff 25%, transparent);
+}
+
+.bn-ssh-management-icon svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.75;
+}
+
+.bn-ssh-private-badge,
+.bn-ssh-verified-badge {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 7px;
+  border: 1px solid color-mix(in srgb, var(--action) 28%, var(--line));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--action) 8%, var(--panel));
+  color: color-mix(in srgb, var(--action) 66%, var(--tx2)) !important;
+  font-size: 11px !important;
+  font-weight: 700;
+  letter-spacing: .01em;
+  white-space: nowrap;
+}
+
+.bn-ssh-private-badge svg {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.35;
+}
+
+.bn-ssh-management-progress {
+  display: grid;
+  grid-template-columns: auto minmax(24px, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 0 2px;
+}
+
+.bn-ssh-management-progress > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.bn-ssh-management-progress > span i {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  border: 1px solid var(--line2);
+  border-radius: 50%;
+  background: var(--lift);
+  color: var(--tx3);
+  font-size: 11px;
+  font-style: normal;
+}
+
+.bn-ssh-management-progress > span.is-active {
+  color: var(--tx1);
+}
+
+.bn-ssh-management-progress > span.is-active i {
+  border-color: var(--action);
+  background: color-mix(in srgb, var(--action) 13%, var(--lift));
+  color: color-mix(in srgb, var(--action) 72%, var(--tx1));
+}
+
+.bn-ssh-management-progress > b {
+  height: 1px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--action) 54%, var(--line)), var(--line));
+}
+
+.bn-ssh-runtime-target {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 11px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--bg) 42%, var(--panel));
+}
+
+.bn-ssh-runtime-target > div {
+  min-width: 0;
+}
+
+.bn-ssh-runtime-target > div > span,
+.bn-ssh-runtime-target code {
+  display: block;
+}
+
+.bn-ssh-runtime-target > div > span {
+  margin-bottom: 2px;
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: .045em;
+  text-transform: uppercase;
+}
+
+.bn-ssh-runtime-target code {
+  overflow: hidden;
+  color: var(--tx2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-ssh-identity-state {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.bn-ssh-identity-state i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--warn);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--warn) 12%, transparent);
+}
+
+.bn-ssh-identity-state.is-known {
+  color: color-mix(in srgb, var(--action) 62%, var(--tx2));
+}
+
+.bn-ssh-identity-state.is-known i {
+  background: var(--action);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--action) 12%, transparent);
+}
+
+.bn-ssh-management-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 112px;
+  gap: 10px;
+}
+
+.bn-ssh-management-fields.is-auth {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.bn-ssh-management-form label {
+  min-width: 0;
+}
+
+.bn-ssh-management-form label > span {
+  color: var(--tx2);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.bn-ssh-management-form label > small {
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.bn-ssh-management-form input {
+  width: 100%;
+  min-height: 36px;
+  padding: 7px 9px;
+  border: 1px solid var(--line2);
+  border-radius: 6px;
+  outline: none;
+  background: color-mix(in srgb, var(--lift) 76%, var(--panel));
+  color: var(--tx1);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  box-shadow: inset 0 1px 2px color-mix(in srgb, var(--bg) 20%, transparent);
+  transition: border-color .12s ease, box-shadow .12s ease, background .12s ease;
+}
+
+.bn-ssh-management-form input:hover {
+  border-color: color-mix(in srgb, var(--tx2) 48%, var(--line2));
+}
+
+.bn-ssh-management-form input:focus {
+  border-color: var(--action);
+  background: var(--panel);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--action) 13%, transparent),
+    inset 0 1px 2px color-mix(in srgb, var(--bg) 16%, transparent);
+}
+
+.bn-ssh-management-form input::placeholder {
+  color: color-mix(in srgb, var(--tx3) 72%, transparent);
+}
+
+.bn-device-fingerprint.bn-ssh-host-card {
+  gap: 7px;
+  padding: 11px;
+  border-color: color-mix(in srgb, var(--action) 42%, var(--line2));
+  background: color-mix(in srgb, var(--action) 8%, var(--panel));
+}
+
+.bn-ssh-host-card > div {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.bn-ssh-host-card > span {
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-ssh-host-card code {
+  padding: 7px 8px;
+  border: 1px solid color-mix(in srgb, var(--action) 20%, var(--line));
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--bg) 42%, var(--panel));
+  color: color-mix(in srgb, var(--action) 72%, var(--tx1));
+}
+
+.bn-ssh-host-check {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--action) 16%, var(--lift));
+  color: var(--action);
+}
+
+.bn-ssh-host-check svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.bn-ssh-host-card > div > div {
+  min-width: 0;
+}
+
+.bn-ssh-host-card > div p {
+  margin: 1px 0 0;
+}
+
+.bn-ssh-management-actions {
+  align-items: center;
+  padding-top: 2px;
+  border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+}
+
+.bn-ssh-management-actions button {
+  min-height: 34px;
+  padding-inline: 12px !important;
+}
+
+.bn-ssh-cancel-button {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--tx3);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 12px;
+}
+
+.bn-ssh-cancel-button:hover:not(:disabled) {
+  border-color: var(--line2);
+  background: var(--hover);
+  color: var(--tx1);
+}
+
+.bn-ssh-submit-button {
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--action) 24%, transparent);
+}
+
 .bn-runtime-uninstall label {
   display: flex;
   flex-direction: column;
@@ -1357,13 +1739,29 @@ button.bn-compute-device-card:active:not(:disabled) {
 
 .bn-compute-device-detail {
   flex: 0 0 auto;
-  margin: 0 12px 12px;
-  border: 1px solid var(--line);
+  margin: 12px;
+  border: 1px solid #737373;
   border-radius: 7px;
   background: var(--lift);
 }
 
-.bn-compute-device-detail-head,
+.bn-compute-device-detail-nav {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  padding: 7px 10px;
+  border-bottom: 1px solid color-mix(in srgb, #00d2ff 42%, var(--line));
+}
+
+.bn-compute-device-detail-head {
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
 .bn-compute-robots-head {
   display: flex;
   align-items: center;
@@ -1372,47 +1770,59 @@ button.bn-compute-device-card:active:not(:disabled) {
   padding: 10px;
 }
 
-.bn-compute-device-detail-head {
-  border-bottom: 1px solid var(--line);
-}
-
 .bn-device-back-button {
   display: inline-flex;
-  min-height: 34px;
+  width: max-content;
+  max-width: 100%;
+  min-height: 32px;
+  flex: 0 0 auto;
   align-items: center;
-  gap: 7px;
-  margin: 0 0 12px;
-  padding: 0 11px;
-  border: 1px solid var(--line2);
+  gap: 6px;
+  margin: 0;
+  padding: 0 10px 0 7px;
+  border: 1px solid #737373;
   border-radius: 6px;
-  background: var(--panel);
+  background: var(--lift);
   color: var(--tx1);
   cursor: pointer;
   font-family: var(--font-ui);
-  font-size: 13px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1;
+  white-space: nowrap;
   box-shadow: 0 1px 2px color-mix(in srgb, var(--bg) 28%, transparent);
-  transition: border-color .12s ease, background .12s ease;
+  transition: border-color .12s ease, background .12s ease, box-shadow .12s ease;
 }
 
 .bn-device-back-button:hover {
-  border-color: var(--accent);
-  background: var(--hover);
+  border-color: #00d2ff;
+  background: color-mix(in srgb, #00d2ff 11%, var(--lift));
+  box-shadow: 0 0 0 1px color-mix(in srgb, #00d2ff 20%, transparent);
 }
 
-.bn-compute-device-detail-head .bn-device-back-button > span {
+.bn-device-back-icon {
   display: grid;
-  width: 24px;
-  height: 24px;
-  flex: 0 0 24px;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
   place-items: center;
-  color: var(--accent);
+  color: #00d2ff;
+}
+
+.bn-device-back-label {
+  display: inline-flex;
+  height: 18px;
+  flex: 0 0 auto;
+  align-items: center;
+  line-height: 18px;
+  transform: translateY(1px);
+  white-space: nowrap;
 }
 
 .bn-device-back-icon svg {
   display: block;
-  width: 22px;
-  height: 22px;
+  width: 18px;
+  height: 18px;
 }
 
 .bn-device-back-icon path {
@@ -1424,8 +1834,12 @@ button.bn-compute-device-card:active:not(:disabled) {
 }
 
 .bn-device-back-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline: 2px solid color-mix(in srgb, #00d2ff 55%, transparent);
   outline-offset: 3px;
+}
+
+.bn-compute-device-detail-head .bn-run-detail-actions {
+  justify-content: flex-start;
 }
 
 .bn-runtime-check-button {
@@ -1460,6 +1874,91 @@ button.bn-compute-device-card:active:not(:disabled) {
 
 .bn-runtime-check-button:disabled {
   opacity: .8;
+}
+
+.bn-device-action-button {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--line2);
+  border-radius: 5px;
+  background: var(--lift);
+  color: var(--tx2);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-align: center;
+  transition:
+    color .12s ease,
+    border-color .12s ease,
+    background .12s ease,
+    box-shadow .12s ease,
+    transform .08s ease;
+}
+
+.bn-device-action-button:hover:not(:disabled) {
+  border-color: #00d2ff;
+  background: color-mix(in srgb, #00d2ff 10%, var(--lift));
+  color: var(--tx1);
+  box-shadow: 0 0 0 1px color-mix(in srgb, #00d2ff 16%, transparent);
+  transform: translateY(-1px);
+}
+
+.bn-device-action-button:active:not(:disabled) {
+  box-shadow: none;
+  transform: translateY(0);
+}
+
+.bn-device-action-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, #00d2ff 58%, transparent);
+  outline-offset: 2px;
+}
+
+.bn-device-action-button:disabled {
+  cursor: default;
+  opacity: .45;
+  transform: none;
+}
+
+.bn-device-action-button.is-primary {
+  border-color: var(--action);
+  background: var(--action);
+  color: var(--action-ink);
+  font-weight: 750;
+}
+
+.bn-device-action-button.is-primary:hover:not(:disabled) {
+  border-color: #00d2ff;
+  background: color-mix(in srgb, var(--action) 84%, #00d2ff);
+  color: var(--action-ink);
+}
+
+.bn-device-action-button.is-danger {
+  border-color: color-mix(in srgb, var(--err) 72%, var(--line2));
+  background: color-mix(in srgb, var(--err) 5%, var(--lift));
+  color: var(--err);
+}
+
+.bn-device-action-button.is-danger:hover:not(:disabled) {
+  border-color: var(--err);
+  background: color-mix(in srgb, var(--err) 13%, var(--lift));
+  color: var(--err);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--err) 16%, transparent);
+}
+
+.bn-device-header-actions {
+  width: 100%;
+  align-items: stretch;
+}
+
+.bn-device-header-actions .bn-device-action-button {
+  min-width: 0;
+  flex: 1 1 120px;
 }
 
 .bn-runtime-check-result {
@@ -1518,6 +2017,290 @@ button.bn-compute-device-card:active:not(:disabled) {
   color: var(--tx3);
   font-size: 11px;
   line-height: 1.4;
+}
+
+.bn-device-update-form {
+  border-color: color-mix(in srgb, #00d2ff 45%, var(--line2));
+}
+
+.bn-device-update-password {
+  gap: 7px !important;
+  padding: 10px;
+  border: 1px solid #737373;
+  border-radius: 7px;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, #00d2ff 7%, var(--lift)),
+      var(--lift) 58%
+    );
+}
+
+.bn-device-update-password > span {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.bn-device-update-password > span strong {
+  color: var(--tx1);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.bn-device-update-password > span small {
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 400;
+  text-align: right;
+}
+
+.bn-device-update-password input {
+  width: 100%;
+  min-height: 38px;
+  box-sizing: border-box;
+  padding: 8px 11px;
+  border: 1px solid #737373;
+  border-radius: 6px;
+  outline: none;
+  background: var(--surface);
+  color: var(--tx1);
+  caret-color: #00d2ff;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  transition:
+    border-color .14s ease,
+    box-shadow .14s ease,
+    background .14s ease;
+}
+
+.bn-device-update-password input::placeholder {
+  color: var(--tx3);
+  opacity: .78;
+}
+
+.bn-device-update-password input:hover {
+  border-color: #00d2ff;
+}
+
+.bn-device-update-password input:focus {
+  border-color: #00d2ff;
+  background: var(--lift);
+  box-shadow: 0 0 0 3px color-mix(in srgb, #00d2ff 18%, transparent);
+}
+
+.bn-device-update-password input:-webkit-autofill,
+.bn-device-update-password input:-webkit-autofill:hover,
+.bn-device-update-password input:-webkit-autofill:focus {
+  -webkit-text-fill-color: var(--tx1);
+  caret-color: #00d2ff;
+  box-shadow: 0 0 0 1000px var(--surface) inset;
+}
+
+.bn-device-update-caution {
+  grid-column: 1 / -1;
+  padding: 9px 11px;
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--line2));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--warn) 7%, var(--lift));
+  color: var(--tx2);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.bn-device-update-report {
+  display: grid;
+  min-width: 0;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid #737373;
+  border-radius: 7px;
+  background: var(--surface);
+}
+
+.bn-device-update-report-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.bn-device-update-report-head > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.bn-device-update-report-head strong {
+  color: var(--tx1);
+  font-size: 13px;
+}
+
+.bn-device-update-report-head span {
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.bn-device-update-report-head > span {
+  flex: 0 0 auto;
+  padding: 3px 7px;
+  border: 1px solid var(--line2);
+  border-radius: 999px;
+  background: var(--lift);
+}
+
+.bn-device-update-components {
+  display: grid;
+  gap: 7px;
+}
+
+.bn-device-update-component {
+  display: grid;
+  min-width: 0;
+  grid-template-areas:
+    "identity version actions";
+  grid-template-columns: minmax(0, 1fr) minmax(0, .9fr) minmax(126px, auto);
+  align-items: center;
+  gap: 8px 16px;
+  padding: 10px 11px;
+  border: 1px solid var(--line2);
+  border-radius: 6px;
+  background: var(--lift);
+}
+
+.bn-device-update-component > div:first-child,
+.bn-device-update-version {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.bn-device-update-component > div:first-child {
+  grid-area: identity;
+}
+
+.bn-device-update-version {
+  grid-area: version;
+}
+
+.bn-device-update-component strong {
+  color: var(--tx1);
+  font-size: 12px;
+}
+
+.bn-device-update-component code {
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.bn-device-update-version > span,
+.bn-device-update-component > small {
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-device-update-version > strong {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+  overflow-wrap: anywhere;
+}
+
+.bn-device-update-version i {
+  color: #00d2ff;
+  font-style: normal;
+}
+
+.bn-device-update-version.is-result > strong > span:first-child:not(.is-current) {
+  color: var(--tx3);
+  font-weight: 500;
+}
+
+.bn-device-update-version.is-result .is-current {
+  color: #00d2ff;
+}
+
+.bn-device-update-version.is-result code b {
+  color: var(--tx2);
+  font-weight: 500;
+}
+
+.bn-device-update-component > small > strong {
+  color: var(--tx2);
+  font-size: inherit;
+}
+
+.bn-device-update-state {
+  justify-self: end;
+  padding: 3px 7px;
+  border: 1px solid var(--line2);
+  border-radius: 999px;
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+
+.bn-device-update-state.is-changed {
+  border-color: color-mix(in srgb, #00d2ff 55%, var(--line2));
+  color: #00d2ff;
+}
+
+.bn-device-update-state.is-blocked {
+  border-color: color-mix(in srgb, var(--warn) 60%, var(--line2));
+  color: var(--warn);
+}
+
+.bn-device-update-row-actions {
+  display: grid;
+  min-width: 0;
+  grid-area: actions;
+  justify-items: end;
+  gap: 7px;
+}
+
+.bn-device-update-row-actions .bn-device-action-button {
+  min-width: 118px;
+  max-width: 100%;
+  white-space: normal;
+}
+
+.bn-device-update-component > small {
+  grid-column: 1 / -1;
+}
+
+.bn-device-update-component > .bn-device-update-component-error {
+  color: var(--warn);
+}
+
+.bn-device-update-warnings {
+  display: grid;
+  gap: 4px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--warn) 50%, var(--line2));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--warn) 7%, var(--lift));
+}
+
+.bn-device-update-warnings span {
+  color: var(--tx2);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.bn-device-update-report-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 3px;
 }
 
 @keyframes bn-runtime-check-pulse {
@@ -1581,7 +2364,7 @@ button.bn-compute-device-card:active:not(:disabled) {
 .bn-device-robot-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
   padding: 0 10px 10px;
 }
 
@@ -1619,6 +2402,18 @@ button.bn-compute-device-card:active:not(:disabled) {
 .bn-card-list .bn-device-card {
   border-radius: 6px;
   box-shadow: none;
+}
+
+.bn-device-robot-list .bn-device-card {
+  overflow: hidden;
+  border: 1px solid #00d2ff;
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 0 0 1px color-mix(in srgb, #00d2ff 7%, transparent);
+}
+
+.bn-device-robot-list .bn-device-card.is-expanded {
+  box-shadow: 0 0 0 2px color-mix(in srgb, #00d2ff 14%, transparent);
 }
 
 .bn-device-card-summary:hover {
@@ -1687,6 +2482,240 @@ button.bn-compute-device-card:active:not(:disabled) {
 
 .bn-device-card-detail {
   padding: 10px;
+  border-top: 1px solid color-mix(in srgb, #00d2ff 38%, var(--line));
+}
+
+.bn-robot-card-actions {
+  width: 100%;
+  align-items: stretch;
+  justify-content: stretch;
+  gap: 7px;
+}
+
+.bn-robot-card-actions + .bn-robot-card-actions {
+  margin-top: 7px;
+  padding-top: 9px;
+  border-top: 1px solid var(--line);
+}
+
+.bn-robot-card-actions button {
+  min-width: 0;
+  min-height: 34px;
+  flex: 1 1 135px;
+  justify-content: center;
+  line-height: 1.25;
+  text-align: center;
+}
+
+.bn-robot-monitor {
+  margin-top: 10px;
+  overflow: hidden;
+  border: 1px solid #00d2ff;
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 0 0, color-mix(in srgb, #00d2ff 9%, transparent), transparent 38%),
+    color-mix(in srgb, var(--panel) 94%, #00151b);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, #00d2ff 14%, transparent);
+}
+
+.bn-robot-monitor-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid color-mix(in srgb, #00d2ff 30%, var(--line));
+}
+
+.bn-robot-monitor-head > div:first-child {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+
+.bn-robot-monitor-head strong,
+.bn-robot-monitor-head span {
+  display: block;
+}
+
+.bn-robot-monitor-head strong {
+  color: var(--tx1);
+  font-size: 13px;
+}
+
+.bn-robot-monitor-head > div:first-child div > span {
+  margin-top: 2px;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.bn-robot-monitor-pulse {
+  width: 9px;
+  height: 9px;
+  flex: 0 0 9px;
+  border-radius: 50%;
+  background: var(--tx3);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--tx3) 12%, transparent);
+}
+
+.bn-robot-monitor-pulse.is-live {
+  background: #00d2ff;
+  box-shadow: 0 0 0 4px color-mix(in srgb, #00d2ff 15%, transparent);
+  animation: bn-monitor-pulse 1.7s ease-out infinite;
+}
+
+.bn-robot-monitor-pulse.is-stale,
+.bn-robot-monitor-pulse.is-waiting {
+  background: var(--warn);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--warn) 14%, transparent);
+}
+
+@keyframes bn-monitor-pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, #00d2ff 35%, transparent); }
+  70%, 100% { box-shadow: 0 0 0 7px transparent; }
+}
+
+.bn-robot-monitor-status {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.bn-robot-monitor-status > span {
+  padding: 3px 7px;
+  border: 1px solid #737373;
+  border-radius: 999px;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.bn-robot-monitor-status > span:first-child {
+  color: var(--warn);
+  font-weight: 800;
+  letter-spacing: .04em;
+}
+
+.bn-robot-monitor-status > span:first-child.is-live {
+  border-color: color-mix(in srgb, #00d2ff 75%, #737373);
+  color: #00d2ff;
+}
+
+.bn-robot-monitor-meta {
+  display: flex;
+  gap: 12px;
+  padding: 8px 12px 0;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.bn-robot-monitor-meta span + span::before {
+  margin-right: 12px;
+  color: #737373;
+  content: "·";
+}
+
+.bn-robot-monitor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+  padding: 9px 10px 10px;
+}
+
+.bn-joint-monitor-card {
+  min-width: 0;
+  padding: 9px;
+  border: 1px solid #737373;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--lift) 91%, transparent);
+}
+
+.bn-joint-monitor-title,
+.bn-joint-monitor-speed {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.bn-joint-monitor-title strong {
+  overflow: hidden;
+  color: var(--tx2);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+
+.bn-joint-monitor-title span,
+.bn-joint-monitor-speed strong {
+  color: #00d2ff;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.bn-joint-monitor-chart {
+  display: block;
+  width: 100%;
+  height: 44px;
+  margin: 7px 0 5px;
+  border-block: 1px solid color-mix(in srgb, #737373 42%, transparent);
+  background:
+    linear-gradient(to right, color-mix(in srgb, #737373 15%, transparent) 1px, transparent 1px) 0 0 / 25% 100%,
+    linear-gradient(to bottom, color-mix(in srgb, #737373 11%, transparent) 1px, transparent 1px) 0 0 / 100% 50%;
+}
+
+.bn-joint-monitor-chart line {
+  stroke: color-mix(in srgb, #737373 48%, transparent);
+  stroke-dasharray: 3 4;
+  stroke-width: 1;
+}
+
+.bn-joint-monitor-chart polyline {
+  fill: none;
+  stroke: #00d2ff;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+  vector-effect: non-scaling-stroke;
+}
+
+.bn-joint-monitor-speed span {
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-joint-monitor-speed strong {
+  color: var(--tx2);
+  font-weight: 600;
+}
+
+.bn-robot-monitor-empty {
+  padding: 18px 14px;
+  text-align: center;
+}
+
+.bn-robot-monitor-empty strong,
+.bn-robot-monitor-empty span {
+  display: block;
+}
+
+.bn-robot-monitor-empty strong {
+  color: var(--tx2);
+  font-size: 12px;
+}
+
+.bn-robot-monitor-empty span {
+  max-width: 560px;
+  margin: 5px auto 0;
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.45;
 }
 
 .bn-device-card-addresses {
@@ -1791,6 +2820,46 @@ button.bn-compute-device-card:active:not(:disabled) {
   border-radius: 4px;
 }
 
+button.bn-device-fact {
+  width: 100%;
+  appearance: none;
+  color: inherit;
+  font-family: inherit;
+  text-align: left;
+}
+
+.bn-device-fact.is-interactive {
+  cursor: pointer;
+  transition: border-color .12s ease, background .12s ease;
+}
+
+.bn-device-fact.is-interactive:hover,
+.bn-device-fact.is-interactive:focus-visible {
+  border-color: #00d2ff;
+  background: color-mix(in srgb, #00d2ff 6%, var(--panel));
+  outline: none;
+}
+
+.bn-device-fact.is-interactive > span {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 5px;
+}
+
+.bn-device-fact.is-interactive i {
+  color: #00d2ff;
+  font-size: 16px;
+  font-style: normal;
+  line-height: .7;
+  transform: rotate(90deg);
+  transition: transform .12s ease;
+}
+
+.bn-device-fact.is-interactive[aria-expanded="true"] i {
+  transform: rotate(-90deg);
+}
+
 .bn-device-fact span,
 .bn-device-fact strong {
   display: block;
@@ -1812,6 +2881,25 @@ button.bn-compute-device-card:active:not(:disabled) {
   white-space: nowrap;
 }
 
+@container devices-panel (max-width: 700px) {
+  .bn-device-update-component {
+    grid-template-areas:
+      "identity actions"
+      "version actions";
+    grid-template-columns: minmax(0, 1fr) minmax(136px, auto);
+    align-items: start;
+  }
+
+  .bn-device-update-row-actions {
+    align-self: stretch;
+    align-content: center;
+  }
+
+  .bn-device-update-component > small {
+    grid-column: 1 / -1;
+  }
+}
+
 @container devices-panel (max-width: 430px) {
   .bn-devices-panel > .bn-runs-toolbar {
     align-items: stretch;
@@ -1824,7 +2912,7 @@ button.bn-compute-device-card:active:not(:disabled) {
   }
 
   .bn-devices-panel > .bn-runs-toolbar .bn-runs-actions button,
-  .bn-devices-panel .bn-run-detail-actions button,
+  .bn-devices-panel .bn-run-detail-actions:not(.bn-robot-card-actions) button,
   .bn-device-form-actions button {
     flex: 1 1 auto;
     min-height: 30px;
@@ -1848,14 +2936,45 @@ button.bn-compute-device-card:active:not(:disabled) {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .bn-robot-monitor-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .bn-robot-monitor-grid {
+    grid-template-columns: 1fr;
+  }
+
   .bn-host-environment-grid {
     grid-template-columns: 1fr;
   }
 
-  .bn-compute-device-detail-head,
   .bn-compute-robots-head {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .bn-runtime-uninstall.bn-ssh-management-form {
+    margin-inline: 10px;
+    padding: 13px;
+  }
+
+  .bn-runtime-uninstall > div:first-child.bn-ssh-management-head {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .bn-ssh-private-badge {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .bn-ssh-runtime-target {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .bn-ssh-management-fields {
+    grid-template-columns: minmax(0, 1fr) 88px;
   }
 
   .bn-devices-panel .bn-device-card-detail {
@@ -1874,6 +2993,42 @@ button.bn-compute-device-card:active:not(:disabled) {
 
   .bn-device-continue button {
     align-self: flex-start;
+  }
+
+  .bn-device-update-report-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .bn-device-update-report-head > span {
+    align-self: flex-start;
+  }
+
+  .bn-device-update-component {
+    grid-template-areas:
+      "identity"
+      "version"
+      "actions";
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .bn-device-update-version {
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .bn-device-update-row-actions {
+    width: 100%;
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: stretch;
+  }
+
+  .bn-device-update-state {
+    justify-self: start;
+  }
+
+  .bn-device-update-row-actions .bn-device-action-button {
+    width: 100%;
   }
 
   .bn-devices-panel .bn-device-runtime-reuse button {
@@ -1900,6 +3055,25 @@ button.bn-compute-device-card:active:not(:disabled) {
     grid-template-columns: 1fr;
   }
 
+  .bn-ssh-management-fields,
+  .bn-ssh-management-fields.is-auth {
+    grid-template-columns: 1fr;
+  }
+
+  .bn-ssh-management-progress > span {
+    gap: 4px;
+    font-size: 11px;
+  }
+
+  .bn-ssh-host-card > div {
+    grid-template-columns: 24px minmax(0, 1fr);
+  }
+
+  .bn-ssh-verified-badge {
+    grid-column: 2;
+    justify-self: start;
+  }
+
   .bn-device-card-summary {
     grid-template-columns: 9px minmax(0, 1fr) 12px;
   }
@@ -1910,9 +3084,59 @@ button.bn-compute-device-card:active:not(:disabled) {
 }
 
 .bn-deploy-target {
-  padding: 10px 12px;
+  padding: 14px 12px;
   border-bottom: 1px solid var(--line);
   background: var(--lift);
+}
+
+.bn-deploy-nav {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 42px;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid color-mix(in srgb, #00d2ff 42%, var(--line));
+  background: var(--panel);
+}
+
+.bn-deploy-nav-button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  min-width: max-content;
+  min-height: 28px;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid color-mix(in srgb, #00d2ff 38%, transparent);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--tx2);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.bn-deploy-nav-button:hover {
+  border-color: #00d2ff;
+  background: var(--hover);
+  color: var(--tx1);
+}
+
+.bn-deploy-nav-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline-offset: 1px;
+}
+
+.bn-deploy-refresh {
+  margin-left: auto;
 }
 
 .bn-deploy-target-head {
@@ -1926,6 +3150,95 @@ button.bn-compute-device-card:active:not(:disabled) {
   color: var(--tx1);
   font-size: 13px;
   font-weight: 650;
+}
+
+.bn-deploy-target-copy {
+  margin-top: 3px;
+  color: var(--tx3);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.bn-deploy-route {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 10px;
+  border: 1px solid #00d2ff;
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 0 0 1px color-mix(in srgb, #00d2ff 8%, transparent);
+}
+
+.bn-deploy-route article {
+  min-width: 0;
+}
+
+.bn-deploy-route article > span,
+.bn-deploy-route article > strong,
+.bn-deploy-route article > small {
+  display: block;
+}
+
+.bn-deploy-route article > span {
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.bn-deploy-route article > strong {
+  overflow: hidden;
+  margin-top: 2px;
+  color: var(--tx1);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-deploy-route article > small {
+  overflow: hidden;
+  margin-top: 1px;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-deploy-route > i {
+  color: color-mix(in srgb, var(--action) 66%, var(--tx3));
+  font-size: 14px;
+  font-style: normal;
+  text-align: center;
+}
+
+.bn-deploy-target-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 10px;
+}
+
+.bn-deploy-target-picker > span {
+  color: var(--tx2);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.bn-deploy-target-picker > small {
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.bn-deploy-target-picker .bn-deploy-device-select {
+  margin-top: 0;
 }
 
 .bn-deploy-device-select {
@@ -2385,7 +3698,7 @@ button.bn-compute-device-card:active:not(:disabled) {
 .bn-robot-step-actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   flex-wrap: wrap;
   gap: 6px;
   margin-top: 8px;
@@ -2473,27 +3786,29 @@ button.bn-compute-device-card:active:not(:disabled) {
   white-space: normal;
 }
 
-@container deployment-panel (max-width: 620px) {
-  .bn-deploy-target-head,
-  .bn-deploy-panel > .bn-runs-toolbar {
-    align-items: stretch;
-    flex-direction: column;
+@container deployment-panel (min-width: 621px) {
+  .bn-deploy-target {
+    padding: 18px 24px 20px;
   }
 
-  .bn-deploy-target-head .bn-runs-actions,
-  .bn-deploy-panel > .bn-runs-toolbar .bn-runs-actions {
-    justify-content: flex-start;
+  .bn-deploy-target > .bn-deploy-target-head,
+  .bn-deploy-target > .bn-deploy-route,
+  .bn-deploy-target > .bn-deploy-target-picker,
+  .bn-deploy-target > .bn-device-help,
+  .bn-deploy-target > .bn-robot-step-status,
+  .bn-deploy-target > .bn-robot-deploy-steps {
+    max-width: 680px;
+    margin-left: auto;
+    margin-right: auto;
   }
 
-  .bn-deploy-panel .bn-robot-step-actions {
-    align-items: stretch;
-    justify-content: flex-start;
+  .bn-robot-deploy-step {
+    padding: 14px;
   }
 
-  .bn-deploy-panel .bn-robot-step-actions button,
-  .bn-deploy-panel > .bn-runs-toolbar .bn-runs-actions button {
-    flex: 1 1 130px;
-    min-height: 32px;
+  .bn-deployment-section-head {
+    padding-right: 24px;
+    padding-left: 24px;
   }
 }
 
@@ -2513,8 +3828,7 @@ button.bn-compute-device-card:active:not(:disabled) {
     white-space: normal;
   }
 
-  .bn-deploy-panel .bn-robot-step-actions button,
-  .bn-deploy-panel > .bn-runs-toolbar .bn-runs-actions button {
+  .bn-deploy-panel .bn-robot-step-actions button {
     flex-basis: 100%;
     width: 100%;
   }
@@ -2551,13 +3865,13 @@ button.bn-compute-device-card:active:not(:disabled) {
   gap: 3px;
   margin-top: 8px;
   padding: 9px 10px;
-  border: 1px solid color-mix(in srgb, var(--ok) 44%, var(--line2));
+  border: 1px solid var(--line2);
   border-radius: 6px;
-  background: color-mix(in srgb, var(--ok) 8%, transparent);
+  background: var(--lift);
 }
 
 .bn-device-lease-notice strong {
-  color: var(--ok);
+  color: var(--tx2);
   font-size: 12px;
 }
 
@@ -2566,6 +3880,71 @@ button.bn-compute-device-card:active:not(:disabled) {
   font-size: 12px;
   line-height: 1.45;
   overflow-wrap: anywhere;
+}
+
+.bn-device-lease-notice.is-active {
+  border-color: color-mix(in srgb, var(--ok) 44%, var(--line2));
+  background: color-mix(in srgb, var(--ok) 8%, transparent);
+}
+
+.bn-device-lease-notice.is-active strong {
+  color: var(--ok);
+}
+
+.bn-device-lease-notice.is-running {
+  border-color: color-mix(in srgb, #00d2ff 44%, var(--line2));
+  background: color-mix(in srgb, #00d2ff 7%, transparent);
+}
+
+.bn-device-lease-notice.is-running strong {
+  color: #00d2ff;
+}
+
+.bn-device-lease-notice.is-stored {
+  border-color: color-mix(in srgb, #00d2ff 34%, var(--line2));
+  background: color-mix(in srgb, #00d2ff 5%, transparent);
+}
+
+.bn-device-lease-notice.is-stored strong {
+  color: color-mix(in srgb, #00d2ff 76%, var(--tx2));
+}
+
+.bn-device-torque-warning {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--warn) 58%, var(--line2));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--warn) 7%, var(--lift));
+}
+
+.bn-device-torque-warning > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.bn-device-torque-warning strong {
+  color: var(--warn);
+  font-size: 12px;
+}
+
+.bn-device-torque-warning span {
+  color: var(--tx2);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.bn-device-torque-warning button {
+  flex: 0 0 auto;
+}
+
+.bn-device-torque-warning.is-unknown {
+  border-color: color-mix(in srgb, var(--warn) 42%, var(--line2));
+  background: color-mix(in srgb, var(--warn) 5%, var(--lift));
 }
 
 .bn-device-runtime-reuse {

--- a/editor/vite.config.ts
+++ b/editor/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       '/api': {
         target: 'http://127.0.0.1:7777',
         changeOrigin: true,
+        ws: true,
         rewrite: path => path.replace(/^\/api/, ''),
       },
     },

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import io
 import json
 import subprocess
@@ -47,6 +48,7 @@ class _HardwareService:
         *,
         status_overrides: dict | None = None,
         runtime_features: list[str] | None = None,
+        torque_readback_available: bool = True,
     ) -> None:
         self.token = token
         self.requests: list[tuple[str, str, str | None, dict | None]] = []
@@ -64,6 +66,7 @@ class _HardwareService:
             **(status_overrides or {}),
         }
         self.runtime_deployments: dict[str, dict] = {}
+        self.runtime_telemetry: dict[str, dict] = {}
         self.runtime_packages = [
             {"name": "blacknode-runtime", "version": "0.2.0"},
         ]
@@ -77,6 +80,7 @@ class _HardwareService:
             "component_sync_v1",
             "deployment_ownership_v1",
         ]
+        self.torque_readback_available = torque_readback_available
 
     def __call__(self, request, timeout=0):
         del timeout
@@ -209,6 +213,14 @@ class _HardwareService:
             action = parts[2] if len(parts) > 2 else ""
             if request.method == "GET" and action == "logs":
                 return _JsonResponse({"id": deployment_id, "logs": "remote output\n"})
+            if request.method == "GET" and action == "telemetry":
+                return _JsonResponse(self.runtime_telemetry.get(deployment_id, {
+                    "available": False,
+                    "deployment_id": deployment_id,
+                    "stream": "robot-state",
+                    "stale": True,
+                    "message": "Waiting for telemetry.",
+                }))
             if request.method == "GET" and not action:
                 return _JsonResponse(record)
             if request.method == "DELETE" and not action:
@@ -241,6 +253,16 @@ class _HardwareService:
                 self.status_payload["error"] = (
                     "serial hardware is leased to a Blacknode deployment"
                 )
+            elif method == "disable_torque":
+                self.status_payload["armed"] = False
+                if self.torque_readback_available:
+                    self.status_payload["torque_enabled"] = False
+                else:
+                    self.status_payload["torque_enabled"] = None
+                    self.status_payload["torque_report_error"] = (
+                        "Could not read the physical torque-enable register for "
+                        "servo_2 (servo 2)."
+                    )
             return _JsonResponse({
                 "jsonrpc": "2.0",
                 "id": body.get("id"),
@@ -497,6 +519,170 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn("systemctl list-unit-files 'blacknode-hardware*.service'", uploaded[0])
         self.assertIn('systemctl restart "$service_name"', uploaded[0])
         self.assertNotIn("ssh-password", uploaded[0])
+
+    def test_managed_update_uses_trusted_clean_checkouts_and_returns_versions(self):
+        uploaded = []
+
+        class RemoteFile(io.StringIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                uploaded.append(self.getvalue())
+                self.close()
+                return False
+
+        class Sftp:
+            def file(self, _path, _mode):
+                return RemoteFile()
+
+            def chmod(self, _path, _mode):
+                return None
+
+            def close(self):
+                return None
+
+        connection = SimpleNamespace(
+            client=SimpleNamespace(open_sftp=lambda: Sftp()),
+            fingerprint="SHA256:trusted-device-key",
+            close=lambda: None,
+        )
+        commands = []
+        remote_report = {
+            "ok": True,
+            "components": [{
+                "kind": "runtime",
+                "service_name": "blacknode-runtime.service",
+                "port": 8766,
+                "before": {"version": "0.3.8", "commit": "111111111111"},
+                "after": {"version": "0.3.9", "commit": "222222222222"},
+                "changed": True,
+                "state": "active",
+            }],
+        }
+
+        def fake_run(_connection, command, **kwargs):
+            commands.append(command)
+            if command.startswith("bash "):
+                kwargs["on_output"]("__BLACKNODE_UPDATE_PROGRESS__=55|Updating runtime")
+                return (
+                    "__BLACKNODE_UPDATE_REPORT__="
+                    + json.dumps(remote_report, separators=(",", ":"))
+                    + "\n"
+                )
+            return ""
+
+        progress = []
+        with (
+            patch.object(device_installer, "_connect", return_value=connection),
+            patch.object(device_installer, "_run", side_effect=fake_run),
+        ):
+            result = device_installer.update_managed_services(
+                host="192.168.1.87",
+                port=22,
+                username="robot",
+                password="ssh-password",
+                host_fingerprint="SHA256:trusted-device-key",
+                instance_id="default",
+                runtime_port=8766,
+                hardware_ports=[8767],
+                hardware_device_ids={8767: "follower-device"},
+                progress=progress.append,
+            )
+
+        self.assertEqual(result["components"][0]["after"]["version"], "0.3.9")
+        self.assertEqual(result["host_fingerprint"], "SHA256:trusted-device-key")
+        self.assertIn(" default 8766 ", commands[0])
+        targets = json.loads(base64.urlsafe_b64decode(
+            commands[0].split()[-1]
+        ).decode("utf-8"))
+        self.assertEqual(targets, [{
+            "port": 8767,
+            "device_id": "follower-device",
+        }])
+        self.assertIn("status --porcelain --untracked-files=normal", uploaded[0])
+        self.assertIn("merge --ff-only '@{upstream}'", uploaded[0])
+        self.assertIn("temiroff/{repository}", uploaded[0])
+        self.assertIn('sudo systemctl stop "$unit"', uploaded[0])
+        self.assertIn('progress 8 "Resolving selected managed services"', uploaded[0])
+        self.assertIn("./install-service.sh --all", uploaded[0])
+        self.assertIn('device["service_port"] = int(target["port"])', uploaded[0])
+        self.assertIn("stop_verified_manual_hardware", uploaded[0])
+        self.assertIn("Refusing to stop unverified process", uploaded[0])
+        self.assertIn('active_matches+=("$unit")', uploaded[0])
+        self.assertIn('enabled_matches+=("$unit")', uploaded[0])
+        self.assertIn('"/etc/systemd/system/$unit"', uploaded[0])
+        self.assertIn("Discovered units:", uploaded[0])
+        self.assertIn(
+            "Repair Hardware did not create exactly one persistent service",
+            uploaded[0],
+        )
+        self.assertNotIn("ssh-password", uploaded[0])
+        self.assertTrue(any(item["progress"] == 55 for item in progress))
+
+    def test_managed_update_check_compares_upstream_without_changing_source(self):
+        connection = SimpleNamespace(
+            fingerprint="SHA256:trusted-device-key",
+            close=lambda: None,
+        )
+        commands = []
+        report = {
+            "ok": True,
+            "components": [{
+                "kind": "runtime",
+                "service_name": "blacknode-runtime.service",
+                "port": 8766,
+                "installed": {"version": "0.3.8", "commit": "111111111111"},
+                "latest": {"version": "0.3.9", "commit": "222222222222"},
+                "update_available": True,
+                "can_update": True,
+                "dirty": False,
+                "state": "active",
+                "error": "",
+            }],
+        }
+
+        def fake_run(_connection, command, **_kwargs):
+            commands.append(command)
+            return (
+                "__BLACKNODE_UPDATE_CHECK__="
+                + json.dumps(report, separators=(",", ":"))
+                + "\n"
+            )
+
+        with (
+            patch.object(device_installer, "_connect", return_value=connection),
+            patch.object(device_installer, "_run", side_effect=fake_run),
+        ):
+            result = device_installer.inspect_managed_service_updates(
+                host="192.168.1.87",
+                port=22,
+                username="robot",
+                password="ssh-password",
+                host_fingerprint="SHA256:trusted-device-key",
+                instance_id="default",
+                runtime_port=8766,
+                hardware_ports=[8767],
+                hardware_device_ids={8767: "follower-device"},
+            )
+
+        self.assertTrue(result["components"][0]["update_available"])
+        self.assertIn('"git", "ls-remote"', commands[0])
+        self.assertIn("raw.githubusercontent.com", commands[0])
+        self.assertIn('"status", "--porcelain"', commands[0])
+        self.assertNotIn('"fetch"', commands[0])
+        self.assertNotIn('"merge"', commands[0])
+        self.assertIn('states[unit]["active"] == "active"', commands[0])
+        self.assertIn('unit_path.read_text(encoding="utf-8")', commands[0])
+        self.assertIn("Discovered units:", commands[0])
+        self.assertIn(
+            'component["latest"]["version"] = component["installed"]["version"]',
+            commands[0],
+        )
+        self.assertIn('"show",', commands[0])
+        self.assertIn("Repair Hardware will reconcile", commands[0])
+        remote_python = commands[0].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+        compile(remote_python, "<managed-update-check>", "exec")
 
     def test_workflow_requirements_are_normalized_and_exposed_by_graph(self):
         original_metadata = dict(server._session.metadata)
@@ -848,6 +1034,158 @@ class EditorDeviceApiTests(unittest.TestCase):
             host_fingerprint="SHA256:trusted-device-key",
         )
 
+    def test_manual_device_can_enable_ssh_management_after_pairing(self):
+        runtime = _HardwareService("runtime-token")
+        with patch("device_registry.urllib.request.urlopen", side_effect=runtime):
+            paired = self.client.post("/device-hosts", json={
+                "name": "Manually paired computer",
+                "runtime_url": "http://192.168.1.87:8766",
+                "runtime_token": runtime.token,
+            }).json()["device"]
+
+        inspection = {
+            "ok": True,
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "instances": [{
+                "instance_id": "default",
+                "runtime_dir": "/home/robot/blacknode-runtime",
+                "service_name": "blacknode-runtime.service",
+                "port": 8766,
+                "service_installed": True,
+                "running": True,
+                "healthy": True,
+                "device_id": "alex-desktop",
+            }],
+        }
+        with patch.object(
+            server,
+            "inspect_runtime",
+            return_value=inspection,
+        ) as inspect:
+            response = self.client.post(
+                f"/device-hosts/{paired['id']}/management",
+                json={
+                    "host": "192.168.1.87",
+                    "port": 22,
+                    "username": "robot",
+                    "password": "ssh-password",
+                    "host_fingerprint": "SHA256:trusted-device-key",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        managed = response.json()["device"]["managed_runtime"]
+        self.assertEqual(managed["instance_id"], "default")
+        self.assertEqual(managed["runtime_port"], 8766)
+        self.assertEqual(managed["service_name"], "blacknode-runtime.service")
+        self.assertEqual(managed["ssh_username"], "robot")
+        self.assertNotIn("ssh-password", response.text)
+        inspect.assert_called_once_with(
+            host="192.168.1.87",
+            port=22,
+            username="robot",
+            password="ssh-password",
+            host_fingerprint="SHA256:trusted-device-key",
+        )
+
+        saved = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        saved_host = saved["hosts"][paired["id"]]
+        self.assertEqual(
+            saved_host["managed_runtime"]["host_fingerprint"],
+            "SHA256:trusted-device-key",
+        )
+        self.assertNotIn("password", json.dumps(saved_host).lower())
+
+    def test_ssh_management_recovers_identity_for_a_legacy_paired_runtime(self):
+        runtime = _HardwareService("runtime-token")
+        with patch("device_registry.urllib.request.urlopen", side_effect=runtime):
+            paired = self.client.post("/device-hosts", json={
+                "name": "Legacy paired computer",
+                "runtime_url": "http://192.168.1.87:8766",
+                "runtime_token": runtime.token,
+            }).json()["device"]
+
+        saved = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        saved["hosts"][paired["id"]]["remote_device_id"] = ""
+        self.registry_path.write_text(json.dumps(saved), encoding="utf-8")
+        inspection = {
+            "ok": True,
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "instances": [{
+                "instance_id": "default",
+                "runtime_dir": "/home/robot/blacknode-runtime",
+                "service_name": "blacknode-runtime.service",
+                "port": 8766,
+                "service_installed": True,
+                "running": True,
+                "healthy": True,
+                "device_id": "alex-desktop",
+            }],
+        }
+
+        with (
+            patch.object(server, "inspect_runtime", return_value=inspection),
+            patch("device_registry.urllib.request.urlopen", side_effect=runtime),
+        ):
+            response = self.client.post(
+                f"/device-hosts/{paired['id']}/management",
+                json={
+                    "host": "192.168.1.87",
+                    "port": 22,
+                    "username": "robot",
+                    "password": "ssh-password",
+                    "host_fingerprint": "SHA256:trusted-device-key",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        updated = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            updated["hosts"][paired["id"]]["remote_device_id"],
+            "alex-desktop",
+        )
+
+    def test_ssh_management_rejects_a_different_runtime_identity(self):
+        runtime = _HardwareService("runtime-token")
+        with patch("device_registry.urllib.request.urlopen", side_effect=runtime):
+            paired = self.client.post("/device-hosts", json={
+                "name": "Manually paired computer",
+                "runtime_url": "http://192.168.1.87:8766",
+                "runtime_token": runtime.token,
+            }).json()["device"]
+
+        inspection = {
+            "ok": True,
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "instances": [{
+                "instance_id": "default",
+                "runtime_dir": "/home/robot/blacknode-runtime",
+                "service_name": "blacknode-runtime.service",
+                "port": 8766,
+                "service_installed": True,
+                "running": True,
+                "healthy": True,
+                "device_id": "different-computer",
+            }],
+        }
+        with patch.object(server, "inspect_runtime", return_value=inspection):
+            response = self.client.post(
+                f"/device-hosts/{paired['id']}/management",
+                json={
+                    "host": "192.168.1.99",
+                    "port": 22,
+                    "username": "robot",
+                    "password": "ssh-password",
+                    "host_fingerprint": "SHA256:trusted-device-key",
+                },
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("no installed Blacknode runtime service", response.text)
+        listed = self.client.get("/device-hosts").json()["devices"][0]
+        self.assertNotIn("managed_runtime", listed)
+        self.assertNotIn("ssh-password", response.text)
+
     def test_managed_runtime_uninstall_removes_only_selected_registry_tree(self):
         runtime = _HardwareService("generated-runtime-token")
         install_result = {
@@ -1040,10 +1378,90 @@ class EditorDeviceApiTests(unittest.TestCase):
 
         self.assertTrue(status.json()["connected"])
         self.assertEqual(rpc.json()["result"], {"ok": True})
-        self.assertEqual(hardware.requests[-2][1], "/status")
-        self.assertEqual(hardware.requests[-2][2], f"Bearer {hardware.token}")
-        self.assertEqual(hardware.requests[-1][1], "/rpc")
-        self.assertEqual(hardware.requests[-1][3]["method"], "stop")
+        status_requests = [
+            request for request in hardware.requests
+            if request[1] == "/status"
+        ]
+        rpc_requests = [
+            request for request in hardware.requests
+            if request[1] == "/rpc"
+        ]
+        self.assertTrue(status_requests)
+        self.assertEqual(status_requests[-1][2], f"Bearer {hardware.token}")
+        self.assertTrue(rpc_requests)
+        self.assertEqual(rpc_requests[-1][3]["method"], "stop")
+
+    def test_device_status_keeps_last_verified_hardware_version(self):
+        hardware = _HardwareService(status_overrides={
+            "software_version": "0.1.1",
+        })
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            self.assertEqual(paired["software_version"], "0.1.1")
+            hardware.status_payload.pop("software_version")
+            status = self.client.get(f"/devices/{paired['id']}/status")
+
+        self.assertEqual(status.status_code, 200)
+        self.assertEqual(status.json()["software_version"], "0.1.1")
+        self.assertTrue(status.json()["software_version_cached"])
+        saved = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            saved["devices"][paired["id"]]["software_version"],
+            "0.1.1",
+        )
+
+    def test_release_torque_requires_no_running_deployment_and_verifies_register_state(self):
+        hardware = _HardwareService(status_overrides={
+            "connected": True,
+            "armed": False,
+            "torque_enabled": True,
+        })
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            released = self.client.post(
+                f"/devices/{paired['id']}/release-torque",
+            )
+
+        self.assertEqual(released.status_code, 200)
+        self.assertFalse(released.json()["status"]["torque_enabled"])
+        rpc_methods = [
+            body["method"]
+            for method, path, _auth, body in hardware.requests
+            if method == "POST" and path == "/rpc"
+        ]
+        self.assertIn("disable_torque", rpc_methods)
+
+    def test_release_torque_reports_when_register_readback_is_unavailable(self):
+        hardware = _HardwareService(
+            status_overrides={
+                "connected": True,
+                "armed": False,
+                "torque_enabled": None,
+            },
+            torque_readback_available=False,
+        )
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            released = self.client.post(
+                f"/devices/{paired['id']}/release-torque",
+            )
+
+        self.assertEqual(released.status_code, 200)
+        payload = released.json()
+        self.assertIsNone(payload["status"]["torque_enabled"])
+        self.assertIn("servo_2", payload["verification_warning"])
 
     def test_managed_device_pause_stops_deployments_and_disarms_then_resumes(self):
         hardware = _HardwareService("hardware-token")
@@ -1244,6 +1662,284 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(events[-1]["type"], "done")
         self.assertTrue(events[-1]["result"]["device"]["paused"])
 
+    def test_managed_runtime_update_can_run_when_hardware_is_not_selected(self):
+        hardware = _HardwareService(status_overrides={
+            "software_version": "0.1.1",
+            "torque_enabled": False,
+        })
+        runtime = _HardwareService("runtime-token")
+        runtime.runtime_deployments["live"] = {
+            "id": "live",
+            "name": "Live workflow",
+            "state": "running",
+            "target_device_id": "alex-desktop",
+        }
+        host = server._device_registry.pair_host(
+            name="Robot computer",
+            runtime_url="http://192.168.1.87:8766",
+            runtime_token=runtime.token,
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "alex-desktop",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.1.87",
+                "ssh_port": 22,
+                "ssh_username": "robot",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "default",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime.service",
+                "runtime_dir": "~/blacknode-runtime",
+            },
+        )
+        server._device_registry.pair(
+            name="Follower",
+            base_url="http://192.168.1.87:8767",
+            token=hardware.token,
+            host_id=host["id"],
+            status=hardware.status_payload,
+        )
+
+        def route(request, timeout=0):
+            if urllib.parse.urlsplit(request.full_url).port == 8766:
+                return runtime(request, timeout)
+            return hardware(request, timeout)
+
+        update_result = {
+            "ok": True,
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "components": [
+                {
+                    "kind": "runtime",
+                    "service_name": "blacknode-runtime.service",
+                    "port": 8766,
+                    "before": {"version": "0.3.8", "commit": "111111111111"},
+                    "after": {"version": "0.3.9", "commit": "222222222222"},
+                    "changed": True,
+                    "state": "active",
+                },
+            ],
+        }
+        with (
+            patch("device_registry.urllib.request.urlopen", side_effect=route),
+            patch.object(
+                server,
+                "update_managed_services",
+                return_value=update_result,
+            ) as update,
+        ):
+            response = self.client.post(
+                f"/device-hosts/{host['id']}/update-stream",
+                json={"password": "ssh-password", "scope": "runtime"},
+            )
+
+        events = [json.loads(line) for line in response.text.splitlines() if line]
+        self.assertEqual(events[-1]["type"], "done")
+        result = events[-1]["result"]
+        self.assertEqual(
+            result["update"]["components"][0]["reported_version"],
+            "0.1.0",
+        )
+        self.assertEqual(result["scope"], "runtime")
+        self.assertEqual(runtime.runtime_deployments["live"]["state"], "stopped")
+        self.assertFalse(result["robots"][0]["status"]["armed"])
+        update.assert_called_once()
+        self.assertEqual(update.call_args.kwargs["hardware_ports"], [])
+        self.assertTrue(update.call_args.kwargs["include_runtime"])
+        self.assertNotIn("ssh-password", response.text)
+
+    def test_managed_runtime_update_falls_back_to_verified_ssh_when_api_times_out(self):
+        host = server._device_registry.pair_host(
+            name="Robot computer",
+            runtime_url="http://192.168.1.87:8766",
+            runtime_token="runtime-token",
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "alex-desktop",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.1.87",
+                "ssh_port": 22,
+                "ssh_username": "robot",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "default",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime.service",
+                "runtime_dir": "~/blacknode-runtime",
+            },
+        )
+
+        class _UnavailableRuntime:
+            def list_deployments(self):
+                raise device_registry.DeviceRegistryError(
+                    "Could not reach http://192.168.1.87:8766: timed out."
+                )
+
+            def manifest(self):
+                return {
+                    "service": "blacknode-runtime",
+                    "protocol_version": 1,
+                    "runtime_version": "0.3.9",
+                    "device_id": "alex-desktop",
+                }
+
+        update_result = {
+            "ok": True,
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "components": [
+                {
+                    "kind": "runtime",
+                    "service_name": "blacknode-runtime.service",
+                    "port": 8766,
+                    "before": {"version": "0.3.8", "commit": "111111111111"},
+                    "after": {"version": "0.3.9", "commit": "222222222222"},
+                    "changed": True,
+                    "state": "active",
+                },
+            ],
+        }
+        progress: list[dict] = []
+        with (
+            patch.object(
+                server._device_registry,
+                "host_client",
+                return_value=_UnavailableRuntime(),
+            ),
+            patch.object(server.time, "sleep"),
+            patch.object(
+                server,
+                "control_runtime",
+                return_value={
+                    "ok": True,
+                    "action": "pause",
+                    "state": "inactive",
+                    "service_name": "blacknode-runtime.service",
+                },
+            ) as control,
+            patch.object(
+                server,
+                "update_managed_services",
+                return_value=update_result,
+            ) as update,
+        ):
+            result = server._update_device_host_payload(
+                host["id"],
+                server.UpdateManagedDeviceReq(
+                    password="ssh-password",
+                    scope="runtime",
+                ),
+                progress.append,
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(len(result["warnings"]), 1)
+        self.assertIn("verified SSH service identity", result["warnings"][0])
+        control.assert_called_once()
+        self.assertEqual(control.call_args.kwargs["action"], "pause")
+        update.assert_called_once()
+        self.assertEqual(result["runtime"]["runtime_version"], "0.3.9")
+        self.assertEqual(progress[-1]["progress"], 100)
+
+    def test_managed_update_check_reports_installed_latest_and_live_versions(self):
+        hardware = _HardwareService(status_overrides={
+            "software_version": "0.1.0",
+        })
+        runtime = _HardwareService("runtime-token")
+        host = server._device_registry.pair_host(
+            name="Robot computer",
+            runtime_url="http://192.168.1.87:8766",
+            runtime_token=runtime.token,
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "alex-desktop",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.1.87",
+                "ssh_port": 22,
+                "ssh_username": "robot",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "default",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime.service",
+                "runtime_dir": "~/blacknode-runtime",
+            },
+        )
+        server._device_registry.pair(
+            name="Follower",
+            base_url="http://192.168.1.87:8767",
+            token=hardware.token,
+            host_id=host["id"],
+            status=hardware.status_payload,
+        )
+
+        def route(request, timeout=0):
+            if urllib.parse.urlsplit(request.full_url).port == 8766:
+                return runtime(request, timeout)
+            return hardware(request, timeout)
+
+        checked = {
+            "ok": True,
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "components": [
+                {
+                    "kind": "runtime",
+                    "service_name": "blacknode-runtime.service",
+                    "port": 8766,
+                    "installed": {"version": "0.3.8", "commit": "111111111111"},
+                    "latest": {"version": "0.3.9", "commit": "222222222222"},
+                    "update_available": True,
+                    "can_update": True,
+                    "dirty": False,
+                    "state": "active",
+                    "error": "",
+                },
+                {
+                    "kind": "hardware",
+                    "service_name": "blacknode-hardware-follower.service",
+                    "port": 8767,
+                    "installed": {"version": "0.1.0", "commit": "333333333333"},
+                    "latest": {"version": "0.1.0", "commit": "333333333333"},
+                    "update_available": False,
+                    "can_update": True,
+                    "dirty": False,
+                    "state": "active",
+                    "error": "",
+                },
+            ],
+        }
+        with (
+            patch("device_registry.urllib.request.urlopen", side_effect=route),
+            patch.object(
+                server,
+                "inspect_managed_service_updates",
+                return_value=checked,
+            ) as inspect,
+        ):
+            response = self.client.post(
+                f"/device-hosts/{host['id']}/update-check-stream",
+                json={"password": "ssh-password"},
+            )
+
+        events = [json.loads(line) for line in response.text.splitlines() if line]
+        result = events[-1]["result"]
+        self.assertEqual(events[-1]["type"], "done")
+        self.assertIn("1 of 2 services", result["summary"])
+        self.assertEqual(
+            result["check"]["components"][0]["reported_version"],
+            "0.1.0",
+        )
+        self.assertEqual(
+            result["check"]["components"][1]["reported_version"],
+            "0.1.0",
+        )
+        inspect.assert_called_once()
+        self.assertEqual(inspect.call_args.kwargs["hardware_ports"], [8767])
+        self.assertNotIn("ssh-password", response.text)
+
     def test_managed_robot_service_can_be_restarted_by_exact_hardware_port(self):
         hardware = _HardwareService()
         host = server._device_registry.pair_host(
@@ -1385,6 +2081,162 @@ class EditorDeviceApiTests(unittest.TestCase):
             if method == "POST" and path == "/rpc"
         ]
         self.assertNotIn("resume", rpc_methods)
+
+    def test_device_status_reports_running_monitor_without_motion_lease(self):
+        hardware = _HardwareService(status_overrides={
+            "connected": True,
+            "leased_to_deployment": False,
+        })
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Leader arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            hardware.runtime_deployments["leader-monitor"] = {
+                "id": "leader-monitor",
+                "name": "Leader monitor",
+                "state": "running",
+                "target_device_id": paired["id"],
+            }
+            response = self.client.get(f"/devices/{paired['id']}/status")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["running_deployment"], {
+            "id": "leader-monitor",
+            "name": "Leader monitor",
+            "state": "running",
+        })
+        self.assertNotIn("deployment_lease", payload)
+        self.assertIn("does not report that it owns motion control", payload["notice"])
+
+    def test_robot_monitor_uses_hardware_positions_while_idle(self):
+        hardware = _HardwareService(status_overrides={
+            "connected": True,
+            "positions": {
+                "shoulder": 12.5,
+                "elbow": -3.0,
+            },
+            "torque_enabled": False,
+        })
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Leader arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            response = self.client.get(f"/devices/{paired['id']}/monitor")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["source"], "hardware")
+        self.assertTrue(payload["available"])
+        self.assertEqual(payload["payload"]["joints"], [
+            {"name": "shoulder", "position": 12.5, "velocity": 0.0},
+            {"name": "elbow", "position": -3.0, "velocity": 0.0},
+        ])
+
+    def test_robot_monitor_switches_to_running_deployment_telemetry(self):
+        hardware = _HardwareService(status_overrides={
+            "connected": False,
+            "leased_to_deployment": True,
+            "error": "serial hardware is leased to a Blacknode deployment",
+        })
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Follower arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            hardware.runtime_deployments["follower-live"] = {
+                "id": "follower-live",
+                "name": "Follower live",
+                "state": "running",
+                "target_device_id": paired["id"],
+            }
+            hardware.runtime_telemetry["follower-live"] = {
+                "available": True,
+                "deployment_id": "follower-live",
+                "stream": "robot-state",
+                "sequence": 42,
+                "sent_at": "2026-07-25T12:00:00+00:00",
+                "received_at": "2026-07-25T12:00:00.010000+00:00",
+                "age_seconds": 0.01,
+                "stale": False,
+                "payload": {
+                    "connected": True,
+                    "torque_enabled": True,
+                    "position_unit": "degree",
+                    "velocity_unit": "degree/s",
+                    "joints": [{
+                        "name": "gripper",
+                        "position": 8.0,
+                        "velocity": 2.0,
+                    }],
+                },
+            }
+            response = self.client.get(f"/devices/{paired['id']}/monitor")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["source"], "deployment")
+        self.assertEqual(payload["source_label"], "Follower live")
+        self.assertTrue(payload["available"])
+        self.assertEqual(payload["sequence"], 42)
+        self.assertEqual(payload["payload"]["joints"][0]["velocity"], 2.0)
+
+    def test_robot_monitor_websocket_streams_selected_robot(self):
+        hardware = _HardwareService(status_overrides={
+            "positions": {"shoulder": 5.0},
+            "torque_enabled": False,
+        })
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            with self.client.websocket_connect(
+                f"/api/devices/{paired['id']}/monitor/ws"
+            ) as websocket:
+                payload = websocket.receive_json()
+
+        self.assertEqual(payload["robot_id"], paired["id"])
+        self.assertEqual(payload["source"], "hardware")
+        self.assertEqual(payload["payload"]["joints"][0]["position"], 5.0)
+
+    def test_device_status_reports_stopped_deployment_stored_on_runtime(self):
+        hardware = _HardwareService(status_overrides={
+            "connected": True,
+            "leased_to_deployment": False,
+        })
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Leader arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            hardware.runtime_deployments["leader-stored"] = {
+                "id": "leader-stored",
+                "name": "Leader workflow",
+                "state": "stopped",
+                "target_device_id": paired["id"],
+                "created_at": "2026-07-24T00:00:00+00:00",
+                "updated_at": "2026-07-25T00:00:00+00:00",
+            }
+            response = self.client.get(f"/devices/{paired['id']}/status")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["stored_deployment"], {
+            "id": "leader-stored",
+            "name": "Leader workflow",
+            "state": "stopped",
+        })
+        self.assertIn("stored on the Runtime", payload["notice"])
+        self.assertIn("can be restarted", payload["notice"])
+        self.assertNotIn("running_deployment", payload)
 
     def test_repairing_same_url_replaces_token_without_duplicating_device(self):
         first = _HardwareService("first-token")
@@ -2399,6 +3251,63 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertTrue(all(
             authorization == f"Bearer {hardware.token}"
             for _method, _path, authorization, _body in remote_requests
+        ))
+
+    def test_remote_deployments_are_scoped_to_the_selected_robot(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Follower arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            common = {
+                "state": "staged",
+                "staged_revision": "cafebabecafebabe",
+                "active_revision": None,
+                "revisions": ["cafebabecafebabe"],
+                "pid": None,
+                "exit_code": None,
+                "error": "",
+                "created_at": "2026-07-23T00:00:00+00:00",
+                "updated_at": "2026-07-23T00:00:01+00:00",
+            }
+            hardware.runtime_deployments.update({
+                "follower": {
+                    **common,
+                    "id": "follower",
+                    "name": "Follower",
+                    "target_device_id": device_id,
+                },
+                "leader": {
+                    **common,
+                    "id": "leader",
+                    "name": "Leader",
+                    "target_device_id": "another-robot",
+                },
+                "legacy": {
+                    **common,
+                    "id": "legacy",
+                    "name": "Legacy deployment",
+                    "target_device_id": "",
+                },
+            })
+
+            listed = self.client.get(f"/devices/{device_id}/deployments")
+            wrong_target = self.client.post(
+                f"/devices/{device_id}/deployments/leader/start",
+            )
+
+        self.assertEqual(listed.status_code, 200)
+        self.assertEqual(
+            {item["id"] for item in listed.json()["deployments"]},
+            {"follower", "legacy"},
+        )
+        self.assertEqual(wrong_target.status_code, 404)
+        self.assertIn("does not belong to this robot", wrong_target.json()["detail"])
+        self.assertFalse(any(
+            path == "/deployments/leader/start"
+            for _method, path, _authorization, _body in hardware.requests
         ))
 
     def test_remote_start_rechecks_device_safety(self):


### PR DESCRIPTION
## What changed
- Clarifies compute-device, robot, deployment, SSH, update, and lifecycle controls in the editor.
- Adds responsive Runtime + Robot Hardware reports and durable version reporting.
- Adds selectable live robot monitoring for idle Hardware and active deployments.
- Improves stored-deployment restart behavior, torque reporting, progress handling, and related documentation.

## Why
Device ownership, service versions, deployment persistence, and physical torque were presented through overlapping controls and transient status. This made it difficult to tell which robot was targeted and whether a workflow remained installed.

## Impact
Operators can manage each robot from a clearly separated card, inspect reliable service versions, restart stored deployments, and view live joint telemetry from the current hardware owner.

## Validation
- `python -m unittest discover -s tests` (438 passed, 8 skipped)
- `cd editor && npm run build`
- Editor device API tests (70 passed)