### PR TITLE
Register robot ROS interface check in package catalog

### DIFF
--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -489,6 +489,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "node_types": [
                         "RobotConnectionDashboard",
                         "RobotDiscovery",
+                        "RobotROSInterfaceCheck",
                         "RobotUSBDiscovery"
                     ]
                 },
@@ -515,6 +516,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "RobotProfileList",
                 "RobotProfileLoad",
                 "RobotProfileSave",
+                "RobotROSInterfaceCheck",
                 "RobotUSBDiscovery"
             ]
         },


### PR DESCRIPTION
Adds RobotROSInterfaceCheck to the official blacknode-robot package catalog so the catalog matches the package manifest.\n\nValidation:\n- python -m pytest tests/test_package_index.py -q\n- python -m blacknode.cli packages validate-catalog packages\\blacknode-robot