### PR TITLE
Register joint motion profile in package catalog

### DIFF
--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -130,6 +130,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                             "name": "ros2",
                             "default": True,
                             "node_types": [
+                                "JointMotionProfile",
                                 "ROS2JointSliders",
                                 "ROS2JointState",
                                 "ROS2ManualMove",
@@ -197,6 +198,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "description": "Generic motion, manipulation, policy, arbitration, and safety controllers.",
             "node_types": [
                 "BaseSafetyGate",
+                "JointMotionProfile",
                 "PolicyRuntime",
                 "PolicySafetyGate",
                 "ROS2BaseMove",


### PR DESCRIPTION
Adds JointMotionProfile to the official blacknode-controllers package catalog so package validation matches the published controller manifest.\n\nValidation:\n- python -m pytest tests/test_package_index.py -q\n- python -m blacknode.cli packages validate-catalog packages\\blacknode-controllers