### PR TITLE
Unify device lifecycle and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,34 @@ service scripts in the new checkout when instance isolation support is needed
 and verifies that runtimes and robot services which were already active remain
 active after the side-by-side setup.
 
+For full separation on one Linux computer, choose **Install a complete
+isolated robot stack**. Blacknode creates a separate Runtime checkout and
+service plus a separate Robot Hardware checkout, Python environment,
+configuration, calibration state, token store, service namespace, and port
+allocation. The Hardware environment starts empty. Connect the new robot,
+follow the instance-scoped command shown on its device card, and attach the
+resulting Hardware pairing details. Existing stacks and robots remain active
+and unchanged.
+
+To use the editor computer as the deployment target, choose **Add device →
+Local computer**, select the local stack installation folder, and press **Add
+local computer**. Blacknode downloads or reuses separate Runtime and Robot
+Hardware checkouts, creates separate Python environments and authentication,
+selects loopback ports, starts both services, verifies their authenticated safe
+state, and pairs the Runtime automatically. Robot Hardware begins disconnected
+and disarmed while it waits for a physical robot configuration. The local
+computer then uses the same deployment, logs, monitoring, project, and Robot
+Hardware screens as a remote computer. Blacknode can pause, resume, and
+uninstall both managed processes directly. Editor-created checkout folders are
+removed during uninstall; existing source checkouts are preserved.
+
 Runtime instances installed through the editor retain only their non-secret SSH
 management identity. **Uninstall runtime** asks for the SSH password again,
-removes the selected instance and its UFW rule, and leaves other runtime
-instances on the computer untouched. **Remove from editor** deletes only the
+shows live cleanup progress, removes the selected instance and its UFW rule,
+and leaves other runtime instances on the computer untouched. Uninstalling a
+complete isolated stack also removes only its instance-scoped Hardware services
+and checkout.
+**Remove from editor** deletes only the
 local registration. **Pause device** first stops active deployments, stops and
 disarms attached robots, then stops that runtime service. **Resume device**
 starts the service and reconnects robot monitoring while keeping motion
@@ -165,9 +189,21 @@ password, resolves the exact hardware systemd unit from that robot's saved
 hardware port, and restarts only that unit. Restart is blocked while a
 deployment is active or the robot is armed. Blacknode then verifies that the
 same authenticated robot returned and keeps motion disarmed.
-**Check device** checks the Runtime and every attached Robot Hardware service
-together. SSH-managed computers also expose one **Runtime + Robot Hardware**
-panel.
+**Check device** groups installed software into one **Software packages** row
+that reports the Runtime and Hardware versions together. If either package
+service cannot be reached, that row identifies the affected service. Attached
+physical robots remain separate rows and report connected, disconnected,
+unknown, unreachable, or still checking, so software health and physical robot
+connection remain visible independently.
+SSH-managed computers also expose one
+**Runtime + Robot Hardware** panel.
+On a local computer, **Software packages** opens separate Runtime and Hardware
+package cards. Each card shows installed and latest versions plus its running or
+stopped state. **Run** and **Stop** control only that package. **Update** advances
+and reinstalls only that clean checkout; **Reinstall** repairs its environment;
+**Delete** removes its installed environment while preserving source and
+configuration for recovery. Device checks are read-only and never start a
+stopped package.
 Its read-only version check compares installed and latest upstream versions
 and commits for both repositories, includes the version reported by each live
 service, and states whether each service is current or has an update. **Update
@@ -179,8 +215,10 @@ Hardware** independently, so a valid Runtime update remains available when a
 Robot Hardware service needs attention. Runtime has its own installation row.
 Robot Hardware has one shared installation row because every robot service on
 that compute device uses the same checkout and environment; a compact status
-line identifies the robot services that were verified. **Restart Robot
-Hardware** remains a per-robot action.
+line identifies the robot services that were verified. A Runtime instance with
+no attached robots identifies the sibling Runtime card that owns Robot Hardware
+on the same managed computer and links to that card. **Restart Robot Hardware**
+remains a per-robot action.
 Unknown versions and service-resolution errors expose **Repair Runtime** or
 **Repair Robot Hardware**. When an authenticated Robot Hardware process was
 started manually from the trusted checkout, Repair Robot Hardware verifies and stops only
@@ -193,7 +231,9 @@ changes remain blocked. When every selected commit is current, the
 matching control becomes **Reinstall
 Runtime + Robot Hardware** and repairs the current package environments before
 restarting and verifying the services. Local source changes block either
-operation and are never overwritten.
+operation and are never overwritten. The Runtime row exposes **Resolve local
+changes** with the verified SSH target, checkout directory, and read-only Git
+inspection commands.
 Updating does not switch off physical actuator power; a torque warning remains
 visible when the updated hardware service reads an enabled servo torque
 register. When no deployment is running, the robot card offers an explicitly
@@ -209,7 +249,7 @@ dashboards and fleet consumers, while the editor monitor uses the authenticated
 device connection directly. Deployed monitoring requires Runtime 0.3.9 or
 newer and `blacknode-drivers` 0.2.1 or newer; restart a running deployment after
 updating so it receives the new telemetry channel.
-Devices initially paired manually can use **Enable SSH controls** later.
+Remote devices initially paired manually can use **Enable SSH controls** later.
 Blacknode confirms the SSH host key and enables management only when the
 installed systemd runtime matches the pairing's exact port and runtime device
 identity. The SSH password remains request-only.
@@ -260,10 +300,13 @@ cannot be deployed accidentally.
 
 Remote deployments appear below the preflight report. Expand one to view its
 device log and use **Run**, **Stop**, **Stage update**, or **Rollback**.
-The robot card also distinguishes a running deployment from a stopped, staged,
-exited, or failed deployment that remains stored on its Runtime. A stored
-deployment exposes **Restart deployment** and **Deployment details**, so a
-Runtime or Hardware reinstall does not require sending the same workflow again.
+The robot card reports hardware connection and deployment status independently.
+Connection shows **Connected**, **Disconnected**, **Checking**, **Unknown**, or
+**Unreachable**. Deployment shows **Active**, **Inactive**, **Completed**,
+**Failed**, or **None**. An inactive, completed, or failed deployment remains
+available on its Runtime and exposes **Restart deployment** and **Deployment
+details**, so a Runtime or Hardware reinstall does not require sending the same
+workflow again.
 **Stage update** uploads the currently validated graph as another revision of
 that deployment. **Rollback** selects the previous revision without starting
 it; use **Run** after checking its state. A running deployment must be stopped

--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -28,16 +28,64 @@ Select **Set up robot** from the Project's Next step and open **Devices**. Start
 with the Jetson, Raspberry Pi, or Ubuntu computer that will run Blacknode
 workflows.
 
-For automatic setup, choose **Add device → Automatic SSH** and enter the
+For a local setup, choose **Add device → Local computer**, select the local
+stack installation folder, and press **Add local computer**. Blacknode prepares
+separate Runtime and Robot Hardware checkouts, Python environments,
+authentication, and state; selects separate loopback ports; starts both
+processes; verifies the Runtime manifest and the Hardware service's disconnected,
+disarmed state; and pairs the Runtime automatically. Robot Hardware waits for a
+physical robot configuration. Deployments, logs, monitoring, Projects, and
+locally attached robots use the same device interfaces as a remote target. The
+device card can pause, resume, check, and uninstall the managed local stack.
+Uninstall removes checkout folders created by Blacknode and preserves existing
+source checkouts.
+Every managed device summary shows the Runtime and Hardware package cards in
+the same layout. Each package reports its installed version and current
+RUNNING, STOPPED, UNREACHABLE, or NOT INSTALLED state, with aligned Run/Stop,
+Restart, Update, Reinstall, and Delete controls. Restart stops and starts only
+the selected local package service. Deleting a local package removes its
+environment while preserving its checkout and configuration for reinstall.
+Runtime state is normalized across local and remote computers: a successful
+health check reports RUNNING, a paused service reports STOPPED, and a failed
+health check reports UNREACHABLE.
+Robot connection status is binary in the device UI. CONNECTED requires a fresh
+positive hardware or deployment report; every other completed connection check
+shows DISCONNECTED. When an active deployment has not published fresh
+connectivity telemetry, the detail explains that Blacknode treated the robot as
+disconnected and asks the user to stop the deployment before verifying the
+physical connection directly.
+Robot Hardware also reports non-invasive serial-device presence while a
+deployment owns the port. This lets a reconnected or unplugged robot move
+between CONNECTED and DISCONNECTED without opening the serial bus twice.
+On Windows, local Runtime and Hardware services use the windowless Python
+launcher and continue in the background with output written to their package
+log files.
+Checking the device or package versions does not start a stopped service.
+Remote package actions use the verified SSH identity and one unsaved password
+field above the same two cards.
+Remote Hardware Run, Stop, and Restart control every exact
+`blacknode-hardware` service attached to that compute device. Stop first ends
+active deployments and disarms each robot; Run and Restart return with motion
+disarmed.
+
+For remote SSH setup, choose **Add device → Remote SSH** and enter the
 computer's IP address, username, and password. Blacknode first displays the
 SSH host-key fingerprint for confirmation. After confirmation it installs the
 runtime service, configures runtime port `8766` in UFW when UFW is active, and
 pairs the runtime with the editor. The SSH password remains in memory for that
 setup request and is not saved.
 
+When another robot needs complete separation on the same Linux computer,
+choose **Install a complete isolated robot stack** during the SSH review. The
+new stack receives separate Runtime and Robot Hardware repositories,
+environments, tokens, state, calibration, systemd service names, and ports.
+Its Hardware environment starts empty. The new device card shows the
+instance-scoped command for adding one newly connected stable serial path;
+existing robots remain assigned to their current stacks.
+
 For manual setup, install `blacknode-runtime` on the device, run
 `./service.sh pairing`, and enter the printed runtime URL and token under
-**Add device → Pair manually**. You can add SSH management later from that
+**Add device → Remote Manual**. You can add SSH management later from that
 device's details with **Enable SSH controls**. Blacknode confirms the SSH host
 key, verifies that the installed systemd runtime has the same port and runtime
 device identity as the existing pairing, and then enables device lifecycle and
@@ -92,9 +140,11 @@ The Project shows the running deployment and its owning device. Use
 **Deployments** to inspect logs, stop, update, or roll back a revision. Stops
 remain explicit because stopping a hardware workflow may release actuator
 torque.
-The robot card reports stopped and staged deployments that remain stored on the
-Runtime and can restart the latest stored deployment after the robot passes the
-same connected, disarmed, calibration, and ownership checks.
+The robot card reports hardware connection separately from deployment status.
+Connection can be connected, disconnected, checking, unknown, or unreachable;
+deployment can be active, inactive, completed, failed, or absent. The latest
+inactive deployment remains available on the Runtime and can restart after the
+robot passes the same connected, disarmed, calibration, and ownership checks.
 
 Update the graph, check setup again, and send a new revision to iterate. Project
 artifacts retain evidence from datasets, training runs, policies, evaluations,

--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -311,7 +311,7 @@ def _load_paramiko():
         import paramiko  # type: ignore
     except ImportError as exc:
         raise DeviceInstallError(
-            "Automatic SSH setup requires Paramiko. Reinstall the editor-server "
+            "Remote SSH setup requires Paramiko. Reinstall the editor-server "
             "requirements, then restart Blacknode."
         ) from exc
     return paramiko
@@ -682,9 +682,17 @@ def install_runtime(
         timeout=15.0,
     )
     clean_action = str(action or "").strip().lower()
-    if clean_action not in {"install", "reuse", "replace", "side_by_side"}:
+    if clean_action not in {
+        "install",
+        "reuse",
+        "replace",
+        "side_by_side",
+        "isolated_stack",
+    }:
         connection.close()
-        raise DeviceInstallError("Choose install, reuse, replace, or side_by_side.")
+        raise DeviceInstallError(
+            "Choose install, reuse, replace, side_by_side, or isolated_stack."
+        )
     started = time.monotonic()
     token = ""
     remote_token_path = ""
@@ -734,6 +742,8 @@ def install_runtime(
                     "runtime_port": runtime_port,
                     "service_name": str(existing.get("service_name") or ""),
                     "runtime_dir": str(existing.get("runtime_dir") or ""),
+                    "stack_mode": "runtime_only",
+                    "hardware_dir": "",
                 }
             remove_old_port = bool(existing.get("service_installed"))
         else:
@@ -775,6 +785,7 @@ if [[ "$instance" == "default" ]]; then
   token_file="$HOME/.blacknode/runtime.auth.token"
   service_name="blacknode-runtime.service"
   service_instance=""
+  hardware_dir="$HOME/blacknode-hardware"
 else
   [[ "$instance" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || {
     echo "Invalid Blacknode runtime instance."
@@ -784,9 +795,11 @@ else
   token_file="$HOME/.blacknode/runtimes/$instance.auth.token"
   service_name="blacknode-runtime-$instance.service"
   service_instance="$instance"
+  hardware_dir="$HOME/blacknode-hardware-instances/$instance"
 fi
 active_sibling_services=()
-if [[ "$action" == "side_by_side" ]] && command -v systemctl >/dev/null 2>&1; then
+if [[ "$action" == "side_by_side" || "$action" == "isolated_stack" ]] \
+  && command -v systemctl >/dev/null 2>&1; then
   mapfile -t active_sibling_services < <(
     systemctl list-units --type=service --state=active --no-legend \
       'blacknode-runtime*.service' 'blacknode-hardware*.service' 2>/dev/null \
@@ -795,6 +808,7 @@ if [[ "$action" == "side_by_side" ]] && command -v systemctl >/dev/null 2>&1; th
 fi
 install_complete=false
 cleanup_install=false
+cleanup_hardware=false
 port_guard=""
 port_file=""
 cleanup_failed_install() {
@@ -812,6 +826,9 @@ cleanup_failed_install() {
     sudo systemctl daemon-reload >/dev/null 2>&1 || true
     rm -rf -- "$runtime_dir"
     rm -f -- "$token_file"
+    if [[ "$cleanup_hardware" == true ]]; then
+      rm -rf -- "$hardware_dir"
+    fi
   fi
   exit "$exit_code"
 }
@@ -820,8 +837,17 @@ case "$runtime_dir" in
   "$HOME/blacknode-runtime"|"$HOME/blacknode-runtimes/"*) ;;
   *) echo "Unsafe runtime directory."; exit 2 ;;
 esac
+case "$hardware_dir" in
+  "$HOME/blacknode-hardware"|"$HOME/blacknode-hardware-instances/"*) ;;
+  *) echo "Unsafe Hardware directory."; exit 2 ;;
+esac
 token_dir="$(dirname -- "$token_file")"
 progress 14 "Preparing the selected runtime"
+if [[ "$action" == "isolated_stack" && -e "$hardware_dir" ]]; then
+  echo "The isolated Hardware directory already exists. Preserve or remove it before retrying:"
+  echo "  $hardware_dir"
+  exit 3
+fi
 if [[ "$action" == "replace" ]]; then
   cleanup_install=true
   sudo systemctl stop "$service_name" >/dev/null 2>&1 || true
@@ -933,6 +959,21 @@ if [[ -n "$service_instance" ]]; then
   BLACKNODE_RUNTIME_INSTANCE="$service_instance" ./configure.sh \
     --device-id "$(hostname)-$service_instance"
 fi
+if [[ "$action" == "isolated_stack" ]]; then
+  progress 72 "Creating the isolated Robot Hardware environment"
+  mkdir -p "$(dirname -- "$hardware_dir")"
+  cleanup_hardware=true
+  git clone https://github.com/temiroff/blacknode-hardware.git "$hardware_dir"
+  if ! grep -q 'BLACKNODE_HARDWARE_INSTANCE' "$hardware_dir/install-service.sh" \
+    || ! grep -q 'previous_working_directory' "$hardware_dir/install-service.sh"; then
+    echo "The downloaded Blacknode Hardware release does not support isolated stacks yet."
+    exit 4
+  fi
+  (
+    cd "$hardware_dir"
+    BLACKNODE_HARDWARE_INSTANCE="$service_instance" ./setup_ubuntu.sh
+  )
+fi
 progress 88 "Installing the runtime service"
 kill "$port_guard" >/dev/null 2>&1 || true
 wait "$port_guard" >/dev/null 2>&1 || true
@@ -1025,6 +1066,16 @@ progress 96 "Verifying the runtime service"
                 if selected_instance == "default"
                 else f"~/blacknode-runtimes/{selected_instance}"
             ),
+            "stack_mode": (
+                "isolated"
+                if clean_action == "isolated_stack"
+                else "runtime_only"
+            ),
+            "hardware_dir": (
+                f"~/blacknode-hardware-instances/{selected_instance}"
+                if clean_action == "isolated_stack"
+                else ""
+            ),
         }
     finally:
         if remote_script_path or remote_token_path:
@@ -1051,6 +1102,7 @@ def update_managed_services(
     hardware_ports: list[int],
     hardware_device_ids: dict[int, str] | None = None,
     include_runtime: bool = True,
+    stack_mode: str = "runtime_only",
     progress: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Fast-forward and restart selected managed Runtime and Hardware services."""
@@ -1063,6 +1115,9 @@ def update_managed_services(
             })
 
     selected_instance = _clean_instance_id(instance_id or "default")
+    selected_stack_mode = str(stack_mode or "runtime_only").strip().lower()
+    if selected_stack_mode not in {"runtime_only", "isolated"}:
+        raise DeviceInstallError("The managed stack mode is invalid.")
     selected_runtime_port = int(runtime_port)
     if selected_runtime_port < 1 or selected_runtime_port > 65535:
         raise DeviceInstallError("The managed runtime port is invalid.")
@@ -1103,6 +1158,7 @@ include_runtime="$1"
 instance="$2"
 runtime_port="$3"
 hardware_targets_payload="$4"
+stack_mode="$5"
 hardware_ports=()
 hardware_device_ids=()
 while IFS=$'\t' read -r target_port target_device_id; do
@@ -1130,6 +1186,11 @@ else
   }
   runtime_dir="$HOME/blacknode-runtimes/$instance"
   runtime_service="blacknode-runtime-$instance.service"
+fi
+if [[ "$stack_mode" == "isolated" ]]; then
+  hardware_repo="$HOME/blacknode-hardware-instances/$instance"
+else
+  hardware_repo="$HOME/blacknode-hardware"
 fi
 
 package_version() {
@@ -1290,7 +1351,6 @@ stop_verified_manual_hardware() {
 }
 
 install_persistent_hardware_services() {
-  local hardware_repo="$HOME/blacknode-hardware"
   [[ -x "$hardware_repo/install-service.sh" ]] || {
     echo "Repair Hardware requires $hardware_repo/install-service.sh." >&2
     return 1
@@ -1570,6 +1630,7 @@ progress 96 "Managed services updated"
             selected_instance,
             str(selected_runtime_port),
             targets_payload,
+            selected_stack_mode,
         ])
         output = _run(
             connection,
@@ -2056,11 +2117,15 @@ def restart_hardware_service(
     password: str,
     host_fingerprint: str,
     hardware_port: int,
+    action: str = "restart",
 ) -> dict[str, Any]:
-    """Restart exactly one Blacknode hardware unit resolved by its HTTP port."""
+    """Control exactly one Blacknode hardware unit resolved by its HTTP port."""
     selected_port = int(hardware_port)
     if selected_port < 1 or selected_port > 65535:
         raise DeviceInstallError("The robot hardware port is invalid.")
+    clean_action = str(action or "").strip().lower()
+    if clean_action not in {"start", "stop", "restart"}:
+        raise DeviceInstallError("Hardware service action must be start, stop, or restart.")
     connection = _connect(
         host,
         port,
@@ -2069,12 +2134,17 @@ def restart_hardware_service(
         expected_fingerprint=host_fingerprint,
         timeout=15.0,
     )
-    remote_script_path = f"/tmp/blacknode-hardware-restart-{secrets.token_hex(8)}.sh"
+    remote_script_path = f"/tmp/blacknode-hardware-control-{secrets.token_hex(8)}.sh"
     script = r"""#!/usr/bin/env bash
 set -euo pipefail
 hardware_port="$1"
+action="$2"
 [[ "$hardware_port" =~ ^[0-9]{1,5}$ ]] || {
   echo "Invalid robot hardware port."
+  exit 2
+}
+[[ "$action" =~ ^(start|stop|restart)$ ]] || {
+  echo "Invalid robot hardware service action."
   exit 2
 }
 mapfile -t candidate_units < <(
@@ -2128,16 +2198,18 @@ else
   echo "Could not choose the hardware service for port $hardware_port. Candidates: ${matches[*]}. Enabled: ${enabled_matches[*]:-none}."
   exit 4
 fi
-sudo -S -p '' systemctl restart "$service_name"
+sudo -S -p '' systemctl "$action" "$service_name"
+expected_state="active"
+[[ "$action" == "stop" ]] && expected_state="inactive"
 state=""
 for _attempt in {1..40}; do
   state="$(systemctl is-active "$service_name" 2>/dev/null || true)"
-  [[ "$state" == "active" ]] && break
+  [[ "$state" == "$expected_state" ]] && break
   sleep 0.25
 done
 echo "__BLACKNODE_HARDWARE_SERVICE__=$service_name"
 echo "__BLACKNODE_HARDWARE_STATE__=$state"
-[[ "$state" == "active" ]]
+[[ "$state" == "$expected_state" ]]
 """
     try:
         sftp = connection.client.open_sftp()
@@ -2149,7 +2221,7 @@ echo "__BLACKNODE_HARDWARE_STATE__=$state"
             sftp.close()
         output = _run(
             connection,
-            f"bash {remote_script_path} {selected_port}",
+            f"bash {remote_script_path} {selected_port} {clean_action}",
             stdin_text=_sudo_input(password),
             timeout=60.0,
         )
@@ -2165,17 +2237,19 @@ echo "__BLACKNODE_HARDWARE_STATE__=$state"
         )
         if not service_match or not state_match:
             raise DeviceInstallError(
-                "The device did not confirm which robot service was restarted."
+                "The device did not confirm which robot service was controlled."
             )
         state = state_match.group(1)
-        if state != "active":
+        expected_state = "inactive" if clean_action == "stop" else "active"
+        if state != expected_state:
             raise DeviceInstallError(
-                f"{service_match.group(1)} did not return to the active state."
+                f"{service_match.group(1)} did not enter the {expected_state} state."
             )
         return {
             "ok": True,
             "hardware_port": selected_port,
             "service_name": service_match.group(1),
+            "action": clean_action,
             "state": state,
         }
     finally:
@@ -2195,8 +2269,23 @@ def uninstall_runtime(
     host_fingerprint: str,
     instance_id: str,
     runtime_port: int,
+    stack_mode: str = "runtime_only",
+    progress: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
+    def report(percent: int, message: str) -> None:
+        if progress is not None:
+            progress({
+                "progress": max(0, min(100, int(percent))),
+                "message": str(message),
+            })
+
+    report(2, "Connecting securely")
     selected_instance = _clean_instance_id(instance_id or "default")
+    selected_stack_mode = str(stack_mode or "runtime_only").strip().lower()
+    if selected_stack_mode not in {"runtime_only", "isolated"}:
+        raise DeviceInstallError("The managed stack mode is invalid.")
+    if selected_stack_mode == "isolated" and selected_instance == "default":
+        raise DeviceInstallError("The default Runtime cannot own an isolated stack.")
     selected_port = int(runtime_port)
     if selected_port < 1 or selected_port > 65535:
         raise DeviceInstallError("The managed runtime port is invalid.")
@@ -2211,8 +2300,12 @@ def uninstall_runtime(
     remote_script_path = f"/tmp/blacknode-runtime-uninstall-{secrets.token_hex(8)}.sh"
     script = """#!/usr/bin/env bash
 set -euo pipefail
+progress() {
+  echo "__BLACKNODE_UNINSTALL_PROGRESS__=$1|$2"
+}
 instance="$1"
 runtime_port="$2"
+stack_mode="$3"
 if [[ "$instance" == "default" ]]; then
   runtime_dir="$HOME/blacknode-runtime"
   token_file="$HOME/.blacknode/runtime.auth.token"
@@ -2223,22 +2316,67 @@ else
   token_file="$HOME/.blacknode/runtimes/$instance.auth.token"
   service_name="blacknode-runtime-$instance.service"
 fi
+hardware_dir="$HOME/blacknode-hardware-instances/$instance"
 case "$runtime_dir" in
   "$HOME/blacknode-runtime"|"$HOME/blacknode-runtimes/"*) ;;
   *) echo "Unsafe runtime directory."; exit 2 ;;
 esac
+progress 20 "Stopping Runtime service"
 sudo systemctl stop "$service_name" >/dev/null 2>&1 || true
 sudo systemctl disable "$service_name" >/dev/null 2>&1 || true
+progress 35 "Removing Runtime service"
 sudo rm -f -- "/etc/systemd/system/$service_name"
 sudo systemctl daemon-reload
+if [[ "$stack_mode" == "isolated" ]]; then
+  case "$hardware_dir" in
+    "$HOME/blacknode-hardware-instances/"*) ;;
+    *) echo "Unsafe Hardware directory."; exit 2 ;;
+  esac
+  progress 48 "Finding isolated Robot Hardware services"
+  mapfile -t hardware_units < <(
+    {
+      systemctl list-unit-files 'blacknode-hardware*.service' --no-legend 2>/dev/null
+      systemctl list-units --all --type=service 'blacknode-hardware*.service' \
+        --no-legend 2>/dev/null
+    } | awk '{print $1}' | sort -u
+  )
+  for hardware_unit in "${hardware_units[@]}"; do
+    [[ "$hardware_unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\\.service$ ]] \
+      || continue
+    working_directory="$(
+      systemctl show "$hardware_unit" --property=WorkingDirectory --value 2>/dev/null || true
+    )"
+    [[ "$working_directory" == "$hardware_dir" ]] || continue
+    progress 60 "Stopping isolated Robot Hardware services"
+    hardware_port="$(
+      systemctl cat "$hardware_unit" 2>/dev/null \
+        | sed -nE 's/.*--port[= ]"?([0-9]+).*/\\1/p' \
+        | tail -n 1
+    )"
+    sudo systemctl stop "$hardware_unit" >/dev/null 2>&1 || true
+    sudo systemctl disable "$hardware_unit" >/dev/null 2>&1 || true
+    sudo rm -f -- "/etc/systemd/system/$hardware_unit"
+    if [[ "$hardware_port" =~ ^[0-9]+$ ]] \
+      && command -v ufw >/dev/null 2>&1 \
+      && sudo ufw status 2>/dev/null | grep -qi '^Status: active'; then
+      sudo ufw --force delete allow "$hardware_port/tcp" >/dev/null 2>&1 || true
+    fi
+  done
+  progress 74 "Removing isolated Robot Hardware files"
+  sudo systemctl daemon-reload
+  rm -rf -- "$hardware_dir"
+fi
+progress 84 "Removing Runtime files and firewall rule"
 if command -v ufw >/dev/null 2>&1 \
   && sudo ufw status 2>/dev/null | grep -qi '^Status: active'; then
   sudo ufw --force delete allow "$runtime_port/tcp" >/dev/null 2>&1 || true
 fi
 rm -rf -- "$runtime_dir"
 rm -f -- "$token_file"
+progress 94 "Finalizing uninstall"
 """
     try:
+        report(10, "Inspecting the managed stack")
         inspection = _inspect_connection(connection)
         existing = _find_instance(inspection, selected_instance)
         if existing:
@@ -2255,14 +2393,24 @@ rm -f -- "$token_file"
             sftp.chmod(remote_script_path, 0o700)
         finally:
             sftp.close()
+
+        def remote_output(line: str) -> None:
+            match = re.match(
+                r"^__BLACKNODE_UNINSTALL_PROGRESS__=(\d{1,3})\|(.*)$",
+                line.strip(),
+            )
+            if match:
+                report(int(match.group(1)), match.group(2).strip())
+
         _run(
             connection,
             (
                 f"sudo -S -p '' -v && bash {remote_script_path} "
-                f"{selected_instance} {selected_port}"
+                f"{selected_instance} {selected_port} {selected_stack_mode}"
             ),
             stdin_text=password + "\n",
             timeout=120.0,
+            on_output=remote_output,
         )
         return {
             "ok": True,
@@ -2270,6 +2418,7 @@ rm -f -- "$token_file"
             "instance_id": selected_instance,
             "runtime_port": selected_port,
             "already_absent": not bool(existing),
+            "stack_mode": selected_stack_mode,
         }
     finally:
         try:

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -447,6 +447,21 @@ class DeviceRegistry:
                         "runtime_port",
                         "service_name",
                         "runtime_dir",
+                        "stack_mode",
+                        "hardware_dir",
+                        "hardware_port",
+                        "hardware_service_name",
+                        "hardware_state",
+                        "hardware_configured",
+                        "hardware_pid_file",
+                        "hardware_token_file",
+                        "hardware_log_path",
+                        "hardware_owned_install",
+                        "management_mode",
+                        "config_path",
+                        "pid_file",
+                        "log_path",
+                        "owned_install",
                     }
                 }
                 if managed_runtime
@@ -552,13 +567,45 @@ class DeviceRegistry:
             "runtime_port",
             "service_name",
             "runtime_dir",
+            "stack_mode",
+            "hardware_dir",
+            "hardware_port",
+            "hardware_service_name",
+            "hardware_state",
+            "hardware_configured",
+            "hardware_pid_file",
+            "hardware_token_file",
+            "hardware_log_path",
+            "hardware_owned_install",
+            "management_mode",
+            "config_path",
+            "pid_file",
+            "log_path",
+            "owned_install",
         }
         management = {
             key: value
             for key, value in managed_runtime.items()
             if key in allowed_keys
         }
-        if set(management) != allowed_keys:
+        required_keys = allowed_keys - {
+            "stack_mode",
+            "hardware_dir",
+            "hardware_port",
+            "hardware_service_name",
+            "hardware_state",
+            "hardware_configured",
+            "hardware_pid_file",
+            "hardware_token_file",
+            "hardware_log_path",
+            "hardware_owned_install",
+            "management_mode",
+            "config_path",
+            "pid_file",
+            "log_path",
+            "owned_install",
+        }
+        if not required_keys.issubset(management):
             raise DeviceRegistryError(
                 "The verified SSH runtime identity is incomplete."
             )

--- a/editor-server/local_runtime.py
+++ b/editor-server/local_runtime.py
@@ -1,0 +1,1339 @@
+"""Install and manage an isolated Blacknode stack on the editor computer."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import shutil
+import socket
+import stat
+import subprocess
+import sys
+import time
+import tomllib
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+_RUNTIME_REPOSITORY = "https://github.com/temiroff/blacknode-runtime.git"
+_HARDWARE_REPOSITORY = "https://github.com/temiroff/blacknode-hardware.git"
+
+
+class LocalRuntimeError(RuntimeError):
+    """A local Runtime installation or lifecycle action failed."""
+
+
+def default_local_runtime_dir() -> Path:
+    return Path.home() / "Blacknode"
+
+
+def _report(
+    progress: Callable[[dict[str, Any]], None] | None,
+    percent: int,
+    message: str,
+) -> None:
+    if progress is not None:
+        progress({
+            "progress": max(0, min(100, int(percent))),
+            "message": str(message),
+        })
+
+
+def _runtime_python(runtime_dir: Path) -> Path:
+    return runtime_dir / ".venv" / (
+        "Scripts/python.exe" if os.name == "nt" else "bin/python"
+    )
+
+
+def _hardware_python(hardware_dir: Path) -> Path:
+    return hardware_dir / ".venv" / (
+        "Scripts/python.exe" if os.name == "nt" else "bin/python"
+    )
+
+
+def _background_python(python: Path) -> Path:
+    """Use the windowless venv launcher for persistent Windows services."""
+    if os.name != "nt":
+        return python
+    pythonw = python.with_name("pythonw.exe")
+    return pythonw if pythonw.is_file() else python
+
+
+def _validate_runtime_checkout(runtime_dir: Path) -> None:
+    pyproject = runtime_dir / "pyproject.toml"
+    service_script = runtime_dir / "scripts" / "runtime_service.py"
+    if not pyproject.is_file() or not service_script.is_file():
+        raise LocalRuntimeError(
+            f"{runtime_dir} is not an empty folder or a Blacknode Runtime checkout."
+        )
+    try:
+        manifest = pyproject.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise LocalRuntimeError(f"Could not inspect {pyproject}: {exc}") from exc
+    if 'name = "blacknode-runtime"' not in manifest:
+        raise LocalRuntimeError(f"{runtime_dir} is not a Blacknode Runtime checkout.")
+
+
+def _validate_hardware_checkout(hardware_dir: Path) -> None:
+    pyproject = hardware_dir / "pyproject.toml"
+    service_script = hardware_dir / "scripts" / "hardware_service.py"
+    if not pyproject.is_file() or not service_script.is_file():
+        raise LocalRuntimeError(
+            f"{hardware_dir} is not an empty folder or a Blacknode Hardware checkout."
+        )
+    try:
+        manifest = pyproject.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise LocalRuntimeError(f"Could not inspect {pyproject}: {exc}") from exc
+    if 'name = "blacknode-hardware"' not in manifest:
+        raise LocalRuntimeError(f"{hardware_dir} is not a Blacknode Hardware checkout.")
+
+
+def _resolve_install_dir(value: str, core_root: Path) -> Path:
+    raw = str(value or "").strip()
+    if not raw:
+        raise LocalRuntimeError("Choose the local stack installation folder.")
+    runtime_dir = Path(raw).expanduser().resolve()
+    core_dir = Path(core_root).resolve()
+    anchor = Path(runtime_dir.anchor).resolve()
+    if runtime_dir in {anchor, Path.home().resolve(), core_dir}:
+        raise LocalRuntimeError(
+            "Choose a dedicated subfolder for the local stack installation."
+        )
+    if runtime_dir.exists() and not runtime_dir.is_dir():
+        raise LocalRuntimeError(f"The stack installation path is not a folder: {runtime_dir}")
+    return runtime_dir
+
+
+def _run(args: list[str], *, cwd: Path | None = None, timeout: float = 900.0) -> str:
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=str(cwd) if cwd is not None else None,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            check=False,
+            creationflags=(
+                getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
+            ),
+        )
+    except FileNotFoundError as exc:
+        raise LocalRuntimeError(f"Required command is unavailable: {args[0]}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise LocalRuntimeError(
+            f"Local Runtime setup did not finish within {int(timeout)} seconds."
+        ) from exc
+    if completed.returncode:
+        output = "\n".join(
+            (completed.stdout + "\n" + completed.stderr).strip().splitlines()[-16:]
+        )
+        raise LocalRuntimeError(
+            f"Local Runtime setup command failed with code {completed.returncode}."
+            + (f"\n{output}" if output else "")
+        )
+    return completed.stdout
+
+
+def _port_available(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        try:
+            listener.bind(("127.0.0.1", int(port)))
+        except OSError:
+            return False
+    return True
+
+
+def _select_port(preferred: int = 8766, reserved: set[int] | None = None) -> int:
+    reserved_ports = reserved or set()
+    for port in range(max(1, int(preferred)), 8866):
+        if port not in reserved_ports and _port_available(port):
+            return port
+    raise LocalRuntimeError("No available local Runtime port was found from 8766 to 8865.")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _checkout_version(checkout_dir: Path) -> str:
+    try:
+        payload = tomllib.loads(
+            (checkout_dir / "pyproject.toml").read_text(encoding="utf-8")
+        )
+    except (OSError, tomllib.TOMLDecodeError):
+        return "unknown"
+    project = payload.get("project")
+    if not isinstance(project, dict):
+        return "unknown"
+    return str(project.get("version") or "unknown")
+
+
+def _version_from_pyproject_text(value: str) -> str:
+    try:
+        payload = tomllib.loads(value)
+    except tomllib.TOMLDecodeError:
+        return "unknown"
+    project = payload.get("project")
+    return (
+        str(project.get("version") or "unknown")
+        if isinstance(project, dict)
+        else "unknown"
+    )
+
+
+def _remove_tree(path: Path) -> None:
+    """Remove one verified installation tree, clearing Windows read-only bits."""
+    if not path.exists():
+        return
+
+    def make_writable_and_retry(function, target, _error_info) -> None:
+        last_error: OSError | None = None
+        for delay in (0.0, 0.1, 0.3, 0.8):
+            if delay:
+                time.sleep(delay)
+            try:
+                os.chmod(
+                    target,
+                    stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR,
+                )
+                function(target)
+                return
+            except OSError as exc:
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+
+    shutil.rmtree(path, onerror=make_writable_and_retry)
+
+
+def _process_command(pid: int) -> str:
+    if pid < 1:
+        return ""
+    if os.name == "nt":
+        command = (
+            f"(Get-CimInstance Win32_Process -Filter \"ProcessId = {pid}\" "
+            "| Select-Object -ExpandProperty CommandLine)"
+        )
+        completed = subprocess.run(
+            ["powershell", "-NoProfile", "-NonInteractive", "-Command", command],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=8,
+            check=False,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+        return completed.stdout.strip() if completed.returncode == 0 else ""
+    proc_command = Path(f"/proc/{pid}/cmdline")
+    if proc_command.is_file():
+        try:
+            return proc_command.read_bytes().replace(b"\0", b" ").decode(
+                "utf-8", errors="replace"
+            )
+        except OSError:
+            return ""
+    completed = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "command="],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=8,
+        check=False,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+def _read_pid(pid_file: Path) -> int:
+    try:
+        return int(pid_file.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return 0
+
+
+def _pid_is_expected(pid: int, runtime_dir: Path, config_path: Path) -> bool:
+    command = _process_command(pid)
+    if not command:
+        return False
+    normalized = command.casefold() if os.name == "nt" else command
+    runtime_marker = str(runtime_dir / "scripts" / "runtime_service.py")
+    config_marker = str(config_path)
+    if os.name == "nt":
+        runtime_marker = runtime_marker.casefold()
+        config_marker = config_marker.casefold()
+    return runtime_marker in normalized and config_marker in normalized
+
+
+def _pid_is_hardware(
+    pid: int,
+    hardware_dir: Path,
+    token_path: Path,
+) -> bool:
+    command = _process_command(pid)
+    if not command:
+        return False
+    normalized = command.casefold() if os.name == "nt" else command
+    hardware_marker = str(hardware_dir / "scripts" / "hardware_service.py")
+    token_marker = str(token_path)
+    if os.name == "nt":
+        hardware_marker = hardware_marker.casefold()
+        token_marker = token_marker.casefold()
+    return hardware_marker in normalized and token_marker in normalized
+
+
+def _spawn_runtime(runtime_dir: Path, config_path: Path, port: int) -> int:
+    python = _background_python(_runtime_python(runtime_dir))
+    service_script = runtime_dir / "scripts" / "runtime_service.py"
+    if not python.is_file() or not service_script.is_file() or not config_path.is_file():
+        raise LocalRuntimeError("The local Runtime installation is incomplete.")
+    state_dir = runtime_dir / ".blacknode-runtime"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    pid_file = state_dir / "runtime.pid"
+    existing_pid = _read_pid(pid_file)
+    if existing_pid and _pid_is_expected(existing_pid, runtime_dir, config_path):
+        return existing_pid
+    if existing_pid:
+        try:
+            os.kill(existing_pid, 0)
+        except OSError:
+            pass
+        else:
+            raise LocalRuntimeError(
+                f"PID {existing_pid} no longer belongs to this Runtime; "
+                f"remove the stale file after inspecting it: {pid_file}"
+            )
+        pid_file.unlink(missing_ok=True)
+    if not _port_available(port):
+        raise LocalRuntimeError(
+            f"Local port {port} is already in use. Stop that process or choose another "
+            "installation after it releases the port."
+        )
+    log_path = state_dir / "runtime.log"
+    log_handle = log_path.open("a", encoding="utf-8")
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+    process_options: dict[str, Any]
+    if os.name == "nt":
+        process_options = {
+            "creationflags": (
+                getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                | getattr(subprocess, "DETACHED_PROCESS", 0)
+                | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            )
+        }
+    else:
+        process_options = {"start_new_session": True}
+    try:
+        process = subprocess.Popen(
+            [
+                str(python),
+                "-u",
+                str(service_script),
+                "--config",
+                str(config_path),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+            ],
+            cwd=str(runtime_dir),
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            env=env,
+            **process_options,
+        )
+    finally:
+        log_handle.close()
+    pid_file.write_text(f"{process.pid}\n", encoding="utf-8")
+    return int(process.pid)
+
+
+def _request_manifest(port: int, token: str, *, timeout: float = 1.0) -> dict[str, Any]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{int(port)}/manifest",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        payload = json.loads(response.read())
+    if (
+        not isinstance(payload, dict)
+        or payload.get("service") != "blacknode-runtime"
+        or payload.get("protocol_version") != 1
+    ):
+        raise LocalRuntimeError("The local port returned an incompatible service.")
+    return payload
+
+
+def _spawn_hardware(hardware_dir: Path, token_path: Path, port: int) -> int:
+    python = _background_python(_hardware_python(hardware_dir))
+    service_script = hardware_dir / "scripts" / "hardware_service.py"
+    if not python.is_file() or not service_script.is_file() or not token_path.is_file():
+        raise LocalRuntimeError("The local Robot Hardware installation is incomplete.")
+    state_dir = hardware_dir / ".blacknode-hardware"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    pid_file = state_dir / "hardware.pid"
+    existing_pid = _read_pid(pid_file)
+    if existing_pid and _pid_is_hardware(existing_pid, hardware_dir, token_path):
+        return existing_pid
+    if existing_pid:
+        try:
+            os.kill(existing_pid, 0)
+        except OSError:
+            pass
+        else:
+            raise LocalRuntimeError(
+                f"PID {existing_pid} no longer belongs to this Robot Hardware service; "
+                f"remove the stale file after inspecting it: {pid_file}"
+            )
+        pid_file.unlink(missing_ok=True)
+    if not _port_available(port):
+        raise LocalRuntimeError(
+            f"Local Robot Hardware port {port} is already in use."
+        )
+    log_path = state_dir / "hardware.log"
+    log_handle = log_path.open("a", encoding="utf-8")
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+    process_options: dict[str, Any]
+    if os.name == "nt":
+        process_options = {
+            "creationflags": (
+                getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                | getattr(subprocess, "DETACHED_PROCESS", 0)
+                | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            )
+        }
+    else:
+        process_options = {"start_new_session": True}
+    try:
+        process = subprocess.Popen(
+            [
+                str(python),
+                "-u",
+                str(service_script),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--device-id",
+                f"{socket.gethostname()}-hardware-awaiting-device",
+                "--auth-token-file",
+                str(token_path),
+                "--require-auth",
+            ],
+            cwd=str(hardware_dir),
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            env=env,
+            **process_options,
+        )
+    finally:
+        log_handle.close()
+    pid_file.write_text(f"{process.pid}\n", encoding="utf-8")
+    return int(process.pid)
+
+
+def _request_hardware_status(
+    port: int,
+    token: str,
+    *,
+    timeout: float = 1.0,
+) -> dict[str, Any]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{int(port)}/status",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        payload = json.loads(response.read())
+    if not isinstance(payload, dict):
+        raise LocalRuntimeError("Robot Hardware returned an invalid status.")
+    if payload.get("connected") is not False or payload.get("armed") is not False:
+        raise LocalRuntimeError(
+            "Robot Hardware did not start in the required disconnected, disarmed state."
+        )
+    return payload
+
+
+def _wait_for_hardware_status(
+    port: int,
+    token: str,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            return _request_hardware_status(port, token)
+        except (OSError, urllib.error.URLError, json.JSONDecodeError, LocalRuntimeError) as exc:
+            last_error = str(exc)
+            time.sleep(0.25)
+    raise LocalRuntimeError(
+        "Robot Hardware started but did not confirm its safe awaiting-device state."
+        + (f" {last_error}" if last_error else "")
+    )
+
+
+def _wait_for_manifest(port: int, token: str, timeout: float = 30.0) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            return _request_manifest(port, token)
+        except (OSError, urllib.error.URLError, json.JSONDecodeError, LocalRuntimeError) as exc:
+            last_error = str(exc)
+            time.sleep(0.25)
+    raise LocalRuntimeError(
+        "The local Runtime process started but did not pass its authenticated check."
+        + (f" {last_error}" if last_error else "")
+    )
+
+
+def install_local_runtime(
+    *,
+    install_dir: str,
+    core_root: Path,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    install_root = _resolve_install_dir(install_dir, core_root)
+    if (
+        install_root.name.casefold() == "blacknode-runtime"
+        and (install_root / "pyproject.toml").is_file()
+    ):
+        runtime_dir = install_root
+        install_root = install_root.parent
+    else:
+        runtime_dir = install_root / "blacknode-runtime"
+    hardware_dir = install_root / "blacknode-hardware"
+    _report(progress, 4, "Checking the local robot stack folder")
+
+    runtime_existed = runtime_dir.exists() and any(runtime_dir.iterdir())
+    if runtime_existed:
+        _validate_runtime_checkout(runtime_dir)
+        runtime_owned = bool(
+            _load_json(runtime_dir / ".blacknode-runtime" / "editor-managed.json").get(
+                "owned_install"
+            )
+        )
+        _report(progress, 10, "Using the existing Runtime checkout")
+    else:
+        runtime_dir.parent.mkdir(parents=True, exist_ok=True)
+        _report(progress, 9, "Downloading Blacknode Runtime")
+        _run(["git", "clone", _RUNTIME_REPOSITORY, str(runtime_dir)], timeout=300)
+        _validate_runtime_checkout(runtime_dir)
+        runtime_owned = True
+
+    runtime_python = _runtime_python(runtime_dir)
+    if not runtime_python.is_file():
+        _report(progress, 18, "Creating the local Runtime environment")
+        _run([sys.executable, "-m", "venv", str(runtime_dir / ".venv")], timeout=180)
+    _report(progress, 25, "Installing Blacknode Runtime")
+    _run(
+        [str(runtime_python), "-m", "pip", "install", "-e", str(runtime_dir)],
+        timeout=900,
+    )
+
+    hardware_existed = hardware_dir.exists() and any(hardware_dir.iterdir())
+    if hardware_existed:
+        _validate_hardware_checkout(hardware_dir)
+        hardware_owned = bool(
+            _load_json(
+                hardware_dir / ".blacknode-hardware" / "editor-managed.json"
+            ).get("owned_install")
+        )
+        _report(progress, 34, "Using the existing Robot Hardware checkout")
+    else:
+        hardware_dir.parent.mkdir(parents=True, exist_ok=True)
+        _report(progress, 33, "Downloading Blacknode Robot Hardware")
+        _run(["git", "clone", _HARDWARE_REPOSITORY, str(hardware_dir)], timeout=300)
+        _validate_hardware_checkout(hardware_dir)
+        hardware_owned = True
+
+    hardware_python = _hardware_python(hardware_dir)
+    if not hardware_python.is_file():
+        _report(progress, 41, "Creating the Robot Hardware environment")
+        _run([sys.executable, "-m", "venv", str(hardware_dir / ".venv")], timeout=180)
+    _report(progress, 48, "Installing Blacknode Robot Hardware")
+    _run(
+        [str(hardware_python), "-m", "pip", "install", "-e", str(hardware_dir)],
+        timeout=900,
+    )
+
+    _report(progress, 57, "Connecting Runtime to this Blacknode workspace")
+    _run(
+        [
+            str(runtime_python),
+            "-m",
+            "pip",
+            "install",
+            "-e",
+            str(Path(core_root).resolve()),
+        ],
+        timeout=900,
+    )
+
+    private_dir = runtime_dir / ".blacknode-runtime"
+    private_dir.mkdir(parents=True, exist_ok=True)
+    token_path = private_dir / "auth.token"
+    token = token_path.read_text(encoding="utf-8").strip() if token_path.is_file() else ""
+    if len(token) < 32:
+        token = secrets.token_urlsafe(32)
+        token_path.write_text(token + "\n", encoding="utf-8")
+        try:
+            os.chmod(token_path, 0o600)
+        except OSError:
+            pass
+    metadata_path = private_dir / "editor-managed.json"
+    previous = _load_json(metadata_path)
+    preferred_port = int(previous.get("runtime_port") or 8766)
+    config_path = private_dir / "runtime.json"
+    existing_pid = _read_pid(private_dir / "runtime.pid")
+    existing_running = bool(
+        existing_pid and _pid_is_expected(existing_pid, runtime_dir, config_path)
+    )
+    runtime_port = (
+        preferred_port
+        if existing_running or _port_available(preferred_port)
+        else 0
+    )
+
+    hardware_private_dir = hardware_dir / ".blacknode-hardware"
+    hardware_private_dir.mkdir(parents=True, exist_ok=True)
+    hardware_token_path = hardware_private_dir / "auth.token"
+    hardware_token = (
+        hardware_token_path.read_text(encoding="utf-8").strip()
+        if hardware_token_path.is_file()
+        else ""
+    )
+    if len(hardware_token) < 32:
+        hardware_token = secrets.token_urlsafe(32)
+        hardware_token_path.write_text(hardware_token + "\n", encoding="utf-8")
+        try:
+            os.chmod(hardware_token_path, 0o600)
+        except OSError:
+            pass
+    hardware_metadata_path = hardware_private_dir / "editor-managed.json"
+    previous_hardware = _load_json(hardware_metadata_path)
+    preferred_hardware_port = int(previous_hardware.get("hardware_port") or 8765)
+    hardware_pid_file = hardware_private_dir / "hardware.pid"
+    existing_hardware_pid = _read_pid(hardware_pid_file)
+    existing_hardware_running = bool(
+        existing_hardware_pid
+        and _pid_is_hardware(
+            existing_hardware_pid,
+            hardware_dir,
+            hardware_token_path,
+        )
+    )
+    hardware_port = (
+        preferred_hardware_port
+        if existing_hardware_running or _port_available(preferred_hardware_port)
+        else _select_port(8765)
+    )
+    if not runtime_port:
+        runtime_port = _select_port(8766, reserved={hardware_port})
+    if hardware_port == runtime_port:
+        runtime_port = _select_port(runtime_port + 1, reserved={hardware_port})
+
+    state_path = private_dir / "state"
+    config_path.write_text(
+        json.dumps({
+            "device_id": f"{socket.gethostname()}-local",
+            "auth_token_file": str(token_path),
+            "state_dir": str(state_path),
+            "hardware_url": f"http://127.0.0.1:{hardware_port}",
+            "blacknode_root": str(Path(core_root).resolve()),
+        }, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _report(progress, 68, f"Configured Robot Hardware port {hardware_port}")
+    hardware_pid = _spawn_hardware(
+        hardware_dir,
+        hardware_token_path,
+        hardware_port,
+    )
+    hardware_metadata_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "owned_install": hardware_owned,
+            "hardware_port": hardware_port,
+            "pid": hardware_pid,
+            "token_file": str(hardware_token_path),
+            "log_path": str(hardware_private_dir / "hardware.log"),
+            "configured": False,
+        }, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _report(progress, 78, "Verifying safe Robot Hardware state")
+    hardware_status = _wait_for_hardware_status(hardware_port, hardware_token)
+
+    _report(progress, 84, f"Starting local Runtime on port {runtime_port}")
+    pid = _spawn_runtime(runtime_dir, config_path, runtime_port)
+    metadata = {
+        "schema_version": 1,
+        "owned_install": runtime_owned,
+        "runtime_port": runtime_port,
+        "pid": pid,
+        "config_path": str(config_path),
+        "log_path": str(private_dir / "runtime.log"),
+    }
+    metadata_path.write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _report(progress, 94, "Verifying the complete local robot stack")
+    manifest = _wait_for_manifest(runtime_port, token)
+    return {
+        "ok": True,
+        "runtime_token": token,
+        "runtime_url": f"http://127.0.0.1:{runtime_port}",
+        "manifest": manifest,
+        "runtime_port": runtime_port,
+        "runtime_dir": str(runtime_dir),
+        "service_name": "blacknode-runtime-local-process",
+        "instance_id": "local",
+        "stack_mode": "runtime_only",
+        "hardware_dir": str(hardware_dir),
+        "hardware_port": hardware_port,
+        "hardware_service_name": "blacknode-hardware-local-awaiting-device",
+        "hardware_state": "awaiting_device",
+        "hardware_configured": False,
+        "hardware_pid_file": str(hardware_pid_file),
+        "hardware_token_file": str(hardware_token_path),
+        "hardware_log_path": str(hardware_private_dir / "hardware.log"),
+        "hardware_owned_install": hardware_owned,
+        "hardware_status": hardware_status,
+        "management_mode": "local",
+        "config_path": str(config_path),
+        "pid_file": str(private_dir / "runtime.pid"),
+        "log_path": str(private_dir / "runtime.log"),
+        "owned_install": runtime_owned,
+        "elapsed_seconds": round(time.monotonic() - started, 1),
+    }
+
+
+def ensure_local_hardware(managed: dict[str, Any]) -> dict[str, Any]:
+    hardware_dir = Path(str(managed.get("hardware_dir") or "")).expanduser().resolve()
+    token_path = Path(
+        str(managed.get("hardware_token_file") or "")
+    ).expanduser().resolve()
+    port = int(managed.get("hardware_port") or 0)
+    _validate_hardware_checkout(hardware_dir)
+    if token_path.parent != hardware_dir / ".blacknode-hardware" or port < 1:
+        raise LocalRuntimeError("The saved local Robot Hardware identity is incomplete.")
+    token = token_path.read_text(encoding="utf-8").strip()
+    if len(token) < 32:
+        raise LocalRuntimeError("The local Robot Hardware pairing token is invalid.")
+    pid = _spawn_hardware(hardware_dir, token_path, port)
+    status = _wait_for_hardware_status(port, token)
+    return {
+        "ok": True,
+        "state": "active",
+        "hardware_state": "awaiting_device",
+        "service_name": "blacknode-hardware-local-awaiting-device",
+        "pid": pid,
+        "status": status,
+    }
+
+
+def inspect_local_hardware(managed: dict[str, Any]) -> dict[str, Any]:
+    """Inspect the saved Hardware package without starting its service."""
+    hardware_dir = Path(str(managed.get("hardware_dir") or "")).expanduser().resolve()
+    token_path = Path(
+        str(managed.get("hardware_token_file") or "")
+    ).expanduser().resolve()
+    pid_file = Path(
+        str(managed.get("hardware_pid_file") or "")
+    ).expanduser().resolve()
+    port = int(managed.get("hardware_port") or 0)
+    _validate_hardware_checkout(hardware_dir)
+    if (
+        token_path.parent != hardware_dir / ".blacknode-hardware"
+        or pid_file.parent != hardware_dir / ".blacknode-hardware"
+        or port < 1
+    ):
+        raise LocalRuntimeError("The saved local Hardware package identity is incomplete.")
+    installed = _hardware_python(hardware_dir).is_file()
+    pid = _read_pid(pid_file)
+    running = bool(
+        installed
+        and pid
+        and _pid_is_hardware(pid, hardware_dir, token_path)
+    )
+    result: dict[str, Any] = {
+        "ok": running,
+        "kind": "hardware",
+        "state": "running" if running else "stopped",
+        "installed": installed,
+        "installed_version": _checkout_version(hardware_dir),
+        "service_name": "blacknode-hardware-local-awaiting-device",
+        "service_url": f"http://127.0.0.1:{port}",
+        "pid": pid if running else 0,
+    }
+    if not installed:
+        result["error"] = "The Hardware package environment is not installed."
+        return result
+    if not running:
+        result["error"] = "The Hardware package service is stopped."
+        return result
+    try:
+        token = token_path.read_text(encoding="utf-8").strip()
+        result["status"] = _request_hardware_status(port, token)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, LocalRuntimeError) as exc:
+        result["ok"] = False
+        result["state"] = "unreachable"
+        result["error"] = f"The Hardware package service is unreachable: {exc}"
+    return result
+
+
+def stop_local_hardware(managed: dict[str, Any]) -> dict[str, Any]:
+    hardware_dir = Path(str(managed.get("hardware_dir") or "")).expanduser().resolve()
+    token_path = Path(
+        str(managed.get("hardware_token_file") or "")
+    ).expanduser().resolve()
+    pid_file = Path(
+        str(managed.get("hardware_pid_file") or "")
+    ).expanduser().resolve()
+    _validate_hardware_checkout(hardware_dir)
+    if (
+        token_path.parent != hardware_dir / ".blacknode-hardware"
+        or pid_file.parent != hardware_dir / ".blacknode-hardware"
+    ):
+        raise LocalRuntimeError("The saved local Robot Hardware identity is incomplete.")
+    pid = _read_pid(pid_file)
+    if not pid:
+        return {
+            "ok": True,
+            "state": "inactive",
+            "service_name": "blacknode-hardware-local-awaiting-device",
+        }
+    if not _pid_is_hardware(pid, hardware_dir, token_path):
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            pid_file.unlink(missing_ok=True)
+        else:
+            raise LocalRuntimeError(
+                f"Refusing to stop PID {pid}; it is not the saved Robot Hardware process."
+            )
+        return {
+            "ok": True,
+            "state": "inactive",
+            "service_name": "blacknode-hardware-local-awaiting-device",
+        }
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(pid), "/T", "/F"],
+            capture_output=True,
+            timeout=15,
+            check=False,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    else:
+        os.kill(pid, 15)
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                break
+            time.sleep(0.1)
+    pid_file.unlink(missing_ok=True)
+    return {
+        "ok": True,
+        "state": "inactive",
+        "service_name": "blacknode-hardware-local-awaiting-device",
+    }
+
+
+def ensure_local_runtime(managed: dict[str, Any]) -> dict[str, Any]:
+    hardware = None
+    if managed.get("hardware_dir"):
+        hardware = ensure_local_hardware(managed)
+    runtime_dir = Path(str(managed.get("runtime_dir") or "")).expanduser().resolve()
+    config_path = Path(str(managed.get("config_path") or "")).expanduser().resolve()
+    port = int(managed.get("runtime_port") or 0)
+    _validate_runtime_checkout(runtime_dir)
+    if config_path.parent != runtime_dir / ".blacknode-runtime" or port < 1:
+        raise LocalRuntimeError("The saved local Runtime identity is incomplete.")
+    pid = _spawn_runtime(runtime_dir, config_path, port)
+    return {
+        "ok": True,
+        "action": "resume",
+        "state": "active",
+        "service_name": "blacknode-runtime-local-process",
+        "pid": pid,
+        "hardware": hardware,
+    }
+
+
+def inspect_local_runtime(managed: dict[str, Any]) -> dict[str, Any]:
+    """Inspect the saved Runtime package without starting its service."""
+    runtime_dir = Path(str(managed.get("runtime_dir") or "")).expanduser().resolve()
+    config_path = Path(str(managed.get("config_path") or "")).expanduser().resolve()
+    pid_file = Path(str(managed.get("pid_file") or "")).expanduser().resolve()
+    port = int(managed.get("runtime_port") or 0)
+    _validate_runtime_checkout(runtime_dir)
+    if (
+        config_path.parent != runtime_dir / ".blacknode-runtime"
+        or pid_file.parent != runtime_dir / ".blacknode-runtime"
+        or port < 1
+    ):
+        raise LocalRuntimeError("The saved local Runtime package identity is incomplete.")
+    installed = _runtime_python(runtime_dir).is_file()
+    pid = _read_pid(pid_file)
+    running = bool(
+        installed
+        and pid
+        and _pid_is_expected(pid, runtime_dir, config_path)
+    )
+    result: dict[str, Any] = {
+        "ok": running,
+        "kind": "runtime",
+        "state": "running" if running else "stopped",
+        "installed": installed,
+        "installed_version": _checkout_version(runtime_dir),
+        "service_name": "blacknode-runtime-local-process",
+        "service_url": f"http://127.0.0.1:{port}",
+        "pid": pid if running else 0,
+    }
+    if not installed:
+        result["error"] = "The Runtime package environment is not installed."
+        return result
+    if not running:
+        result["error"] = "The Runtime package service is stopped."
+        return result
+    config = _load_json(config_path)
+    token_path = Path(str(config.get("auth_token_file") or "")).expanduser().resolve()
+    try:
+        token = token_path.read_text(encoding="utf-8").strip()
+        result["manifest"] = _request_manifest(port, token)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, LocalRuntimeError) as exc:
+        result["ok"] = False
+        result["state"] = "unreachable"
+        result["error"] = f"The Runtime package service is unreachable: {exc}"
+    return result
+
+
+def _inspect_local_checkout_update(
+    *,
+    checkout_dir: Path,
+    kind: str,
+    service_name: str,
+    port: int,
+) -> dict[str, Any]:
+    component: dict[str, Any] = {
+        "kind": kind,
+        "service_name": service_name,
+        "port": int(port),
+        "installed": {
+            "version": _checkout_version(checkout_dir),
+            "commit": "unknown",
+        },
+        "latest": {"version": "unknown", "commit": "unknown"},
+        "update_available": False,
+        "can_update": False,
+        "dirty": False,
+        "state": "unknown",
+        "error": "",
+    }
+    try:
+        component["installed"]["commit"] = _run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=checkout_dir,
+            timeout=20,
+        ).strip()
+        component["dirty"] = bool(
+            _run(
+                ["git", "status", "--porcelain", "--untracked-files=normal"],
+                cwd=checkout_dir,
+                timeout=20,
+            ).strip()
+        )
+        remote = _run(
+            ["git", "ls-remote", "--symref", "origin", "HEAD"],
+            cwd=checkout_dir,
+            timeout=60,
+        )
+        upstream_ref = ""
+        latest_commit = ""
+        for line in remote.splitlines():
+            if line.startswith("ref:") and line.endswith("\tHEAD"):
+                upstream_ref = line.split()[1]
+            elif line.endswith("\tHEAD"):
+                latest_commit = line.split()[0]
+        if not upstream_ref or not latest_commit:
+            raise LocalRuntimeError("The package origin did not report its default branch.")
+        _run(
+            ["git", "fetch", "--quiet", "origin", upstream_ref],
+            cwd=checkout_dir,
+            timeout=180,
+        )
+        fetched_commit = _run(
+            ["git", "rev-parse", "FETCH_HEAD"],
+            cwd=checkout_dir,
+            timeout=20,
+        ).strip()
+        if fetched_commit:
+            latest_commit = fetched_commit
+        latest_pyproject = _run(
+            ["git", "show", f"{latest_commit}:pyproject.toml"],
+            cwd=checkout_dir,
+            timeout=20,
+        )
+        component["latest"] = {
+            "version": _version_from_pyproject_text(latest_pyproject),
+            "commit": latest_commit,
+        }
+        component["update_available"] = (
+            component["installed"]["commit"] != latest_commit
+        )
+        component["can_update"] = not component["dirty"]
+        if component["dirty"]:
+            component["error"] = (
+                "Local source changes must be committed, stashed, or removed "
+                "before update."
+            )
+    except LocalRuntimeError as exc:
+        component["error"] = str(exc)
+    return component
+
+
+def inspect_local_package_updates(
+    managed: dict[str, Any],
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Compare both local package checkouts with their upstream default branches."""
+    components: list[dict[str, Any]] = []
+    runtime_dir = Path(str(managed.get("runtime_dir") or "")).expanduser().resolve()
+    _validate_runtime_checkout(runtime_dir)
+    runtime_status = inspect_local_runtime(managed)
+    _report(progress, 20, "Checking the Runtime package")
+    runtime_component = _inspect_local_checkout_update(
+        checkout_dir=runtime_dir,
+        kind="runtime",
+        service_name=str(
+            managed.get("service_name") or "blacknode-runtime-local-process"
+        ),
+        port=int(managed.get("runtime_port") or 0),
+    )
+    runtime_component["state"] = runtime_status["state"]
+    runtime_component["reported_version"] = (
+        (runtime_status.get("manifest") or {}).get("runtime_version")
+        or runtime_status["installed_version"]
+    )
+    runtime_component["environment_installed"] = runtime_status["installed"]
+    if not runtime_status["installed"] and not runtime_component["error"]:
+        runtime_component["error"] = (
+            "The Runtime package environment is not installed. Reinstall it to run "
+            "the service."
+        )
+    components.append(runtime_component)
+
+    hardware_value = str(managed.get("hardware_dir") or "").strip()
+    if hardware_value:
+        hardware_dir = Path(hardware_value).expanduser().resolve()
+        _validate_hardware_checkout(hardware_dir)
+        hardware_status = inspect_local_hardware(managed)
+        _report(progress, 55, "Checking the Hardware package")
+        hardware_component = _inspect_local_checkout_update(
+            checkout_dir=hardware_dir,
+            kind="hardware",
+            service_name=str(
+                managed.get("hardware_service_name")
+                or "blacknode-hardware-local-awaiting-device"
+            ),
+            port=int(managed.get("hardware_port") or 0),
+        )
+        hardware_component["state"] = hardware_status["state"]
+        hardware_component["reported_version"] = (
+            (hardware_status.get("status") or {}).get("software_version")
+            or hardware_status["installed_version"]
+        )
+        hardware_component["environment_installed"] = hardware_status["installed"]
+        if not hardware_status["installed"] and not hardware_component["error"]:
+            hardware_component["error"] = (
+                "The Hardware package environment is not installed. Reinstall it to run "
+                "the service."
+            )
+        components.append(hardware_component)
+    return {"ok": not any(item["error"] for item in components), "components": components}
+
+
+def manage_local_package(
+    managed: dict[str, Any],
+    *,
+    kind: str,
+    action: str,
+    core_root: Path,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Run, stop, restart, update, reinstall, or delete one local package environment."""
+    clean_kind = str(kind or "").strip().lower()
+    clean_action = str(action or "").strip().lower()
+    if clean_kind not in {"runtime", "hardware"}:
+        raise LocalRuntimeError("Package must be runtime or hardware.")
+    if clean_action not in {
+        "run", "stop", "restart", "update", "reinstall", "delete",
+    }:
+        raise LocalRuntimeError(
+            "Package action must be run, stop, restart, update, reinstall, or delete."
+        )
+
+    is_runtime = clean_kind == "runtime"
+    checkout_dir = Path(
+        str(managed.get("runtime_dir" if is_runtime else "hardware_dir") or "")
+    ).expanduser().resolve()
+    if is_runtime:
+        _validate_runtime_checkout(checkout_dir)
+        current = inspect_local_runtime(managed)
+    else:
+        _validate_hardware_checkout(checkout_dir)
+        current = inspect_local_hardware(managed)
+    was_active = current.get("state") in {"running", "unreachable"}
+
+    runtime_only_management = dict(managed)
+    runtime_only_management["hardware_dir"] = ""
+
+    def stop_selected() -> None:
+        if is_runtime:
+            stop_local_runtime(runtime_only_management)
+        else:
+            stop_local_hardware(managed)
+
+    def run_selected() -> dict[str, Any]:
+        return (
+            ensure_local_runtime(runtime_only_management)
+            if is_runtime
+            else ensure_local_hardware(managed)
+        )
+
+    if clean_action == "run":
+        _report(progress, 45, f"Starting the {clean_kind.title()} package service")
+        result = run_selected()
+        _report(progress, 100, f"{clean_kind.title()} package service is running")
+        return {"ok": True, "kind": clean_kind, "action": clean_action, "result": result}
+    if clean_action == "stop":
+        _report(progress, 45, f"Stopping the {clean_kind.title()} package service")
+        result = stop_selected()
+        _report(progress, 100, f"{clean_kind.title()} package service is stopped")
+        return {"ok": True, "kind": clean_kind, "action": clean_action, "result": result}
+    if clean_action == "restart":
+        _report(progress, 30, f"Stopping the {clean_kind.title()} package service")
+        stop_selected()
+        _report(progress, 65, f"Starting the {clean_kind.title()} package service")
+        result = run_selected()
+        _report(progress, 100, f"{clean_kind.title()} package service restarted")
+        return {
+            "ok": True,
+            "kind": clean_kind,
+            "action": clean_action,
+            "restarted": True,
+            "result": result,
+        }
+
+    _report(progress, 20, f"Stopping the {clean_kind.title()} package service")
+    stop_selected()
+    environment_dir = checkout_dir / ".venv"
+    if clean_action == "delete":
+        _report(progress, 65, f"Deleting the {clean_kind.title()} package environment")
+        if environment_dir.is_dir():
+            _remove_tree(environment_dir)
+        _report(progress, 100, f"{clean_kind.title()} package environment deleted")
+        return {
+            "ok": True,
+            "kind": clean_kind,
+            "action": clean_action,
+            "source_preserved": True,
+            "configuration_preserved": True,
+        }
+
+    if clean_action == "update":
+        _report(progress, 35, f"Downloading {clean_kind.title()} package updates")
+        component = _inspect_local_checkout_update(
+            checkout_dir=checkout_dir,
+            kind=clean_kind,
+            service_name=str(
+                managed.get("service_name" if is_runtime else "hardware_service_name")
+                or ""
+            ),
+            port=int(
+                managed.get("runtime_port" if is_runtime else "hardware_port") or 0
+            ),
+        )
+        if component["error"]:
+            raise LocalRuntimeError(str(component["error"]))
+        if component["update_available"]:
+            _run(
+                ["git", "merge", "--ff-only", str(component["latest"]["commit"])],
+                cwd=checkout_dir,
+                timeout=180,
+            )
+
+    python = _runtime_python(checkout_dir) if is_runtime else _hardware_python(checkout_dir)
+    if not python.is_file():
+        _report(progress, 55, f"Creating the {clean_kind.title()} package environment")
+        _run([sys.executable, "-m", "venv", str(environment_dir)], timeout=180)
+    _report(progress, 70, f"Installing the {clean_kind.title()} package")
+    _run([str(python), "-m", "pip", "install", "-e", str(checkout_dir)], timeout=900)
+    if is_runtime:
+        _report(progress, 82, "Connecting Runtime to this Blacknode workspace")
+        _run(
+            [str(python), "-m", "pip", "install", "-e", str(Path(core_root).resolve())],
+            timeout=900,
+        )
+    restarted = False
+    if was_active:
+        _report(progress, 92, f"Restarting the {clean_kind.title()} package service")
+        run_selected()
+        restarted = True
+    _report(progress, 100, f"{clean_kind.title()} package {clean_action} complete")
+    return {
+        "ok": True,
+        "kind": clean_kind,
+        "action": clean_action,
+        "restarted": restarted,
+        "installed_version": _checkout_version(checkout_dir),
+    }
+
+
+def stop_local_runtime(managed: dict[str, Any]) -> dict[str, Any]:
+    hardware = None
+    if managed.get("hardware_dir"):
+        hardware = stop_local_hardware(managed)
+    runtime_dir = Path(str(managed.get("runtime_dir") or "")).expanduser().resolve()
+    config_path = Path(str(managed.get("config_path") or "")).expanduser().resolve()
+    pid_file = Path(str(managed.get("pid_file") or "")).expanduser().resolve()
+    _validate_runtime_checkout(runtime_dir)
+    if (
+        config_path.parent != runtime_dir / ".blacknode-runtime"
+        or pid_file.parent != runtime_dir / ".blacknode-runtime"
+    ):
+        raise LocalRuntimeError("The saved local Runtime identity is incomplete.")
+    pid = _read_pid(pid_file)
+    if not pid:
+        return {
+            "ok": True,
+            "action": "pause",
+            "state": "inactive",
+            "service_name": "blacknode-runtime-local-process",
+            "hardware": hardware,
+        }
+    if not _pid_is_expected(pid, runtime_dir, config_path):
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            pid_file.unlink(missing_ok=True)
+        else:
+            raise LocalRuntimeError(
+                f"Refusing to stop PID {pid}; it is not the saved Blacknode Runtime process."
+            )
+        return {
+            "ok": True,
+            "action": "pause",
+            "state": "inactive",
+            "service_name": "blacknode-runtime-local-process",
+            "hardware": hardware,
+        }
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(pid), "/T", "/F"],
+            capture_output=True,
+            timeout=15,
+            check=False,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    else:
+        os.kill(pid, 15)
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                break
+            time.sleep(0.1)
+    pid_file.unlink(missing_ok=True)
+    return {
+        "ok": True,
+        "action": "pause",
+        "state": "inactive",
+        "service_name": "blacknode-runtime-local-process",
+        "hardware": hardware,
+    }
+
+
+def uninstall_local_runtime(
+    managed: dict[str, Any],
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    runtime_dir = Path(str(managed.get("runtime_dir") or "")).expanduser().resolve()
+    hardware_dir_value = str(managed.get("hardware_dir") or "").strip()
+    hardware_dir = (
+        Path(hardware_dir_value).expanduser().resolve()
+        if hardware_dir_value
+        else None
+    )
+    runtime_was_present = runtime_dir.exists()
+    hardware_was_present = hardware_dir is not None and hardware_dir.exists()
+    _report(progress, 25, "Stopping the local Runtime and Robot Hardware")
+    if runtime_was_present:
+        runtime_management = dict(managed)
+        if not hardware_was_present:
+            runtime_management["hardware_dir"] = ""
+        stop_local_runtime(runtime_management)
+    elif hardware_was_present:
+        stop_local_hardware(managed)
+
+    if hardware_dir is not None:
+        _report(progress, 55, "Removing local Robot Hardware files")
+        if bool(managed.get("hardware_owned_install")) and hardware_dir.exists():
+            _validate_hardware_checkout(hardware_dir)
+            if hardware_dir in {
+                Path(hardware_dir.anchor).resolve(),
+                Path.home().resolve(),
+            }:
+                raise LocalRuntimeError("Refusing to remove a broad Robot Hardware path.")
+            _remove_tree(hardware_dir)
+        else:
+            hardware_private_dir = hardware_dir / ".blacknode-hardware"
+            if hardware_private_dir.is_dir():
+                _remove_tree(hardware_private_dir)
+    _report(progress, 75, "Removing local Runtime files")
+    if bool(managed.get("owned_install")) and runtime_dir.exists():
+        _validate_runtime_checkout(runtime_dir)
+        if runtime_dir in {Path(runtime_dir.anchor).resolve(), Path.home().resolve()}:
+            raise LocalRuntimeError("Refusing to remove a broad local Runtime path.")
+        _remove_tree(runtime_dir)
+    else:
+        private_dir = runtime_dir / ".blacknode-runtime"
+        if private_dir.is_dir():
+            _remove_tree(private_dir)
+    return {
+        "ok": True,
+        "instance_id": "local",
+        "runtime_port": int(managed.get("runtime_port") or 0),
+        "already_absent": not runtime_was_present and not hardware_was_present,
+        "stack_mode": "runtime_only",
+        "source_preserved": (
+            not bool(managed.get("owned_install"))
+            or (
+                hardware_dir is not None
+                and not bool(managed.get("hardware_owned_install"))
+            )
+        ),
+    }

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -70,6 +70,18 @@ from device_registry import (
     HardwareDeviceClient,
     RuntimeDeviceClient,
 )
+from local_runtime import (
+    LocalRuntimeError,
+    default_local_runtime_dir,
+    ensure_local_runtime,
+    inspect_local_hardware,
+    inspect_local_package_updates,
+    inspect_local_runtime,
+    install_local_runtime,
+    manage_local_package,
+    stop_local_runtime,
+    uninstall_local_runtime,
+)
 from artifact_store import ArtifactStore, ArtifactStoreError
 from project_store import ProjectStore, ProjectStoreError
 from run_store import RunStore
@@ -264,6 +276,7 @@ class NodeControlReq(BaseModel):
 
 class PickDirectoryReq(BaseModel):
     initial_path: str = ""
+    title: str = ""
 
 class DatasetTrimReq(BaseModel):
     token: str
@@ -438,6 +451,10 @@ class InstallDeviceHostReq(InspectDeviceHostReq):
     action: str = "install"
     instance_id: str = ""
 
+class InstallLocalDeviceHostReq(BaseModel):
+    name: str = "Local computer"
+    install_dir: str
+
 class ConfigureDeviceHostManagementReq(InspectDeviceHostReq):
     pass
 
@@ -451,6 +468,15 @@ class RuntimeLifecycleReq(BaseModel):
 class UpdateManagedDeviceReq(BaseModel):
     password: str
     scope: str = "all"
+    operation: str = "auto"
+
+
+class LocalPackageActionReq(BaseModel):
+    action: str
+
+class RemoteHardwarePackageActionReq(BaseModel):
+    action: str
+    password: str
 
 class RobotLifecycleReq(BaseModel):
     action: str
@@ -1591,7 +1617,7 @@ def control_node(node_id: str, req: NodeControlReq):
     return {"ok": True, "node_id": node_id, "outputs": outputs}
 
 
-def _pick_directory(initial_path: str = "") -> str:
+def _pick_directory(initial_path: str = "", title: str = "") -> str:
     try:
         import tkinter as tk
         from tkinter import filedialog
@@ -1607,7 +1633,7 @@ def _pick_directory(initial_path: str = "") -> str:
         root.update()
         return str(filedialog.askdirectory(
             parent=root,
-            title="Choose a folder that will contain Blacknode datasets",
+            title=str(title or "Choose a folder that will contain Blacknode datasets"),
             initialdir=str(initial),
             mustexist=True,
         ) or "")
@@ -1618,7 +1644,7 @@ def _pick_directory(initial_path: str = "") -> str:
 @app.post("/filesystem/pick-directory")
 def pick_directory(req: PickDirectoryReq):
     try:
-        selected = _pick_directory(req.initial_path)
+        selected = _pick_directory(req.initial_path, req.title)
     except RuntimeError as exc:
         raise HTTPException(503, str(exc)) from exc
     return {"selected": selected, "cancelled": not bool(selected)}
@@ -2916,9 +2942,63 @@ def _device_host_runtime_status(host_id: str) -> dict[str, Any]:
         return {
             "ok": False,
             "paused": True,
+            "state": "stopped",
             "runtime_url": host["runtime_url"],
             "error": "Runtime is paused.",
         }
+    managed = host.get("managed_runtime")
+    if (
+        isinstance(managed, dict)
+        and str(managed.get("management_mode") or "") == "local"
+    ):
+        managed_hardware: dict[str, Any] | None = None
+        if managed.get("hardware_dir"):
+            try:
+                managed_hardware = inspect_local_hardware(managed)
+            except LocalRuntimeError as exc:
+                managed_hardware = {
+                    "ok": False,
+                    "kind": "hardware",
+                    "state": "unavailable",
+                    "installed": False,
+                    "installed_version": "unknown",
+                    "service_url": (
+                        f"http://127.0.0.1:{int(managed.get('hardware_port') or 0)}"
+                    ),
+                    "service_name": str(
+                        managed.get("hardware_service_name")
+                        or "blacknode-hardware-local-awaiting-device"
+                    ),
+                    "error": str(exc),
+                }
+        try:
+            runtime_report = inspect_local_runtime(managed)
+        except LocalRuntimeError as exc:
+            runtime_report = {
+                "ok": False,
+                "kind": "runtime",
+                "state": "unavailable",
+                "installed": False,
+                "installed_version": "unknown",
+                "error": str(exc),
+            }
+        result = {
+            "ok": bool(runtime_report.get("ok")),
+            "runtime_url": host["runtime_url"],
+            "state": str(runtime_report.get("state") or "unavailable"),
+            "installed": bool(runtime_report.get("installed")),
+            "installed_version": str(
+                runtime_report.get("installed_version") or "unknown"
+            ),
+        }
+        manifest = runtime_report.get("manifest")
+        if isinstance(manifest, dict):
+            result["manifest"] = manifest
+        if runtime_report.get("error"):
+            result["error"] = str(runtime_report["error"])
+        if managed_hardware is not None:
+            result["hardware"] = managed_hardware
+        return result
     try:
         manifest = _device_registry.host_client(host_id).manifest()
         if (
@@ -2931,14 +3011,17 @@ def _device_host_runtime_status(host_id: str) -> dict[str, Any]:
     except (DeviceRegistryError, KeyError) as exc:
         return {
             "ok": False,
+            "state": "unreachable",
             "runtime_url": host["runtime_url"],
             "error": str(exc),
         }
-    return {
+    result = {
         "ok": True,
+        "state": "running",
         "runtime_url": host["runtime_url"],
         "manifest": manifest,
     }
+    return result
 
 
 @app.get("/device-hosts")
@@ -2966,6 +3049,105 @@ def pair_device_host(req: PairDeviceHostReq):
         "device": host,
         "runtime": _device_host_runtime_status(host["id"]),
     }
+
+
+@app.get("/device-hosts/local-install-defaults")
+def local_device_host_install_defaults():
+    return {"install_dir": str(default_local_runtime_dir())}
+
+
+def _install_local_device_host_payload(
+    req: InstallLocalDeviceHostReq,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    installed = install_local_runtime(
+        install_dir=req.install_dir,
+        core_root=Path(__file__).resolve().parents[1],
+        progress=progress,
+    )
+    if progress is not None:
+        progress({"progress": 98, "message": "Pairing the local Runtime"})
+    runtime_url = str(installed["runtime_url"])
+    runtime_token = str(installed["runtime_token"])
+    manifest = dict(installed["manifest"])
+    host = _device_registry.pair_host(
+        name=req.name,
+        runtime_url=runtime_url,
+        runtime_token=runtime_token,
+        manifest=manifest,
+        managed_runtime={
+            key: installed[key]
+            for key in (
+                "management_mode",
+                "instance_id",
+                "runtime_port",
+                "service_name",
+                "runtime_dir",
+                "stack_mode",
+                "hardware_dir",
+                "hardware_port",
+                "hardware_service_name",
+                "hardware_state",
+                "hardware_configured",
+                "hardware_pid_file",
+                "hardware_token_file",
+                "hardware_log_path",
+                "hardware_owned_install",
+                "config_path",
+                "pid_file",
+                "log_path",
+                "owned_install",
+            )
+        },
+    )
+    if progress is not None:
+        progress({"progress": 100, "message": "Local computer is ready"})
+    return {
+        "device": host,
+        "runtime": {
+            "ok": True,
+            "runtime_url": runtime_url,
+            "manifest": manifest,
+        },
+        "install": {
+            key: value
+            for key, value in installed.items()
+            if key not in {"runtime_token", "manifest"}
+        },
+    }
+
+
+@app.post("/device-hosts/local-install-stream")
+def install_local_device_host_stream(req: InstallLocalDeviceHostReq):
+    def event_stream():
+        events: queue.Queue[dict[str, Any]] = queue.Queue()
+
+        def worker() -> None:
+            try:
+                result = _install_local_device_host_payload(req, progress=events.put)
+                events.put({"type": "done", "result": result})
+            except (LocalRuntimeError, DeviceRegistryError) as exc:
+                events.put({"type": "error", "error": str(exc)})
+            except Exception as exc:
+                events.put({
+                    "type": "error",
+                    "error": f"Local Runtime installation failed: {exc}",
+                })
+
+        threading.Thread(
+            target=worker,
+            name="blacknode-local-runtime-install",
+            daemon=True,
+        ).start()
+        while True:
+            event = events.get()
+            if "type" not in event:
+                event = {"type": "progress", **event}
+            yield json.dumps(event, separators=(",", ":")) + "\n"
+            if event.get("type") in {"done", "error"}:
+                break
+
+    return StreamingResponse(event_stream(), media_type="application/x-ndjson")
 
 
 @app.post("/device-hosts/ssh-probe")
@@ -3030,6 +3212,8 @@ def _install_device_host_payload(
             "runtime_port": runtime_port,
             "service_name": installed["service_name"],
             "runtime_dir": installed["runtime_dir"],
+            "stack_mode": installed.get("stack_mode", "runtime_only"),
+            "hardware_dir": installed.get("hardware_dir", ""),
         },
     )
     if progress is not None:
@@ -3326,15 +3510,22 @@ def _control_device_host_lifecycle_payload(
                 )
 
     report(70, f"{'Stopping' if action == 'pause' else 'Starting'} the runtime service")
-    runtime = control_runtime(
-        host=str(managed.get("ssh_host") or ""),
-        port=int(managed.get("ssh_port") or 22),
-        username=str(managed.get("ssh_username") or ""),
-        password=req.password,
-        host_fingerprint=str(managed.get("host_fingerprint") or ""),
-        instance_id=str(managed.get("instance_id") or "default"),
-        action=action,
-    )
+    if str(managed.get("management_mode") or "") == "local":
+        runtime = (
+            stop_local_runtime(managed)
+            if action == "pause"
+            else ensure_local_runtime(managed)
+        )
+    else:
+        runtime = control_runtime(
+            host=str(managed.get("ssh_host") or ""),
+            port=int(managed.get("ssh_port") or 22),
+            username=str(managed.get("ssh_username") or ""),
+            password=req.password,
+            host_fingerprint=str(managed.get("host_fingerprint") or ""),
+            instance_id=str(managed.get("instance_id") or "default"),
+            action=action,
+        )
 
     if action == "resume":
         robots = list(host.get("robots") or [])
@@ -3396,7 +3587,12 @@ def _lifecycle_stream(worker: Callable[[Callable[[dict[str, Any]], None]], dict[
                 events.put({"type": "done", "result": worker(events.put)})
             except HTTPException as exc:
                 events.put({"type": "error", "error": str(exc.detail)})
-            except (DeviceInstallError, DeviceRegistryError, KeyError) as exc:
+            except (
+                DeviceInstallError,
+                DeviceRegistryError,
+                LocalRuntimeError,
+                KeyError,
+            ) as exc:
                 events.put({"type": "error", "error": str(exc)})
             except Exception as exc:
                 events.put({"type": "error", "error": f"Lifecycle action failed: {exc}"})
@@ -3424,6 +3620,159 @@ def stream_device_host_lifecycle(host_id: str, req: RuntimeLifecycleReq):
     )
 
 
+def _manage_local_package_payload(
+    host_id: str,
+    kind: str,
+    req: LocalPackageActionReq,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    host = _device_registry.get_host_public(host_id)
+    if host is None:
+        raise HTTPException(404, "Device not found")
+    managed = host.get("managed_runtime")
+    if (
+        not isinstance(managed, dict)
+        or str(managed.get("management_mode") or "") != "local"
+    ):
+        raise HTTPException(409, "Package controls are available for local devices.")
+    clean_kind = str(kind or "").strip().lower()
+    clean_action = str(req.action or "").strip().lower()
+    result = manage_local_package(
+        managed,
+        kind=clean_kind,
+        action=clean_action,
+        core_root=Path(__file__).resolve().parents[1],
+        progress=progress,
+    )
+    return {
+        "ok": True,
+        "kind": clean_kind,
+        "action": clean_action,
+        "package": result,
+        "runtime": _device_host_runtime_status(host_id),
+    }
+
+
+@app.post("/device-hosts/{host_id}/local-packages/{kind}/action-stream")
+def stream_local_package_action(
+    host_id: str,
+    kind: str,
+    req: LocalPackageActionReq,
+):
+    return _lifecycle_stream(
+        lambda progress: _manage_local_package_payload(
+            host_id,
+            kind,
+            req,
+            progress,
+        )
+    )
+
+
+def _manage_remote_hardware_package_payload(
+    host_id: str,
+    req: RemoteHardwarePackageActionReq,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    def report(percent: int, message: str) -> None:
+        if progress is not None:
+            progress({"progress": percent, "message": message})
+
+    host = _device_registry.get_host_public(host_id)
+    if host is None:
+        raise HTTPException(404, "Device not found")
+    managed = host.get("managed_runtime")
+    if not isinstance(managed, dict) or str(managed.get("management_mode") or "") == "local":
+        raise HTTPException(409, "Remote Hardware package controls require verified SSH management.")
+    action = str(req.action or "").strip().lower()
+    if action not in {"run", "stop", "restart"}:
+        raise HTTPException(400, "Hardware package action must be run, stop, or restart.")
+    if not str(req.password or ""):
+        raise HTTPException(400, "Enter the SSH password to control the Hardware package.")
+    robots = list(host.get("robots") or [])
+    if not robots:
+        raise HTTPException(409, "Attach a robot before controlling the remote Hardware package.")
+
+    service_action = {"run": "start", "stop": "stop", "restart": "restart"}[action]
+    services: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for index, robot in enumerate(robots):
+        robot_id = str(robot.get("id") or "")
+        robot_name = str(robot.get("name") or robot_id or "Robot")
+        if not robot_id:
+            continue
+        if action in {"stop", "restart"}:
+            report(
+                5 + int(index * 35 / max(1, len(robots))),
+                f"Stopping deployments and disarming {robot_name}",
+            )
+            try:
+                _control_robot_lifecycle_payload(
+                    robot_id,
+                    RobotLifecycleReq(action="pause"),
+                )
+            except (DeviceRegistryError, HTTPException, KeyError) as exc:
+                detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
+                raise HTTPException(
+                    409,
+                    f"{robot_name} could not confirm deployment stop and disarm before "
+                    f"service control: {detail}",
+                ) from exc
+        try:
+            hardware_port = urllib.parse.urlsplit(str(robot.get("base_url") or "")).port
+        except ValueError as exc:
+            raise HTTPException(409, f"{robot_name} has an invalid hardware service URL.") from exc
+        if not hardware_port:
+            raise HTTPException(409, f"{robot_name} has no hardware service port.")
+        report(
+            40 + int(index * 50 / max(1, len(robots))),
+            f"{'Stopping' if service_action == 'stop' else service_action.title() + 'ing'} "
+            f"{robot_name} Hardware service",
+        )
+        services.append(restart_hardware_service(
+            host=str(managed.get("ssh_host") or ""),
+            port=int(managed.get("ssh_port") or 22),
+            username=str(managed.get("ssh_username") or ""),
+            password=req.password,
+            host_fingerprint=str(managed.get("host_fingerprint") or ""),
+            hardware_port=hardware_port,
+            action=service_action,
+        ))
+        _device_registry.set_device_paused(robot_id, action == "stop")
+
+    hardware_state = "stopped" if action == "stop" else "running"
+    device = _device_registry.set_host_management(
+        host_id,
+        {**managed, "hardware_state": hardware_state},
+    )
+    summary = (
+        f"Hardware package {hardware_state} across {len(services)} robot service"
+        f"{'' if len(services) == 1 else 's'}; motion remains disarmed."
+    )
+    if warnings:
+        summary += f" Completed with {len(warnings)} safety warning{'' if len(warnings) == 1 else 's'}."
+    report(100, summary)
+    return {
+        "ok": True,
+        "action": action,
+        "state": hardware_state,
+        "services": services,
+        "device": device,
+        "warnings": warnings,
+        "summary": summary,
+    }
+
+
+@app.post("/device-hosts/{host_id}/hardware-package/action-stream")
+def stream_remote_hardware_package_action(
+    host_id: str,
+    req: RemoteHardwarePackageActionReq,
+):
+    return _lifecycle_stream(
+        lambda progress: _manage_remote_hardware_package_payload(host_id, req, progress)
+    )
+
+
 def _update_device_host_payload(
     host_id: str,
     req: UpdateManagedDeviceReq,
@@ -3436,8 +3785,6 @@ def _update_device_host_payload(
                 "message": str(message),
             })
 
-    if not str(req.password or ""):
-        raise HTTPException(400, "Enter the SSH password to update this device.")
     scope = str(req.scope or "all").strip().lower()
     if scope not in {"all", "runtime", "hardware"}:
         raise HTTPException(400, "Update scope must be all, runtime, or hardware.")
@@ -3450,6 +3797,106 @@ def _update_device_host_payload(
             409,
             "Enable SSH controls for this device before updating its services.",
         )
+    if str(managed.get("management_mode") or "") == "local":
+        operation = str(req.operation or "auto").strip().lower()
+        if operation not in {"auto", "update", "reinstall"}:
+            raise HTTPException(
+                400,
+                "Local package operation must be update or reinstall.",
+            )
+        before_report = inspect_local_package_updates(managed)
+        before_components = {
+            str(item.get("kind") or ""): item
+            for item in before_report.get("components") or []
+            if isinstance(item, dict)
+        }
+        kinds = ["runtime", "hardware"] if scope == "all" else [scope]
+        results: list[dict[str, Any]] = []
+        for index, kind in enumerate(kinds):
+            before = before_components.get(kind)
+            if before is None:
+                raise HTTPException(409, f"The local {kind.title()} package is unavailable.")
+            selected_operation = (
+                "update"
+                if operation == "auto" and before.get("update_available")
+                else "reinstall"
+                if operation == "auto"
+                else operation
+            )
+            report(
+                10 + int(index * 75 / max(1, len(kinds))),
+                f"{selected_operation.title()}ing the local {kind.title()} package",
+            )
+            package_result = manage_local_package(
+                managed,
+                kind=kind,
+                action=selected_operation,
+                core_root=Path(__file__).resolve().parents[1],
+                progress=lambda value, offset=index: report(
+                    10
+                    + int(offset * 75 / max(1, len(kinds)))
+                    + int(
+                        int(value.get("progress") or 0)
+                        * 70
+                        / max(1, len(kinds))
+                        / 100
+                    ),
+                    str(value.get("message") or "Managing local package"),
+                ),
+            )
+            results.append(package_result)
+        after_report = inspect_local_package_updates(managed)
+        after_components = {
+            str(item.get("kind") or ""): item
+            for item in after_report.get("components") or []
+            if isinstance(item, dict)
+        }
+        update_components: list[dict[str, Any]] = []
+        for kind in kinds:
+            before = before_components[kind]
+            after = after_components.get(kind, before)
+            update_components.append({
+                "kind": kind,
+                "service_name": str(after.get("service_name") or ""),
+                "port": int(after.get("port") or 0),
+                "before": dict(before.get("installed") or {}),
+                "after": dict(after.get("installed") or {}),
+                "reported_version": str(
+                    after.get("reported_version")
+                    or (after.get("installed") or {}).get("version")
+                    or "unknown"
+                ),
+                "changed": (
+                    (before.get("installed") or {}).get("commit")
+                    != (after.get("installed") or {}).get("commit")
+                ),
+                "state": str(after.get("state") or "unknown"),
+            })
+        device = _device_registry.get_host_public(host_id)
+        summary = (
+            f"Local {' + '.join(kind.title() for kind in kinds)} package "
+            f"{'operation' if len(kinds) == 1 else 'operations'} completed."
+        )
+        report(100, summary)
+        return {
+            "ok": True,
+            "scope": scope,
+            "device": device,
+            "update": {"ok": True, "components": update_components},
+            "runtime": (
+                inspect_local_runtime(managed).get("manifest")
+                if str(managed.get("runtime_dir") or "")
+                else {}
+            ) or {},
+            "robots": [],
+            "stopped_deployments": [],
+            "controlled_robots": [],
+            "warnings": [],
+            "summary": summary,
+            "packages": results,
+        }
+    if not str(req.password or ""):
+        raise HTTPException(400, "Enter the SSH password to update this device.")
 
     robots = list(host.get("robots") or [])
     hardware_ports: list[int] = []
@@ -3564,6 +4011,7 @@ def _update_device_host_payload(
                 for hardware_port in selected_hardware_ports
             },
             include_runtime=include_runtime,
+            stack_mode=str(managed.get("stack_mode") or "runtime_only"),
             progress=lambda value: report(
                 15 + int(int(value.get("progress") or 0) * 0.75),
                 str(value.get("message") or "Updating managed services"),
@@ -3747,8 +4195,6 @@ def _check_device_host_updates_payload(
                 "message": str(message),
             })
 
-    if not str(req.password or ""):
-        raise HTTPException(400, "Enter the SSH password to check software versions.")
     host = _device_registry.get_host_public(host_id)
     if host is None:
         raise HTTPException(404, "Device not found")
@@ -3758,6 +4204,42 @@ def _check_device_host_updates_payload(
             409,
             "Enable SSH controls for this device before checking upstream versions.",
         )
+    if str(managed.get("management_mode") or "") == "local":
+        report(8, "Checking local Runtime and Hardware packages")
+        checked = inspect_local_package_updates(
+            managed,
+            progress=lambda value: report(
+                10 + int(int(value.get("progress") or 0) * 0.8),
+                str(value.get("message") or "Comparing package versions"),
+            ),
+        )
+        components = [
+            item for item in checked.get("components") or []
+            if isinstance(item, dict)
+        ]
+        available = sum(1 for item in components if item.get("update_available"))
+        blockers = sum(1 for item in components if item.get("error"))
+        if blockers:
+            summary = (
+                f"Checked {len(components)} packages; {blockers} "
+                f"{'needs' if blockers == 1 else 'need'} attention."
+            )
+        elif available:
+            summary = (
+                f"{available} of {len(components)} packages "
+                f"{'has' if available == 1 else 'have'} updates available."
+            )
+        else:
+            summary = f"All {len(components)} local packages are current."
+        report(100, summary)
+        return {
+            "ok": blockers == 0,
+            "check": checked,
+            "warnings": [],
+            "summary": summary,
+        }
+    if not str(req.password or ""):
+        raise HTTPException(400, "Enter the SSH password to check software versions.")
 
     robots = list(host.get("robots") or [])
     hardware_ports: list[int] = []
@@ -3838,19 +4320,31 @@ def _check_device_host_updates_payload(
         item for item in checked.get("components") or []
         if isinstance(item, dict)
     ]
+    includes_hardware = any(
+        item.get("kind") == "hardware" for item in components
+    )
+    target_label = "Runtime + Hardware" if includes_hardware else "Runtime"
     available = sum(1 for item in components if item.get("update_available"))
     blockers = sum(1 for item in components if item.get("error"))
     if blockers:
         summary = (
-            f"Checked {len(components)} services; {blockers} need attention before "
-            "Runtime + Hardware can be updated."
+            f"Checked {len(components)} service"
+            f"{'s' if len(components) != 1 else ''}; {blockers} "
+            f"{'needs' if blockers == 1 else 'need'} attention before "
+            f"{target_label} can be updated."
         )
     elif available:
         summary = (
-            f"{available} of {len(components)} services have updates available."
+            f"{available} of {len(components)} service"
+            f"{'s' if len(components) != 1 else ''} "
+            f"{'has' if len(components) == 1 else 'have'} updates available."
+        )
+    elif includes_hardware:
+        summary = (
+            f"Runtime + Hardware are current across {len(components)} services."
         )
     else:
-        summary = f"Runtime + Hardware are current across {len(components)} services."
+        summary = "Runtime is current."
     if warnings:
         summary += (
             f" {len(warnings)} live service check"
@@ -4042,8 +4536,19 @@ def _control_robot_lifecycle_payload(
     }
 
 
-@app.post("/device-hosts/{host_id}/uninstall")
-def uninstall_device_host(host_id: str, req: UninstallDeviceHostReq):
+def _uninstall_device_host_payload(
+    host_id: str,
+    req: UninstallDeviceHostReq,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    def report(percent: int, message: str) -> None:
+        if progress is not None:
+            progress({
+                "progress": max(0, min(100, int(percent))),
+                "message": str(message),
+            })
+
+    report(3, "Loading the managed device")
     try:
         host = _device_registry.get_host_public(host_id)
     except DeviceRegistryError as exc:
@@ -4058,25 +4563,57 @@ def uninstall_device_host(host_id: str, req: UninstallDeviceHostReq):
             "installation identity. Remove it from the editor or uninstall it on the device.",
         )
     try:
-        result = uninstall_runtime(
-            host=str(managed.get("ssh_host") or ""),
-            port=int(managed.get("ssh_port") or 22),
-            username=str(managed.get("ssh_username") or ""),
-            password=req.password,
-            host_fingerprint=str(managed.get("host_fingerprint") or ""),
-            instance_id=str(managed.get("instance_id") or "default"),
-            runtime_port=int(managed.get("runtime_port") or 0),
-        )
+        if str(managed.get("management_mode") or "") == "local":
+            result = uninstall_local_runtime(managed, progress=progress)
+        else:
+            result = uninstall_runtime(
+                host=str(managed.get("ssh_host") or ""),
+                port=int(managed.get("ssh_port") or 22),
+                username=str(managed.get("ssh_username") or ""),
+                password=req.password,
+                host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                instance_id=str(managed.get("instance_id") or "default"),
+                runtime_port=int(managed.get("runtime_port") or 0),
+                stack_mode=str(managed.get("stack_mode") or "runtime_only"),
+                progress=progress,
+            )
+        report(97, "Removing the saved device registration")
         _device_registry.delete_host(host_id, cascade=True)
-    except DeviceInstallError as exc:
+    except (DeviceInstallError, LocalRuntimeError) as exc:
         raise HTTPException(400, str(exc)) from exc
     except DeviceRegistryError as exc:
         raise HTTPException(409, str(exc)) from exc
+    summary = (
+        (
+            "Local robot stack uninstalled"
+            if managed.get("hardware_dir")
+            else "Local Runtime uninstalled"
+        )
+        if str(managed.get("management_mode") or "") == "local"
+        else
+        "Isolated robot stack uninstalled"
+        if str(managed.get("stack_mode") or "runtime_only") == "isolated"
+        else "Runtime uninstalled"
+    )
+    report(100, summary)
     return {
         "ok": True,
         "id": host_id,
         "uninstall": result,
+        "summary": summary,
     }
+
+
+@app.post("/device-hosts/{host_id}/uninstall")
+def uninstall_device_host(host_id: str, req: UninstallDeviceHostReq):
+    return _uninstall_device_host_payload(host_id, req)
+
+
+@app.post("/device-hosts/{host_id}/uninstall-stream")
+def uninstall_device_host_stream(host_id: str, req: UninstallDeviceHostReq):
+    return _lifecycle_stream(
+        lambda progress: _uninstall_device_host_payload(host_id, req, progress)
+    )
 
 
 @app.post("/device-hosts/{host_id}/robots")
@@ -4152,11 +4689,13 @@ def _device_runtime_status(device_id: str) -> dict[str, Any]:
     except (DeviceRegistryError, KeyError) as exc:
         return {
             "ok": False,
+            "state": "unreachable",
             "runtime_url": device["runtime_url"],
             "error": str(exc),
         }
     return {
         "ok": True,
+        "state": "running",
         "runtime_url": device["runtime_url"],
         "manifest": manifest,
     }
@@ -5458,6 +5997,12 @@ def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
     """Report running deployments separately from physical motion ownership."""
     client = _paired_device_client(device_id)
     status = client.status()
+    status = {
+        **status,
+        "connection_state": (
+            "connected" if bool(status.get("connected")) else "disconnected"
+        ),
+    }
     saved_device = _device_registry.get_public(device_id)
     reported_version = str(status.get("software_version") or "").strip()
     saved_version = str((saved_device or {}).get("software_version") or "").strip()
@@ -5486,7 +6031,8 @@ def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
     )
 
     try:
-        payload = _device_registry.runtime_client(device_id).list_deployments()
+        runtime_client = _device_registry.runtime_client(device_id)
+        payload = runtime_client.list_deployments()
     except (DeviceRegistryError, KeyError, AttributeError, TypeError):
         return status
     deployments = [
@@ -5512,12 +6058,61 @@ def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
         }
         if hardware_is_leased:
             result["deployment_lease"] = deployment
-            result.pop("error", None)
-            result["notice"] = (
-                f"Running deployment '{owner.get('name') or owner.get('id')}' "
-                "controls this robot. Device checks are paused here to prevent "
-                "another process from opening the same hardware connection."
+            connection_present = status.get("connection_present")
+            presence_reported = isinstance(connection_present, bool)
+            result["connected"] = bool(connection_present) if presence_reported else False
+            result["connection_state"] = (
+                "connected" if result["connected"] else "disconnected"
             )
+            result["connection_reported"] = presence_reported
+            connection_source = "device_path" if presence_reported else ""
+            telemetry_message = ""
+            try:
+                telemetry = runtime_client.deployment_telemetry(deployment["id"])
+                telemetry_payload = telemetry.get("payload")
+                telemetry_message = str(telemetry.get("message") or "").strip()
+                telemetry_connected = (
+                    telemetry_payload.get("connected")
+                    if isinstance(telemetry_payload, dict)
+                    else None
+                )
+                if (
+                    bool(telemetry.get("available"))
+                    and not bool(telemetry.get("stale"))
+                    and isinstance(telemetry_connected, bool)
+                ):
+                    result["connected"] = telemetry_connected
+                    result["connection_reported"] = True
+                    result["connection_source"] = "deployment_telemetry"
+                    connection_source = "deployment_telemetry"
+                    result["connection_state"] = (
+                        "connected" if telemetry_connected else "disconnected"
+                    )
+            except (DeviceRegistryError, AttributeError, TypeError) as exc:
+                telemetry_message = str(exc)
+            result.pop("error", None)
+            if not result["connection_reported"]:
+                result["notice"] = (
+                    f"Running deployment '{owner.get('name') or owner.get('id')}' "
+                    "did not report a fresh hardware connection, so Blacknode treats "
+                    "the robot as disconnected."
+                    + (f" {telemetry_message}" if telemetry_message else "")
+                    + " Stop the deployment, then check the device to verify a "
+                    "physical disconnect."
+                )
+            elif connection_source == "device_path":
+                result["notice"] = (
+                    f"Running deployment '{owner.get('name') or owner.get('id')}' "
+                    f"controls this robot. Its configured serial device path is "
+                    f"{'present' if result['connected'] else 'missing'}; this check "
+                    "does not open or compete for the serial port."
+                )
+            else:
+                result["notice"] = (
+                    f"Running deployment '{owner.get('name') or owner.get('id')}' "
+                    "controls this robot. Connection state comes from its fresh "
+                    "deployment telemetry."
+                )
         else:
             result["running_deployment"] = deployment
             result["notice"] = (
@@ -5554,7 +6149,7 @@ def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
     if stored:
         deployment = stored[0]
         result = dict(status)
-        result["stored_deployment"] = {
+        inactive_deployment = {
             "id": str(deployment.get("id") or ""),
             "name": str(
                 deployment.get("name")
@@ -5563,15 +6158,31 @@ def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
             ),
             "state": str(deployment.get("state") or "stopped"),
         }
-        result["notice"] = (
-            f"Deployment '{deployment.get('name') or deployment.get('id')}' "
-            f"is stored on the Runtime in the "
-            f"{deployment.get('state') or 'stopped'} state"
-            + (
-                ". Resume this robot before restarting it."
-                if paused
-                else " and can be restarted."
+        # Keep the old field as a compatibility alias for existing clients.
+        result["inactive_deployment"] = inactive_deployment
+        result["stored_deployment"] = inactive_deployment
+        deployment_name = str(
+            deployment.get("name") or deployment.get("id") or "Deployment"
+        )
+        deployment_state = str(deployment.get("state") or "stopped")
+        state_detail = {
+            "stopped": "stopped",
+            "exited": "completed",
+            "failed": "failed",
+            "staged": "ready to start",
+        }.get(deployment_state, f"inactive ({deployment_state})")
+        next_action = (
+            "Resume this robot before restarting it."
+            if paused
+            else (
+                "Review its details before restarting it."
+                if deployment_state == "failed"
+                else "It can be restarted."
             )
+        )
+        result["notice"] = (
+            f"Deployment '{deployment_name}' is {state_detail} on the Runtime. "
+            f"{next_action}"
         )
         return result
 

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -11,6 +11,7 @@ import { LIVE_STREAM_NODE_TYPES } from './liveNodeTypes'
 import ValueNode from './components/ValueNode'
 import ModelNode from './components/ModelNode'
 import OutputNode from './components/OutputNode'
+import RobotMonitorNode from './components/RobotMonitorNode'
 import SubnetNode from './components/SubnetNode'
 import SubnetBreadcrumb from './components/SubnetBreadcrumb'
 import SubgraphInputNode from './components/SubgraphInputNode'
@@ -30,6 +31,7 @@ const NODE_TYPES = {
   valuenode: ValueNode,
   modelnode: ModelNode,
   outputnode: OutputNode,
+  robotmonitor: RobotMonitorNode,
   subnetnode: SubnetNode,
   subnetinput: SubgraphInputNode,
   subnetoutput: SubgraphOutputNode,
@@ -527,6 +529,86 @@ export default function App() {
     window.addEventListener('blacknode:fit-view', handler)
     return () => window.removeEventListener('blacknode:fit-view', handler)
   }, [fitCurrentCanvas])
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        robotId?: string
+        robotName?: string
+      }>).detail
+      const robotId = String(detail?.robotId || '').trim()
+      const robotName = String(detail?.robotName || '').trim()
+      if (!robotId) return
+
+      void (async () => {
+        try {
+          if (!useStore.getState().nodeTypes.includes('RobotMonitor')) {
+            window.dispatchEvent(new CustomEvent('blacknode:open-panel', {
+              detail: { tab: 'packages' },
+            }))
+            window.dispatchEvent(new CustomEvent('blacknode:notice', {
+              detail: {
+                kind: 'info',
+                title: 'Robot package required',
+                message: 'Install or reload blacknode-robot to add the Robot Monitor node.',
+              },
+            }))
+            return
+          }
+          window.dispatchEvent(new CustomEvent('blacknode:close-panel'))
+          let target = useStore.getState().nodes.find(node => (
+            node.data.type === 'RobotMonitor'
+            && String(node.data.params?.robot_id || '') === robotId
+          ))
+          if (!target) {
+            const before = new Set(useStore.getState().nodes.map(node => node.id))
+            const position = rfInstance.current?.screenToFlowPosition({
+              x: window.innerWidth / 2,
+              y: window.innerHeight / 2,
+            }) ?? { x: 120, y: 100 }
+            await addNode('RobotMonitor', position, {
+              robot_id: robotId,
+              robot_name: robotName,
+            })
+            target = useStore.getState().nodes.find(node => (
+              !before.has(node.id) && node.data.type === 'RobotMonitor'
+            ))
+          } else if (robotName && target.data.params?.robot_name !== robotName) {
+            await updateParam(target.id, 'robot_name', robotName)
+            target = useStore.getState().nodes.find(node => node.id === target?.id) ?? target
+          }
+          if (!target) throw new Error('The Robot Monitor node was not created.')
+
+          const live = useStore.getState()
+          live.onNodesChange(live.nodes.map(node => ({
+            id: node.id,
+            type: 'select' as const,
+            selected: node.id === target?.id,
+          })))
+          selectNode(target.id)
+          window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(() => {
+              rfInstance.current?.setCenter(
+                target!.position.x + 380,
+                target!.position.y + 240,
+                { zoom: 0.9, duration: 320 },
+              )
+            })
+          })
+        } catch (error) {
+          window.dispatchEvent(new CustomEvent('blacknode:notice', {
+            detail: {
+              kind: 'error',
+              title: 'Monitor could not open',
+              message: error instanceof Error ? error.message : String(error),
+            },
+          }))
+        }
+      })()
+    }
+    window.addEventListener('blacknode:monitor-robot', handler)
+    return () => window.removeEventListener('blacknode:monitor-robot', handler)
+  }, [addNode, selectNode, updateParam])
 
   const importWorkflowFile = useCallback(async (file: File) => {
     if (importingFile) return

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -118,14 +118,29 @@ export interface ComputeDevice {
   updated_at: string
   robots: HardwareDevice[]
   managed_runtime?: {
-    ssh_host: string
-    ssh_port: number
-    ssh_username: string
-    host_fingerprint: string
+    management_mode?: 'ssh' | 'local'
+    ssh_host?: string
+    ssh_port?: number
+    ssh_username?: string
+    host_fingerprint?: string
     instance_id: string
     runtime_port: number
     service_name: string
     runtime_dir: string
+    stack_mode?: 'runtime_only' | 'isolated'
+    hardware_dir?: string
+    hardware_port?: number
+    hardware_service_name?: string
+    hardware_state?: 'awaiting_device' | 'configured' | 'running' | 'stopped'
+    hardware_configured?: boolean
+    hardware_pid_file?: string
+    hardware_token_file?: string
+    hardware_log_path?: string
+    hardware_owned_install?: boolean
+    config_path?: string
+    pid_file?: string
+    log_path?: string
+    owned_install?: boolean
   }
 }
 
@@ -204,6 +219,9 @@ export interface SshRuntimeInspection {
 export interface DeviceRuntimeStatus {
   ok: boolean
   paused?: boolean
+  state?: 'running' | 'stopped' | 'unreachable' | 'unavailable' | string
+  installed?: boolean
+  installed_version?: string
   runtime_url: string
   manifest?: {
     service?: string
@@ -211,6 +229,16 @@ export interface DeviceRuntimeStatus {
     runtime_version?: string
     device_id?: string
     [key: string]: unknown
+  }
+  hardware?: {
+    ok: boolean
+    service_url: string
+    service_name: string
+    state: 'awaiting_device' | 'configured' | string
+    installed?: boolean
+    installed_version?: string
+    status?: HardwareDeviceStatus
+    error?: string
   }
   error?: string
 }
@@ -221,6 +249,10 @@ export interface HardwareDeviceStatus {
   software_version_cached?: boolean
   service_features?: string[]
   connected: boolean
+  connection_state?: 'connected' | 'disconnected'
+  connection_reported?: boolean
+  connection_present?: boolean
+  connection_source?: 'device_path' | 'deployment_telemetry' | string
   armed: boolean
   torque_enabled?: boolean
   torque_report_error?: string
@@ -254,6 +286,11 @@ export interface HardwareDeviceStatus {
     state: string
   }
   stored_deployment?: {
+    id: string
+    name: string
+    state: string
+  }
+  inactive_deployment?: {
     id: string
     name: string
     state: string
@@ -350,7 +387,7 @@ export interface ManagedServiceUpdateResult {
   device: ComputeDevice
   update: {
     ok: boolean
-    host_fingerprint: string
+    host_fingerprint?: string
     components: Array<{
       kind: 'runtime' | 'hardware'
       service_name: string
@@ -396,6 +433,7 @@ export interface ManagedServiceUpdateCheckResult {
       dirty: boolean
       state: string
       error: string
+      environment_installed?: boolean
     }>
   }
   warnings: string[]
@@ -420,13 +458,20 @@ export interface InstallComputeDeviceResult {
   runtime: DeviceRuntimeStatus
   install: {
     ok: boolean
-    host_fingerprint: string
+    host_fingerprint?: string
     elapsed_seconds: number
-    action: string
+    action?: string
     instance_id: string
     runtime_port: number
     service_name: string
     runtime_dir: string
+    stack_mode?: 'runtime_only' | 'isolated'
+    hardware_dir?: string
+    management_mode?: 'ssh' | 'local'
+    config_path?: string
+    pid_file?: string
+    log_path?: string
+    owned_install?: boolean
   }
 }
 
@@ -1040,8 +1085,12 @@ export const api = {
     req('PATCH', `/nodes/${id}/params`, { key, value }, 10000),
   controlNode:(id: string, action: string) =>
     req<{ ok: boolean; node_id: string; outputs: Record<string, unknown> }>('POST', `/nodes/${id}/control`, { action }),
-  pickDirectory:(initialPath = '') =>
-    req<{ selected: string; cancelled: boolean }>('POST', '/filesystem/pick-directory', { initial_path: initialPath }),
+  pickDirectory:(initialPath = '', title = '') =>
+    req<{ selected: string; cancelled: boolean }>(
+      'POST',
+      '/filesystem/pick-directory',
+      { initial_path: initialPath, title },
+    ),
   datasetFrame:(token: string, index: number) =>
     req<Record<string, unknown>>('GET', `/dataset/frame/${encodeURIComponent(token)}?index=${Math.max(0, Math.floor(index))}`),
   trimDatasetEpisode:(token: string, frameIndex: number, side: 'before' | 'after') =>
@@ -1107,6 +1156,18 @@ export const api = {
       { name, runtime_url: runtimeUrl, runtime_token: runtimeToken },
       10000,
     ),
+  localComputeDeviceInstallDefaults: () =>
+    req<{ install_dir: string }>('GET', '/device-hosts/local-install-defaults'),
+  installLocalComputeDevice: (
+    name: string,
+    installDir: string,
+    onProgress: (progress: DeviceInstallProgress) => void = () => {},
+  ) =>
+    streamDeviceAction<InstallComputeDeviceResult>(
+      '/device-hosts/local-install-stream',
+      { name, install_dir: installDir },
+      onProgress,
+    ),
   probeComputeDeviceSsh: (
     host: string,
     port: number,
@@ -1168,7 +1229,7 @@ export const api = {
     username: string,
     password: string,
     hostFingerprint: string,
-    action: 'install' | 'reuse' | 'replace' | 'side_by_side',
+    action: 'install' | 'reuse' | 'replace' | 'side_by_side' | 'isolated_stack',
     instanceId: string,
     onProgress: (progress: DeviceInstallProgress) => void = () => {},
   ) =>
@@ -1214,12 +1275,20 @@ export const api = {
       'DELETE',
       `/device-hosts/${encodeURIComponent(id)}`,
     ),
-  uninstallComputeDevice: (id: string, password: string) =>
-    req<{ ok: boolean; id: string; uninstall: { instance_id: string; runtime_port: number } }>(
-      'POST',
-      `/device-hosts/${encodeURIComponent(id)}/uninstall`,
+  uninstallComputeDevice: (
+    id: string,
+    password: string,
+    onProgress: (progress: DeviceActionProgress) => void,
+  ) =>
+    streamDeviceAction<{
+      ok: boolean
+      id: string
+      uninstall: { instance_id: string; runtime_port: number }
+      summary: string
+    }>(
+      `/device-hosts/${encodeURIComponent(id)}/uninstall-stream`,
       { password },
-      180000,
+      onProgress,
     ),
   controlComputeDevice: (
     id: string,
@@ -1236,11 +1305,48 @@ export const api = {
     id: string,
     password: string,
     scope: 'all' | 'runtime' | 'hardware',
+    operation: 'auto' | 'update' | 'reinstall',
     onProgress: (progress: DeviceActionProgress) => void,
   ) =>
     streamDeviceAction<ManagedServiceUpdateResult>(
       `/device-hosts/${encodeURIComponent(id)}/update-stream`,
-      { password, scope },
+      { password, scope, operation },
+      onProgress,
+    ),
+  manageLocalPackage: (
+    id: string,
+    kind: 'runtime' | 'hardware',
+    action: 'run' | 'stop' | 'restart' | 'delete',
+    onProgress: (progress: DeviceActionProgress) => void,
+  ) =>
+    streamDeviceAction<{
+      ok: boolean
+      kind: 'runtime' | 'hardware'
+      action: 'run' | 'stop' | 'restart' | 'delete'
+      package: Record<string, unknown>
+      runtime: DeviceRuntimeStatus
+    }>(
+      `/device-hosts/${encodeURIComponent(id)}/local-packages/${kind}/action-stream`,
+      { action },
+      onProgress,
+    ),
+  manageRemoteHardwarePackage: (
+    id: string,
+    action: 'run' | 'stop' | 'restart',
+    password: string,
+    onProgress: (progress: DeviceActionProgress) => void,
+  ) =>
+    streamDeviceAction<{
+      ok: boolean
+      action: 'run' | 'stop' | 'restart'
+      state: 'running' | 'stopped'
+      services: Array<Record<string, unknown>>
+      device: ComputeDevice
+      warnings: string[]
+      summary: string
+    }>(
+      `/device-hosts/${encodeURIComponent(id)}/hardware-package/action-stream`,
+      { action, password },
       onProgress,
     ),
   checkComputeDeviceUpdates: (

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState, type CSSProperties, type FormEvent } from 'react'
 import {
   api,
-  deviceMonitorSocketUrl,
   type ComputeDevice,
   type DeviceActionProgress,
   type DeviceInstallProgress,
@@ -10,8 +9,6 @@ import {
   type HardwareDeviceStatus,
   type ManagedServiceUpdateCheckResult,
   type ManagedServiceUpdateResult,
-  type RobotTelemetryJoint,
-  type RobotTelemetrySample,
   type SshDeviceProbe,
   type SshRuntimeInspection,
 } from '../api'
@@ -30,9 +27,25 @@ type DeviceState = {
   checkedAt?: number
 }
 
-type RuntimeInstallAction = 'install' | 'reuse' | 'replace' | 'side_by_side'
+type ServiceCheckState =
+  | 'checking'
+  | 'connected'
+  | 'awaiting'
+  | 'stopped'
+  | 'disconnected'
+  | 'unknown'
+  | 'unreachable'
+  | 'unchecked'
+
+type RuntimeInstallAction =
+  | 'install'
+  | 'reuse'
+  | 'replace'
+  | 'side_by_side'
+  | 'isolated_stack'
 
 const DEFAULT_RUNTIME_URL = 'http://192.168.1.87:8766'
+const LOCAL_RUNTIME_URL = 'http://127.0.0.1:8766'
 const DEFAULT_SSH_HOST = '192.168.1.87'
 const FIRST_HARDWARE_PORT = 8765
 const RUNTIME_PORT = 8766
@@ -92,6 +105,15 @@ function runtimeHostname(runtimeUrl: string): string {
   }
 }
 
+function isLocalRuntimeUrl(runtimeUrl: string): boolean {
+  try {
+    const hostname = new URL(runtimeUrl).hostname.toLowerCase()
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1'
+  } catch {
+    return false
+  }
+}
+
 function urlPort(url: string): number | null {
   try {
     const parsed = new URL(url)
@@ -117,9 +139,10 @@ export default function DevicesPanel() {
   const [knownHardwareVersions, setKnownHardwareVersions] = useState<Record<string, string>>({})
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
   const [showDeviceForm, setShowDeviceForm] = useState(false)
-  const [setupMode, setSetupMode] = useState<'automatic' | 'manual'>('automatic')
-  const [deviceName, setDeviceName] = useState('')
-  const [runtimeUrl, setRuntimeUrl] = useState(DEFAULT_RUNTIME_URL)
+  const [setupMode, setSetupMode] = useState<'local' | 'automatic' | 'manual'>('local')
+  const [deviceName, setDeviceName] = useState('Local computer')
+  const [localInstallDir, setLocalInstallDir] = useState('')
+  const [runtimeUrl, setRuntimeUrl] = useState(LOCAL_RUNTIME_URL)
   const [runtimeToken, setRuntimeToken] = useState('')
   const [sshHost, setSshHost] = useState(DEFAULT_SSH_HOST)
   const [sshPort, setSshPort] = useState(22)
@@ -137,6 +160,8 @@ export default function DevicesPanel() {
   const [updatePassword, setUpdatePassword] = useState('')
   const [updateCheckReport, setUpdateCheckReport] = useState<ManagedServiceUpdateCheckResult | null>(null)
   const [updateReport, setUpdateReport] = useState<ManagedServiceUpdateResult | null>(null)
+  const [showDirtySourceHelp, setShowDirtySourceHelp] = useState(false)
+  const showLegacyPackageManager = false as boolean
   const [showUninstallForm, setShowUninstallForm] = useState(false)
   const [uninstallPassword, setUninstallPassword] = useState('')
   const [showSshManagement, setShowSshManagement] = useState(false)
@@ -154,6 +179,15 @@ export default function DevicesPanel() {
   const [linkedProjectName, setLinkedProjectName] = useState('')
 
   const selectedDevice = devices.find(device => device.id === selectedDeviceId) ?? null
+  const selectedDeviceIsLocal = Boolean(
+    selectedDevice && isLocalRuntimeUrl(selectedDevice.runtime_url),
+  )
+  const selectedDeviceManagedLocally = (
+    selectedDevice?.managed_runtime?.management_mode === 'local'
+  )
+  const selectedStackIsIsolated = (
+    selectedDevice?.managed_runtime?.stack_mode === 'isolated'
+  )
   const selectedDeviceState = selectedDevice
     ? deviceStates[selectedDevice.id]
     : undefined
@@ -163,41 +197,205 @@ export default function DevicesPanel() {
       state: robotStates[robot.id],
     }))
     : []
+  const selectedHardwareSiblingDevices = (
+    selectedDevice?.managed_runtime
+    && !selectedDeviceManagedLocally
+    && !selectedStackIsIsolated
+  )
+    ? devices.filter(device => {
+      const selectedManagement = selectedDevice.managed_runtime
+      const candidateManagement = device.managed_runtime
+      if (
+        !selectedManagement
+        || !candidateManagement
+        || candidateManagement.stack_mode === 'isolated'
+      ) return false
+      return (
+        device.id !== selectedDevice.id
+        && device.robots.length > 0
+        && candidateManagement.ssh_host === selectedManagement.ssh_host
+        && candidateManagement.ssh_port === selectedManagement.ssh_port
+        && candidateManagement.ssh_username === selectedManagement.ssh_username
+        && candidateManagement.host_fingerprint === selectedManagement.host_fingerprint
+      )
+    })
+    : []
   const selectedDeviceChecking = Boolean(
     selectedDeviceState?.loading
     || selectedRobotChecks.some(item => item.state?.loading),
   )
+  const selectedManagedHardwareInstalled = Boolean(
+    selectedDevice?.managed_runtime?.hardware_dir,
+  )
+  const selectedManagedHardwareReady = (
+    !selectedManagedHardwareInstalled
+    || selectedDeviceState?.runtime?.hardware?.ok === true
+  )
   const selectedHardwareReady = selectedRobotChecks.every(item => Boolean(
     item.state?.status
     && !item.state.error
-    && (
-      item.state.status.connected
-      || item.state.status.leased_to_deployment
-      || item.state.status.deployment_lease
-    ),
+    && item.state.status.connected,
   ))
   const selectedDeviceReady = Boolean(
     selectedDeviceState?.runtime?.ok
+    && selectedManagedHardwareReady
     && selectedHardwareReady,
   )
-  const selectedServiceVersions = selectedDevice
-    ? [
-      `Runtime ${
-        selectedDeviceState?.runtime?.manifest?.runtime_version
-          ? `v${selectedDeviceState.runtime.manifest.runtime_version}`
-          : 'version not reported'
-      }`,
-      ...selectedRobotChecks.map(({ robot, state }) => (
-        `${robot.name} Hardware ${
-          state?.status?.software_version
-            ? `v${state.status.software_version}`
-            : robot.software_version
-              ? `v${robot.software_version} (last verified)`
-            : 'version not reported'
+  const selectedRuntimeVersionValue = (
+    selectedDeviceState?.runtime?.manifest?.runtime_version
+    || selectedDeviceState?.runtime?.installed_version
+  )
+  const selectedRuntimeVersion = (
+    selectedRuntimeVersionValue
+    && selectedRuntimeVersionValue !== 'unknown'
+  )
+    ? `v${selectedRuntimeVersionValue}`
+    : 'version not reported'
+  const selectedHardwareVersion = (
+    selectedDeviceState?.runtime?.hardware?.status?.software_version
+    || selectedDeviceState?.runtime?.hardware?.installed_version
+    || selectedRobotChecks.find(item => item.state?.status?.software_version)
+      ?.state?.status?.software_version
+    || selectedDevice?.robots.find(robot => robot.software_version)?.software_version
+  )
+  const selectedHardwareVersionLabel = selectedHardwareVersion
+    ? `v${selectedHardwareVersion}`
+    : 'version not reported'
+  const selectedHardwarePackageState = selectedDeviceState?.loading
+    ? 'checking'
+    : selectedDeviceManagedLocally
+      ? selectedDeviceState?.runtime?.hardware?.state || 'unchecked'
+      : selectedDevice?.managed_runtime?.hardware_state === 'stopped'
+        ? 'stopped'
+      : selectedDevice?.managed_runtime?.hardware_state === 'running'
+        ? 'running'
+      : selectedRobotChecks.some(item => item.state?.loading)
+        ? 'checking'
+        : selectedRobotChecks.some(item => item.state?.error)
+          ? 'unreachable'
+          : selectedRobotChecks.some(item => item.state?.status)
+            ? 'running'
+            : selectedDevice?.robots.length
+              ? 'unchecked'
+              : 'unavailable'
+  const selectedRuntimePackageState = selectedDeviceState?.loading
+    ? 'checking'
+    : selectedDeviceState?.runtime?.state
+      || (selectedDeviceState?.runtime?.paused || selectedDevice?.paused
+        ? 'stopped'
+        : selectedDeviceState?.runtime?.ok === true
+          ? 'running'
+          : selectedDeviceState?.runtime
+            ? 'unreachable'
+            : 'unchecked')
+  const selectedAttachedHardwareServiceFailed = selectedRobotChecks.some(item => (
+    Boolean(item.state?.error)
+    || Boolean(item.state?.checkedAt && !item.state?.status)
+  ))
+  const selectedPackageCheckState: ServiceCheckState = selectedDeviceState?.loading
+    ? 'checking'
+    : selectedDeviceState?.runtime?.state === 'stopped'
+      ? 'stopped'
+    : selectedDeviceState?.runtime?.ok !== true
+      ? selectedDeviceState?.runtime
+        ? 'unreachable'
+        : 'unchecked'
+      : selectedManagedHardwareInstalled
+        && selectedDeviceState.runtime.hardware?.state === 'stopped'
+        ? 'stopped'
+        : selectedManagedHardwareInstalled
+        && selectedDeviceState.runtime.hardware?.ok !== true
+        ? 'unreachable'
+        : selectedAttachedHardwareServiceFailed
+          ? 'unreachable'
+          : 'connected'
+  const selectedPackageCheckDetail = selectedDeviceState?.loading
+    ? 'Checking Runtime and Hardware package services'
+    : selectedDeviceState?.runtime?.state === 'stopped'
+      ? `Runtime ${selectedRuntimeVersion} · service stopped · Hardware ${selectedHardwareVersionLabel}`
+    : selectedDeviceState?.runtime?.ok !== true
+      ? `Runtime service unreachable${
+          selectedDeviceState?.runtime?.error
+            ? ` · ${selectedDeviceState.runtime.error}`
+            : ''
         }`
-      )),
+      : selectedManagedHardwareInstalled
+        && selectedDeviceState.runtime.hardware?.state === 'stopped'
+        ? `Runtime ${selectedRuntimeVersion} · Hardware ${selectedHardwareVersionLabel} · service stopped`
+        : selectedManagedHardwareInstalled
+        && selectedDeviceState.runtime.hardware?.ok !== true
+        ? `Runtime ${selectedRuntimeVersion} · Hardware service unreachable${
+            selectedDeviceState.runtime.hardware?.error
+              ? ` · ${selectedDeviceState.runtime.hardware.error}`
+              : ''
+          }`
+        : selectedAttachedHardwareServiceFailed
+          ? `Runtime ${selectedRuntimeVersion} · Hardware service unreachable`
+          : `Runtime ${selectedRuntimeVersion} · Hardware ${selectedHardwareVersionLabel}`
+  const selectedServiceChecks: Array<{
+    id: string
+    name: string
+    kind: 'Software package' | 'Robot hardware'
+    state: ServiceCheckState
+    detail: string
+  }> = selectedDevice
+    ? [
+      {
+        id: `packages:${selectedDevice.id}`,
+        name: 'Software packages',
+        kind: 'Software package',
+        state: selectedPackageCheckState,
+        detail: selectedPackageCheckDetail,
+      },
+      ...selectedRobotChecks.map(({ robot, state }) => {
+        const checkState: ServiceCheckState = state?.loading
+          ? 'checking'
+          : state?.error || (!state?.status && state?.checkedAt)
+            ? 'unreachable'
+            : state?.status?.connected
+              ? 'connected'
+              : state?.status
+                ? 'disconnected'
+                : 'unchecked'
+        const version = state?.status?.software_version
+          ? `v${state.status.software_version}`
+          : robot.software_version
+            ? `v${robot.software_version} (last verified)`
+            : 'version not reported'
+        const detail = checkState === 'checking'
+          ? `Contacting ${robot.base_url}`
+          : checkState === 'connected'
+            ? `Robot Hardware ${version}`
+            : checkState === 'disconnected'
+              ? state?.status?.error || `Robot Hardware ${version} · hardware provider reports disconnected`
+              : checkState === 'unreachable'
+                  ? state?.error || 'Robot Hardware service is unreachable.'
+                  : 'Robot Hardware has not been checked yet.'
+        return {
+          id: `robot:${robot.id}`,
+          name: robot.name,
+          kind: 'Robot hardware' as const,
+          state: checkState,
+          detail,
+        }
+      }),
     ]
     : []
+  const selectedCheckStarted = selectedServiceChecks.some(
+    service => service.state !== 'unchecked',
+  )
+  const selectedCheckHasFailure = selectedServiceChecks.some(
+    service => service.state === 'disconnected' || service.state === 'unreachable',
+  )
+  const selectedCheckHasStopped = selectedServiceChecks.some(
+    service => service.state === 'stopped',
+  )
+  const selectedCheckHasUnknown = selectedServiceChecks.some(
+    service => service.state === 'unknown',
+  )
+  const selectedReadyChecks = selectedServiceChecks.filter(
+    service => service.state === 'connected' || service.state === 'awaiting',
+  ).length
   const selectedLastChecked = Math.max(
     selectedDeviceState?.checkedAt ?? 0,
     ...selectedRobotChecks.map(item => item.state?.checkedAt ?? 0),
@@ -339,6 +537,13 @@ export default function DevicesPanel() {
   }, [])
 
   useEffect(() => {
+    if (!showDeviceForm || setupMode !== 'local' || localInstallDir) return
+    void api.localComputeDeviceInstallDefaults()
+      .then(result => setLocalInstallDir(result.install_dir))
+      .catch(reason => setError(reason instanceof Error ? reason.message : String(reason)))
+  }, [showDeviceForm, setupMode, localInstallDir])
+
+  useEffect(() => {
     const timers = Object.entries(actionProgress).flatMap(([id, value]) => {
       const failed = (
         value.progress <= 0
@@ -359,7 +564,9 @@ export default function DevicesPanel() {
 
   const resetDeviceForm = () => {
     setShowDeviceForm(false)
-    setDeviceName('')
+    setSetupMode('local')
+    setDeviceName('Local computer')
+    setRuntimeUrl(LOCAL_RUNTIME_URL)
     setRuntimeToken('')
     setSshPassword('')
     setSshProbe(null)
@@ -367,6 +574,24 @@ export default function DevicesPanel() {
     setInstallAction('install')
     setInstallInstanceId('default')
     setInstallProgress(null)
+  }
+
+  const selectSetupMode = (mode: 'local' | 'automatic' | 'manual') => {
+    const previousMode = setupMode
+    setSetupMode(mode)
+    setError(null)
+    setInstallProgress(null)
+    if (mode === 'local') {
+      setRuntimeUrl(LOCAL_RUNTIME_URL)
+      if (!deviceName.trim() || deviceName === 'Local computer') {
+        setDeviceName('Local computer')
+      }
+      return
+    }
+    if (previousMode === 'local') {
+      if (runtimeUrl === LOCAL_RUNTIME_URL) setRuntimeUrl(DEFAULT_RUNTIME_URL)
+      if (deviceName === 'Local computer') setDeviceName('')
+    }
   }
 
   const manualPair = async (event: FormEvent) => {
@@ -378,6 +603,44 @@ export default function DevicesPanel() {
         deviceName.trim(),
         runtimeUrl.trim(),
         runtimeToken.trim(),
+      )
+      resetDeviceForm()
+      setSelectedDeviceId(result.device.id)
+      await refresh()
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const browseLocalInstallDir = async () => {
+    setError(null)
+    try {
+      const result = await api.pickDirectory(
+        localInstallDir,
+        'Choose the Blacknode local stack installation folder',
+      )
+      if (!result.cancelled && result.selected) setLocalInstallDir(result.selected)
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    }
+  }
+
+  const installLocalComputer = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!localInstallDir.trim()) {
+      setError('Choose the local stack installation folder.')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    setInstallProgress({ progress: 1, message: 'Starting local robot stack installation' })
+    try {
+      const result = await api.installLocalComputeDevice(
+        deviceName.trim() || 'Local computer',
+        localInstallDir.trim(),
+        setInstallProgress,
       )
       resetDeviceForm()
       setSelectedDeviceId(result.device.id)
@@ -572,23 +835,55 @@ export default function DevicesPanel() {
   }
 
   const uninstallDevice = async (device: ComputeDevice) => {
-    if (!uninstallPassword) {
+    const managedLocally = device.managed_runtime?.management_mode === 'local'
+    if (!managedLocally && !uninstallPassword) {
       setError('Enter the SSH password to uninstall this managed runtime.')
       return
     }
     if (!window.confirm(
-      `Uninstall "${device.name}" from the remote computer? This stops its runtime, removes its service, files, token, firewall rule, attached robot registrations, and this device card.`,
+      managedLocally
+        ? device.managed_runtime?.hardware_dir
+          ? device.managed_runtime?.owned_install && device.managed_runtime?.hardware_owned_install
+            ? `Uninstall "${device.name}" from this computer? This stops Runtime and Robot Hardware, removes both editor-created installation folders and attached robot registrations, and removes this device card.`
+            : `Uninstall "${device.name}" from this computer? This stops Runtime and Robot Hardware, removes their editor-managed configuration and attached robot registrations, preserves existing source checkouts, and removes this device card.`
+          : device.managed_runtime?.owned_install
+            ? `Uninstall "${device.name}" from this computer? This stops its Runtime, removes the editor-created installation folder and attached robot registrations, and removes this device card.`
+            : `Uninstall "${device.name}" from this computer? This stops its Runtime, removes its editor-managed configuration and attached robot registrations, preserves the existing source checkout, and removes this device card.`
+        : `Uninstall "${device.name}" from the remote computer? This stops its runtime, removes its service, files, token, firewall rule, attached robot registrations, and this device card.`,
     )) return
     setBusy(true)
     setError(null)
+    setActionProgress(previous => ({
+      ...previous,
+      [device.id]: {
+        progress: 1,
+        message: 'Starting managed device uninstall',
+      },
+    }))
     try {
-      await api.uninstallComputeDevice(device.id, uninstallPassword)
+      const result = await api.uninstallComputeDevice(
+        device.id,
+        uninstallPassword,
+        progress => setActionProgress(previous => ({
+          ...previous,
+          [device.id]: progress,
+        })),
+      )
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 100, message: result.summary },
+      }))
       setShowUninstallForm(false)
       setUninstallPassword('')
       setSelectedDeviceId(null)
       await refresh()
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : String(reason))
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 0, message: `Uninstall failed: ${message}` },
+      }))
+      setError(message)
     } finally {
       setBusy(false)
     }
@@ -669,8 +964,14 @@ export default function DevicesPanel() {
     }
   }
 
-  const controlDevice = async (device: ComputeDevice, action: 'pause' | 'resume') => {
-    if (!runtimeControlPassword) {
+  const controlDevice = async (
+    device: ComputeDevice,
+    action: 'pause' | 'resume',
+    passwordOverride?: string,
+  ) => {
+    const managedLocally = device.managed_runtime?.management_mode === 'local'
+    const password = passwordOverride ?? runtimeControlPassword
+    if (!managedLocally && !password) {
       setError(`Enter the SSH password to ${action} this managed device.`)
       return
     }
@@ -690,7 +991,7 @@ export default function DevicesPanel() {
       const result = await api.controlComputeDevice(
         device.id,
         action,
-        runtimeControlPassword,
+        managedLocally ? '' : password,
         progress => setActionProgress(previous => ({
           ...previous,
           [device.id]: progress,
@@ -723,8 +1024,10 @@ export default function DevicesPanel() {
   const updateDevice = async (
     device: ComputeDevice,
     scope: 'all' | 'runtime' | 'hardware',
+    requestedOperation: 'update' | 'reinstall' | null = null,
   ) => {
-    if (!updatePassword) {
+    const managedLocally = device.managed_runtime?.management_mode === 'local'
+    if (!managedLocally && !updatePassword) {
       setError('Enter the SSH password to update this managed device.')
       return
     }
@@ -734,17 +1037,25 @@ export default function DevicesPanel() {
     const selectedUpdatesAvailable = selectedComponents.some(
       component => component.update_available,
     )
-    const operation = selectedUpdatesAvailable ? 'Update' : 'Reinstall'
+    const operation = requestedOperation
+      ?? (selectedUpdatesAvailable ? 'update' : 'reinstall')
+    const operationLabel = operation === 'update' ? 'Update' : 'Reinstall'
     const hardwareServiceCount = device.robots.length
-    const targetLabel = scope === 'all'
-      ? 'Runtime + Robot Hardware'
-      : scope === 'runtime'
-        ? 'Runtime'
-        : `shared Robot Hardware installation used by ${hardwareServiceCount} robot service${
-          hardwareServiceCount === 1 ? '' : 's'
-        }`
+    const targetLabel = managedLocally
+      ? scope === 'all'
+        ? 'Runtime + Hardware packages'
+        : scope === 'runtime'
+          ? 'Runtime package'
+          : 'Hardware package'
+      : scope === 'all'
+        ? 'Runtime + Robot Hardware'
+        : scope === 'runtime'
+          ? 'Runtime'
+          : `${device.managed_runtime?.stack_mode === 'isolated' ? 'isolated' : 'shared'} Robot Hardware installation used by ${hardwareServiceCount} robot service${
+            hardwareServiceCount === 1 ? '' : 's'
+          }`
     if (!window.confirm(
-      `${operation} ${targetLabel} on "${device.name}"? Running deployments will stop and robots will return with Blacknode motion disarmed. This action does not switch off physical actuator power.`,
+      `${operationLabel} ${targetLabel} on "${device.name}"? Running deployments will stop and robots will return with Blacknode motion disarmed. This action does not switch off physical actuator power.`,
     )) return
     setBusy(true)
     setError(null)
@@ -753,20 +1064,23 @@ export default function DevicesPanel() {
       ...previous,
       [device.id]: {
         progress: 1,
-        message: scope === 'runtime'
-          ? 'Preparing Runtime update'
-          : scope === 'hardware'
-            ? `Preparing shared Robot Hardware update for ${hardwareServiceCount} robot service${
-              hardwareServiceCount === 1 ? '' : 's'
-            }`
-            : 'Preparing Runtime + Robot Hardware update',
+        message: managedLocally
+          ? `Preparing ${targetLabel}`
+          : scope === 'runtime'
+            ? 'Preparing Runtime update'
+            : scope === 'hardware'
+              ? `Preparing shared Robot Hardware update for ${hardwareServiceCount} robot service${
+                hardwareServiceCount === 1 ? '' : 's'
+              }`
+              : 'Preparing Runtime + Robot Hardware update',
       },
     }))
     try {
       const result = await api.updateComputeDevice(
         device.id,
-        updatePassword,
+        managedLocally ? '' : updatePassword,
         scope,
+        operation,
         progress => setActionProgress(previous => ({
           ...previous,
           [device.id]: progress,
@@ -788,7 +1102,7 @@ export default function DevicesPanel() {
       try {
         const refreshedCheck = await api.checkComputeDeviceUpdates(
           device.id,
-          updatePassword,
+          managedLocally ? '' : updatePassword,
           progress => setActionProgress(previous => ({
             ...previous,
             [device.id]: progress,
@@ -839,7 +1153,8 @@ export default function DevicesPanel() {
   }
 
   const checkDeviceSoftware = async (device: ComputeDevice) => {
-    if (!updatePassword) {
+    const managedLocally = device.managed_runtime?.management_mode === 'local'
+    if (!managedLocally && !updatePassword) {
       setError('Enter the SSH password to compare installed and latest versions.')
       return
     }
@@ -847,6 +1162,7 @@ export default function DevicesPanel() {
     setError(null)
     setUpdateReport(null)
     setUpdateCheckReport(null)
+    setShowDirtySourceHelp(false)
     setActionProgress(previous => ({
       ...previous,
       [device.id]: { progress: 1, message: 'Checking Runtime + Robot Hardware versions' },
@@ -854,7 +1170,7 @@ export default function DevicesPanel() {
     try {
       const result = await api.checkComputeDeviceUpdates(
         device.id,
-        updatePassword,
+        managedLocally ? '' : updatePassword,
         progress => setActionProgress(previous => ({
           ...previous,
           [device.id]: progress,
@@ -881,6 +1197,172 @@ export default function DevicesPanel() {
       setActionProgress(previous => ({
         ...previous,
         [device.id]: { progress: 0, message: `Version check failed: ${message}` },
+      }))
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const manageLocalPackage = async (
+    device: ComputeDevice,
+    kind: 'runtime' | 'hardware',
+    action: 'run' | 'stop' | 'restart' | 'delete',
+  ) => {
+    const packageName = kind === 'runtime' ? 'Runtime package' : 'Hardware package'
+    if (action === 'delete' && !window.confirm(
+      `Delete the installed ${packageName} environment? Its service will stop. The source checkout and configuration are preserved so Reinstall can restore it.`,
+    )) return
+    setBusy(true)
+    setError(null)
+    setActionProgress(previous => ({
+      ...previous,
+      [device.id]: {
+        progress: 1,
+        message: `${
+          action === 'run'
+            ? 'Starting'
+            : action === 'stop'
+              ? 'Stopping'
+              : action === 'restart'
+                ? 'Restarting'
+                : 'Deleting'
+        } ${packageName}`,
+      },
+    }))
+    try {
+      const result = await api.manageLocalPackage(
+        device.id,
+        kind,
+        action,
+        progress => setActionProgress(previous => ({
+          ...previous,
+          [device.id]: progress,
+        })),
+      )
+      setDeviceStates(previous => ({
+        ...previous,
+        [device.id]: {
+          runtime: result.runtime,
+          loading: false,
+          checkedAt: Date.now(),
+        },
+      }))
+      await refreshDevice(device)
+      await checkDeviceSoftware(device)
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 0, message: `${packageName} action failed: ${message}` },
+      }))
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const manageRemoteHardwarePackage = async (
+    device: ComputeDevice,
+    action: 'run' | 'stop' | 'restart',
+  ) => {
+    if (!updatePassword) {
+      setError(`Enter the SSH password to ${action} the Hardware package.`)
+      return
+    }
+    if (device.robots.length === 0) {
+      setError('Attach a robot before controlling the remote Hardware package.')
+      return
+    }
+    if ((action === 'stop' || action === 'restart') && !window.confirm(
+      `${action === 'stop' ? 'Stop' : 'Restart'} the remote Hardware package on "${device.name}"? Active deployments will stop and every robot will be disarmed first.`,
+    )) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await api.manageRemoteHardwarePackage(
+        device.id,
+        action,
+        updatePassword,
+        progress => setActionProgress(previous => ({
+          ...previous,
+          [device.id]: progress,
+        })),
+      )
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 100, message: result.summary },
+      }))
+      await refresh()
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 0, message: `Hardware package action failed: ${message}` },
+      }))
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const restartRemotePackage = async (
+    device: ComputeDevice,
+    kind: 'runtime' | 'hardware',
+  ) => {
+    if (kind === 'hardware') {
+      await manageRemoteHardwarePackage(device, 'restart')
+      return
+    }
+    if (!updatePassword) {
+      setError(`Enter the SSH password to restart the ${kind} package.`)
+      return
+    }
+    const label = 'Runtime package'
+    if (!window.confirm(
+      `Restart the remote ${label} on "${device.name}"? Running deployments will stop and robots must return disarmed.`,
+    )) return
+    setBusy(true)
+    setError(null)
+    setActionProgress(previous => ({
+      ...previous,
+      [device.id]: { progress: 5, message: `Restarting remote ${label}` },
+    }))
+    try {
+      await api.controlComputeDevice(
+          device.id,
+          'pause',
+          updatePassword,
+          progress => setActionProgress(previous => ({
+            ...previous,
+            [device.id]: {
+              progress: Math.min(48, Math.max(5, Math.round(progress.progress * 0.48))),
+              message: progress.message,
+            },
+          })),
+      )
+      await api.controlComputeDevice(
+          device.id,
+          'resume',
+          updatePassword,
+          progress => setActionProgress(previous => ({
+            ...previous,
+            [device.id]: {
+              progress: 50 + Math.round(progress.progress * 0.5),
+              message: progress.message,
+            },
+          })),
+      )
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 100, message: `${label} restarted` },
+      }))
+      await refresh()
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [device.id]: { progress: 0, message: `${label} restart failed: ${message}` },
       }))
       setError(message)
     } finally {
@@ -994,19 +1476,19 @@ export default function DevicesPanel() {
     }
   }
 
-  const restartStoredDeployment = async (
+  const restartDeployment = async (
     robot: HardwareDevice,
     deploymentId: string,
     deploymentName: string,
   ) => {
     if (!window.confirm(
-      `Restart stored deployment "${deploymentName}" on "${robot.name}"? Blacknode will recheck the robot safety state before starting it.`,
+      `Restart deployment "${deploymentName}" on "${robot.name}"? Blacknode will recheck the robot safety state before starting it.`,
     )) return
     setBusy(true)
     setError(null)
     setActionProgress(previous => ({
       ...previous,
-      [robot.id]: { progress: 10, message: 'Restarting stored deployment' },
+      [robot.id]: { progress: 10, message: 'Restarting deployment' },
     }))
     try {
       await api.startRemoteDeployment(robot.id, deploymentId)
@@ -1095,7 +1577,13 @@ export default function DevicesPanel() {
       {showDeviceForm && (
         <form
           className="bn-device-form"
-          onSubmit={setupMode === 'automatic' ? automaticInstall : manualPair}
+          onSubmit={
+            setupMode === 'automatic'
+              ? automaticInstall
+              : setupMode === 'local'
+                ? installLocalComputer
+                : manualPair
+          }
         >
           <div className="bn-device-form-title">Add a compute device</div>
           <p className="bn-device-help">
@@ -1104,23 +1592,24 @@ export default function DevicesPanel() {
           <div className="bn-device-mode-tabs" role="tablist" aria-label="Device setup method">
             <button
               type="button"
-              className={setupMode === 'automatic' ? 'is-active' : ''}
-              onClick={() => {
-                setSetupMode('automatic')
-                setError(null)
-              }}
+              className={setupMode === 'local' ? 'is-active' : ''}
+              onClick={() => selectSetupMode('local')}
             >
-              Automatic SSH
+              Local computer
+            </button>
+            <button
+              type="button"
+              className={setupMode === 'automatic' ? 'is-active' : ''}
+              onClick={() => selectSetupMode('automatic')}
+            >
+              Remote SSH
             </button>
             <button
               type="button"
               className={setupMode === 'manual' ? 'is-active' : ''}
-              onClick={() => {
-                setSetupMode('manual')
-                setError(null)
-              }}
+              onClick={() => selectSetupMode('manual')}
             >
-              Pair manually
+              Remote Manual
             </button>
           </div>
           <label>
@@ -1405,9 +1894,74 @@ export default function DevicesPanel() {
                         </span>
                       </label>
                     )}
+                    <label className={installAction === 'isolated_stack' ? 'is-selected' : ''}>
+                      <input
+                        type="radio"
+                        name="runtime-install-action"
+                        checked={installAction === 'isolated_stack'}
+                        onChange={() => {
+                          setInstallAction('isolated_stack')
+                          setInstallInstanceId(sshInspection.suggested_instance_id)
+                        }}
+                      />
+                      <span>
+                        <strong>Install a complete isolated robot stack</strong>
+                        <small>
+                          Creates {sshInspection.suggested_instance_id} with separate Runtime
+                          and Robot Hardware directories, environments, tokens, state, services,
+                          and ports. Existing stacks remain untouched.
+                        </small>
+                      </span>
+                    </label>
                   </div>
                 </div>
               )}
+            </>
+          ) : setupMode === 'local' ? (
+            <>
+              <div className="bn-device-setup-step">
+                <span className="bn-device-setup-number">1</span>
+                <div>
+                  <strong>Install a local robot stack</strong>
+                  <p>
+                    Choose one folder. Blacknode installs the Runtime package and Hardware
+                    package in separate subfolders and environments, configures
+                    authentication, starts both services, and adds this computer.
+                  </p>
+                </div>
+              </div>
+              <div className="bn-device-local-capabilities" role="note">
+                <strong>Same Blacknode workspace</strong>
+                <span>
+                  Deployments, logs, live monitoring, projects, and attached robots use the
+                  same device APIs as a remote computer.
+                </span>
+                <small>
+                  Robot Hardware starts authenticated, disconnected, and disarmed while it
+                  waits for a physical robot configuration. Tokens stay on this computer.
+                </small>
+              </div>
+              <label>
+                <span>Local stack installation folder</span>
+                <div className="bn-device-path-field">
+                  <input
+                    value={localInstallDir}
+                    onChange={event => setLocalInstallDir(event.target.value)}
+                    placeholder="Choose a folder for the Blacknode stack"
+                    required
+                    spellCheck={false}
+                    disabled={busy}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void browseLocalInstallDir()}
+                    disabled={busy}
+                    style={miniButton}
+                  >
+                    Browse
+                  </button>
+                </div>
+              </label>
             </>
           ) : (
             <>
@@ -1447,7 +2001,7 @@ export default function DevicesPanel() {
             </>
           )}
 
-          {installProgress && setupMode === 'automatic' && (
+          {installProgress && (setupMode === 'automatic' || setupMode === 'local') && (
             <div
               className="bn-device-install-progress"
               role="progressbar"
@@ -1473,16 +2027,26 @@ export default function DevicesPanel() {
                 {busy ? 'Checking…' : 'Check connection'}
               </button>
             ) : (
-              <button type="submit" disabled={busy} style={primaryButton}>
+              <button
+                type="submit"
+                disabled={busy || (setupMode === 'local' && !localInstallDir.trim())}
+                style={primaryButton}
+              >
                 {busy
                   ? setupMode === 'automatic'
                     ? sshInspection ? installAction === 'reuse' ? 'Pairing…' : 'Installing…' : 'Inspecting…'
-                    : 'Pairing…'
+                    : setupMode === 'local' ? 'Installing…' : 'Pairing…'
                   : setupMode === 'automatic'
                     ? sshInspection
-                      ? installAction === 'reuse' ? 'Pair existing runtime' : installAction === 'replace' ? 'Reinstall runtime' : 'Install runtime'
+                      ? installAction === 'reuse'
+                        ? 'Pair existing runtime'
+                        : installAction === 'replace'
+                          ? 'Reinstall runtime'
+                          : installAction === 'isolated_stack'
+                            ? 'Install isolated stack'
+                            : 'Install runtime'
                       : 'Confirm and inspect'
-                    : 'Pair runtime'}
+                    : setupMode === 'local' ? 'Add local computer' : 'Pair runtime'}
               </button>
             )}
           </div>
@@ -1539,6 +2103,7 @@ export default function DevicesPanel() {
                   setUpdateReport(null)
                   setShowDeviceForm(false)
                   setShowRobotForm(false)
+                  setShowSshManagement(false)
                 }}
               />
             ))}
@@ -1580,16 +2145,21 @@ export default function DevicesPanel() {
           <div className="bn-compute-device-detail-head">
             <div className="bn-compute-device-identity">
               <strong>{selectedDevice.name}</strong>
+              {selectedDeviceIsLocal
+                ? <span>Local computer · loopback connection</span>
+                : selectedStackIsIsolated
+                  ? <span>Complete isolated robot stack</span>
+                  : null}
               <code>{selectedDevice.runtime_url}</code>
             </div>
             <div className="bn-run-detail-actions bn-device-header-actions">
               <button
                 onClick={() => void checkDevice(selectedDevice)}
-                disabled={busy || selectedDeviceState?.loading}
-                className={`bn-device-action-button bn-runtime-check-button${selectedDeviceState?.loading ? ' is-checking' : ''}`}
+                disabled={busy || selectedDeviceChecking}
+                className={`bn-device-action-button bn-runtime-check-button${selectedDeviceChecking ? ' is-checking' : ''}`}
                 title="Check the runtime and every attached robot hardware service"
               >
-                {selectedDeviceState?.loading ? 'Checking device…' : 'Check device'}
+                {selectedDeviceChecking ? 'Checking device…' : 'Check device'}
               </button>
               <button
                 onClick={() => renameDevice(selectedDevice)}
@@ -1598,7 +2168,7 @@ export default function DevicesPanel() {
               >
                 Rename
               </button>
-              {!selectedDevice.managed_runtime && (
+              {!selectedDevice.managed_runtime && !selectedDeviceIsLocal && (
                 <button
                   onClick={() => openSshManagement(selectedDevice)}
                   disabled={busy}
@@ -1617,29 +2187,23 @@ export default function DevicesPanel() {
                 <>
                   <button
                     onClick={() => {
-                      setShowRuntimeControl(current => !current)
-                      setShowUpdateForm(false)
-                      setShowUninstallForm(false)
-                      setRuntimeControlPassword('')
-                      setError(null)
+                      if (selectedDeviceManagedLocally) {
+                        void controlDevice(
+                          selectedDevice,
+                          selectedDevice.paused ? 'resume' : 'pause',
+                        )
+                      } else {
+                        setShowRuntimeControl(current => !current)
+                        setShowUpdateForm(false)
+                        setShowUninstallForm(false)
+                        setRuntimeControlPassword('')
+                        setError(null)
+                      }
                     }}
                     disabled={busy}
                     className={`bn-device-action-button${selectedDevice.paused ? ' is-primary' : ''}`}
                   >
                     {selectedDevice.paused ? 'Resume device' : 'Pause device'}
-                  </button>
-                  <button
-                    onClick={() => {
-                      setShowUpdateForm(current => !current)
-                      setShowRuntimeControl(false)
-                      setShowUninstallForm(false)
-                      setUpdatePassword('')
-                      setError(null)
-                    }}
-                    disabled={busy}
-                    className={`bn-device-action-button${showUpdateForm ? ' is-active' : ''}`}
-                  >
-                    Runtime + Robot Hardware
                   </button>
                   <button
                     onClick={() => {
@@ -1652,7 +2216,7 @@ export default function DevicesPanel() {
                     disabled={busy}
                     className="bn-device-action-button is-danger"
                   >
-                    Uninstall runtime
+                    {selectedDeviceManagedLocally ? 'Uninstall local stack' : 'Uninstall runtime'}
                   </button>
                 </>
               )}
@@ -1667,7 +2231,136 @@ export default function DevicesPanel() {
             </div>
           </div>
 
-          {showSshManagement && !selectedDevice.managed_runtime && (
+          {selectedDevice.managed_runtime && (
+            <div className="bn-device-local-note" role="note">
+              <div className="bn-local-package-summary-head">
+                <div>
+                  <strong>Software packages</strong>
+                  <span>
+                    Runtime and Hardware use the same package controls on every device.
+                  </span>
+                </div>
+                {!selectedDeviceManagedLocally && (
+                  <label className="bn-local-package-password">
+                    <span>SSH password · never saved</span>
+                    <input
+                      type="password"
+                      value={updatePassword}
+                      onChange={event => setUpdatePassword(event.target.value)}
+                      autoComplete="current-password"
+                      placeholder="Required for package actions"
+                    />
+                  </label>
+                )}
+              </div>
+              <div className="bn-local-package-summary">
+                <SoftwarePackageSummaryCard
+                  label="Runtime package"
+                  path={selectedDevice.managed_runtime?.runtime_dir || selectedDevice.runtime_url}
+                  state={selectedRuntimePackageState}
+                  version={selectedRuntimeVersion}
+                  installed={selectedDeviceState?.runtime?.installed !== false}
+                  updateAvailable={checkedRuntimeComponents.some(
+                    component => component.update_available,
+                  )}
+                  busy={busy}
+                  onRunStop={action => (
+                    selectedDeviceManagedLocally
+                      ? void manageLocalPackage(selectedDevice, 'runtime', action)
+                      : void controlDevice(
+                          selectedDevice,
+                          action === 'run' ? 'resume' : 'pause',
+                          updatePassword,
+                        )
+                  )}
+                  onRestart={() => (
+                    selectedDeviceManagedLocally
+                      ? void manageLocalPackage(selectedDevice, 'runtime', 'restart')
+                      : void restartRemotePackage(selectedDevice, 'runtime')
+                  )}
+                  onUpdate={() => void updateDevice(selectedDevice, 'runtime', 'update')}
+                  onReinstall={() => void updateDevice(
+                    selectedDevice,
+                    'runtime',
+                    'reinstall',
+                  )}
+                  deleteEnabled={selectedDeviceManagedLocally}
+                  onDelete={() => {
+                    if (selectedDeviceManagedLocally) {
+                      void manageLocalPackage(selectedDevice, 'runtime', 'delete')
+                    }
+                  }}
+                />
+                {selectedDevice.managed_runtime?.hardware_dir
+                  || !selectedDeviceManagedLocally ? (
+                  <SoftwarePackageSummaryCard
+                    label="Hardware package"
+                    path={
+                      selectedDevice.managed_runtime.hardware_dir
+                      || 'Remote Hardware package path not reported'
+                    }
+                    detail={selectedDeviceManagedLocally
+                      ? `Port ${selectedDevice.managed_runtime.hardware_port || 8765}`
+                      : `${selectedDevice.robots.length} robot service${
+                          selectedDevice.robots.length === 1 ? '' : 's'
+                        }`}
+                    state={selectedHardwarePackageState}
+                    version={selectedHardwareVersionLabel}
+                    installed={
+                      selectedDeviceManagedLocally
+                        ? selectedDeviceState?.runtime?.hardware?.installed !== false
+                        : Boolean(
+                            selectedDevice.managed_runtime.hardware_dir
+                            || selectedDevice.robots.length,
+                          )
+                    }
+                    updateAvailable={checkedHardwareHasUpdate}
+                    busy={busy}
+                    runStopEnabled={
+                      selectedDeviceManagedLocally || selectedDevice.robots.length > 0
+                    }
+                    onRunStop={action => (
+                      selectedDeviceManagedLocally
+                        ? void manageLocalPackage(selectedDevice, 'hardware', action)
+                        : void manageRemoteHardwarePackage(selectedDevice, action)
+                    )}
+                    restartEnabled={
+                      selectedDeviceManagedLocally || selectedDevice.robots.length > 0
+                    }
+                    onRestart={() => (
+                      selectedDeviceManagedLocally
+                        ? void manageLocalPackage(selectedDevice, 'hardware', 'restart')
+                        : void restartRemotePackage(selectedDevice, 'hardware')
+                    )}
+                    onUpdate={() => void updateDevice(selectedDevice, 'hardware', 'update')}
+                    onReinstall={() => void updateDevice(
+                      selectedDevice,
+                      'hardware',
+                      'reinstall',
+                    )}
+                    deleteEnabled={selectedDeviceManagedLocally}
+                    onDelete={() => {
+                      if (selectedDeviceManagedLocally) {
+                        void manageLocalPackage(selectedDevice, 'hardware', 'delete')
+                      }
+                    }}
+                  />
+                ) : (
+                  <div className="bn-local-package-missing">
+                    <strong>Hardware package</strong>
+                    <span>Reinstall the local stack to add this package.</span>
+                  </div>
+                )}
+              </div>
+              <span>
+                {selectedDeviceManagedLocally
+                  ? 'Hardware remains disconnected and motion stays disarmed until a physical robot is configured. Device checks, deployments, logs, and monitoring use the loopback connection.'
+                  : 'Remote package actions use the verified SSH identity. Hardware restarts require every attached robot to be stopped and disarmed.'}
+              </span>
+            </div>
+          )}
+
+          {showSshManagement && !selectedDevice.managed_runtime && !selectedDeviceIsLocal && (
             <form
               className="bn-runtime-uninstall bn-ssh-management-form"
               onSubmit={event => void configureSshManagement(event, selectedDevice)}
@@ -1829,7 +2522,7 @@ export default function DevicesPanel() {
             </form>
           )}
 
-          {showRuntimeControl && selectedDevice.managed_runtime && (
+          {showRuntimeControl && selectedDevice.managed_runtime && !selectedDeviceManagedLocally && (
             <form
               className="bn-runtime-uninstall"
               onSubmit={event => {
@@ -1880,11 +2573,12 @@ export default function DevicesPanel() {
             </form>
           )}
 
-          {actionProgress[selectedDevice.id] && (
+          {actionProgress[selectedDevice.id] && !showUninstallForm && (
             <LifecycleProgress value={actionProgress[selectedDevice.id]} />
           )}
 
-          {showUpdateForm && selectedDevice.managed_runtime && (
+          {/* Superseded by the always-visible package cards above. */}
+          {showUpdateForm && selectedDevice.managed_runtime && showLegacyPackageManager && (
             <form
               className="bn-runtime-uninstall bn-device-update-form"
               onSubmit={event => {
@@ -1893,34 +2587,36 @@ export default function DevicesPanel() {
               }}
             >
               <div>
-                <strong>Runtime + Robot Hardware</strong>
+                <strong>Software packages</strong>
                 <span>
-                  Checks the Blacknode Runtime repository and every Blacknode Hardware
-                  repository used by this device. Installed, latest, and live-reported
-                  versions are shown together first. Current versions can also be
-                  reinstalled when you want to repair the environments and restart services.
+                  Shows the Runtime and Hardware packages separately with their installed
+                  and latest versions. Each local package can be run, stopped, restarted,
+                  updated, reinstalled, or deleted independently.
                 </span>
               </div>
-              <label className="bn-device-update-password">
-                <span>
-                  <strong>SSH password</strong>
-                  <small>
-                    {selectedDevice.managed_runtime.ssh_username} · verified device · never saved
-                  </small>
-                </span>
-                <input
-                  type="password"
-                  value={updatePassword}
-                  onChange={event => setUpdatePassword(event.target.value)}
-                  autoComplete="current-password"
-                  placeholder="Enter SSH password"
-                  spellCheck={false}
-                  required
-                />
-              </label>
+              {!selectedDeviceManagedLocally && (
+                <label className="bn-device-update-password">
+                  <span>
+                    <strong>SSH password</strong>
+                    <small>
+                      {selectedDevice.managed_runtime.ssh_username} · verified device · never saved
+                    </small>
+                  </span>
+                  <input
+                    type="password"
+                    value={updatePassword}
+                    onChange={event => setUpdatePassword(event.target.value)}
+                    autoComplete="current-password"
+                    placeholder="Enter SSH password"
+                    spellCheck={false}
+                    required
+                  />
+                </label>
+              )}
               <div className="bn-device-update-caution">
-                Checking versions is read-only. Updating stops deployments and restarts
-                robot monitoring disarmed. Physical servo torque may remain enabled.
+                Checking versions never starts a stopped package. Updating or reinstalling
+                preserves that package's running or stopped state. Deleting removes its
+                installed environment while preserving source and configuration.
               </div>
               <div className="bn-device-form-actions">
                 <button
@@ -1940,14 +2636,21 @@ export default function DevicesPanel() {
             </form>
           )}
 
-          {updateCheckReport && (
-            <section className="bn-device-update-report" aria-label="Runtime and Robot Hardware version report">
+          {showUpdateForm && updateCheckReport && showLegacyPackageManager && (
+            <section className="bn-device-update-report" aria-label="Runtime and Hardware package version report">
               <div className="bn-device-update-report-head">
                 <div>
-                  <strong>Runtime + Robot Hardware version report</strong>
+                  <strong>
+                    {checkedHardwareComponents.length
+                      ? 'Runtime + Hardware package version report'
+                      : 'Runtime package version report'}
+                  </strong>
                   <span>{updateCheckReport.summary}</span>
                 </div>
-                <span>{updateCheckReport.check.components.length} services checked</span>
+                <span>
+                  {updateCheckReport.check.components.length} service
+                  {updateCheckReport.check.components.length === 1 ? '' : 's'} checked
+                </span>
               </div>
               <div className="bn-device-update-components">
                 {checkedRuntimeComponents.map(component => (
@@ -1956,7 +2659,7 @@ export default function DevicesPanel() {
                     key={`check-${component.kind}-${component.service_name}-${component.port}`}
                   >
                     <div>
-                      <strong>Runtime</strong>
+                      <strong>Runtime package</strong>
                       <code>{component.service_name} · port {component.port}</code>
                     </div>
                     <div className="bn-device-update-version">
@@ -1993,44 +2696,144 @@ export default function DevicesPanel() {
                         className={`bn-device-action-button${
                           component.update_available ? ' is-primary' : ''
                         }`}
-                        disabled={busy || component.dirty || !updatePassword}
+                        disabled={
+                          busy
+                          || (!component.dirty && !selectedDeviceManagedLocally && !updatePassword)
+                        }
                         title={component.dirty
-                          ? 'Local source changes must be resolved before reinstalling'
+                          ? 'Show how to preserve or remove local source changes before updating'
                           : component.error
-                            ? 'Attempt to repair and reinstall Runtime'
+                            ? 'Attempt to repair and reinstall the Runtime package'
                             : component.update_available
-                              ? 'Update Runtime'
-                              : 'Reinstall current Runtime'}
-                        onClick={() => void updateDevice(selectedDevice, 'runtime')}
+                              ? 'Update Runtime package'
+                              : 'Reinstall current Runtime package'}
+                        onClick={() => {
+                          if (component.dirty) {
+                            setShowDirtySourceHelp(current => !current)
+                          } else {
+                            void updateDevice(
+                              selectedDevice,
+                              'runtime',
+                              component.environment_installed === false
+                                ? 'reinstall'
+                                : component.update_available
+                                  ? 'update'
+                                  : 'reinstall',
+                            )
+                          }
+                        }}
                       >
                         {busy
                           ? 'Working…'
+                          : component.dirty
+                            ? showDirtySourceHelp
+                              ? 'Hide repair steps'
+                              : 'Resolve local changes'
                           : component.error
+                            || component.environment_installed === false
                             || component.installed.version === 'unknown'
                             || component.latest.version === 'unknown'
-                            ? 'Repair Runtime'
+                            ? 'Repair Runtime package'
                             : component.update_available
-                              ? 'Update Runtime'
-                              : 'Reinstall Runtime'}
+                              ? 'Update Runtime package'
+                              : 'Reinstall Runtime package'}
                       </button>
+                      {selectedDeviceManagedLocally && (
+                        <>
+                          <button
+                            type="button"
+                            className="bn-device-action-button"
+                            disabled={busy || (
+                              component.state !== 'running'
+                              && component.state !== 'unreachable'
+                              && component.environment_installed === false
+                            )}
+                            onClick={() => void manageLocalPackage(
+                              selectedDevice,
+                              'runtime',
+                              component.state === 'running' || component.state === 'unreachable'
+                                ? 'stop'
+                                : 'run',
+                            )}
+                          >
+                            {component.state === 'running' || component.state === 'unreachable'
+                              ? 'Stop'
+                              : 'Run'}
+                          </button>
+                          <button
+                            type="button"
+                            className="bn-device-action-button"
+                            disabled={
+                              busy
+                              || component.environment_installed === false
+                              || (
+                                component.state !== 'running'
+                                && component.state !== 'unreachable'
+                              )
+                            }
+                            title="Restart only the local Runtime package service"
+                            onClick={() => void manageLocalPackage(
+                              selectedDevice,
+                              'runtime',
+                              'restart',
+                            )}
+                          >
+                            Restart
+                          </button>
+                          <button
+                            type="button"
+                            className="bn-device-action-button is-danger"
+                            disabled={busy || component.environment_installed === false}
+                            onClick={() => void manageLocalPackage(
+                              selectedDevice,
+                              'runtime',
+                              'delete',
+                            )}
+                          >
+                            Delete
+                          </button>
+                        </>
+                      )}
                     </div>
                     <small>
-                      Live service reports {component.reported_version || 'version unavailable'}
+                      Service {component.state}
+                      {' · '}reports {component.reported_version || 'version unavailable'}
                     </small>
                     {component.error && (
                       <small className="bn-device-update-component-error">
                         {component.error}
                       </small>
                     )}
+                    {component.dirty && showDirtySourceHelp && (
+                      <div className="bn-device-update-dirty-help">
+                        <strong>Preserve or remove the local edits first</strong>
+                        <span>
+                          Blacknode keeps checkout changes intact. Connect over SSH,
+                          inspect the edits, then commit or stash work you need before
+                          checking versions again.
+                        </span>
+                        <code>
+                          ssh {selectedDevice.managed_runtime?.ssh_username}
+                          @{selectedDevice.managed_runtime?.ssh_host}
+                        </code>
+                        <code>
+                          cd {selectedDevice.managed_runtime?.runtime_dir}
+                        </code>
+                        <code>git status --short &amp;&amp; git diff</code>
+                      </div>
+                    )}
                   </div>
                 ))}
                 {checkedHardwareInstallation && (
                   <div className="bn-device-update-component" key="check-hardware-shared">
                     <div>
-                      <strong>Robot Hardware</strong>
+                      <strong>Hardware package</strong>
                       <code>
-                        Shared installation · {checkedHardwareComponents.length} robot
-                        {' '}service{checkedHardwareComponents.length === 1 ? '' : 's'}
+                        {selectedDeviceManagedLocally
+                          ? `Local package · service ${checkedHardwareInstallation.state}`
+                          : `${selectedStackIsIsolated ? 'Isolated' : 'Shared'} installation · ${
+                            checkedHardwareComponents.length
+                          } robot service${checkedHardwareComponents.length === 1 ? '' : 's'}`}
                       </code>
                     </div>
                     <div className="bn-device-update-version">
@@ -2067,32 +2870,111 @@ export default function DevicesPanel() {
                         className={`bn-device-action-button${
                           checkedHardwareHasUpdate ? ' is-primary' : ''
                         }`}
-                        disabled={busy || !updatePassword || checkedHardwareIsDirty}
-                        title={`Updates the shared Robot Hardware installation and restarts ${
-                          checkedHardwareComponents.length
-                        } robot service${checkedHardwareComponents.length === 1 ? '' : 's'}`}
-                        onClick={() => void updateDevice(selectedDevice, 'hardware')}
+                        disabled={
+                          busy
+                          || checkedHardwareIsDirty
+                          || (!selectedDeviceManagedLocally && !updatePassword)
+                        }
+                        title={selectedDeviceManagedLocally
+                          ? 'Update or reinstall only the local Hardware package'
+                          : `Updates the shared Robot Hardware installation and restarts ${
+                            checkedHardwareComponents.length
+                          } robot service${checkedHardwareComponents.length === 1 ? '' : 's'}`}
+                        onClick={() => void updateDevice(
+                          selectedDevice,
+                          'hardware',
+                          checkedHardwareInstallation.environment_installed === false
+                            ? 'reinstall'
+                            : checkedHardwareHasUpdate
+                              ? 'update'
+                              : 'reinstall',
+                        )}
                       >
                         {busy
                           ? 'Working…'
                           : checkedHardwareNeedsRepair
-                            ? 'Repair Robot Hardware'
+                            || checkedHardwareInstallation.environment_installed === false
+                            ? 'Repair Hardware package'
                             : checkedHardwareHasUpdate
-                              ? 'Update Robot Hardware'
-                              : 'Reinstall Robot Hardware'}
+                              ? 'Update Hardware package'
+                              : 'Reinstall Hardware package'}
                       </button>
+                      {selectedDeviceManagedLocally && (
+                        <>
+                          <button
+                            type="button"
+                            className="bn-device-action-button"
+                            disabled={busy || (
+                              checkedHardwareInstallation.state !== 'running'
+                              && checkedHardwareInstallation.state !== 'unreachable'
+                              && checkedHardwareInstallation.environment_installed === false
+                            )}
+                            onClick={() => void manageLocalPackage(
+                              selectedDevice,
+                              'hardware',
+                              checkedHardwareInstallation.state === 'running'
+                                || checkedHardwareInstallation.state === 'unreachable'
+                                ? 'stop'
+                                : 'run',
+                            )}
+                          >
+                            {checkedHardwareInstallation.state === 'running'
+                              || checkedHardwareInstallation.state === 'unreachable'
+                              ? 'Stop'
+                              : 'Run'}
+                          </button>
+                          <button
+                            type="button"
+                            className="bn-device-action-button"
+                            disabled={
+                              busy
+                              || checkedHardwareInstallation.environment_installed === false
+                              || (
+                                checkedHardwareInstallation.state !== 'running'
+                                && checkedHardwareInstallation.state !== 'unreachable'
+                              )
+                            }
+                            title="Restart only the local Hardware package service"
+                            onClick={() => void manageLocalPackage(
+                              selectedDevice,
+                              'hardware',
+                              'restart',
+                            )}
+                          >
+                            Restart
+                          </button>
+                          <button
+                            type="button"
+                            className="bn-device-action-button is-danger"
+                            disabled={
+                              busy
+                              || checkedHardwareInstallation.environment_installed === false
+                            }
+                            onClick={() => void manageLocalPackage(
+                              selectedDevice,
+                              'hardware',
+                              'delete',
+                            )}
+                          >
+                            Delete
+                          </button>
+                        </>
+                      )}
                     </div>
                     <small>
-                      Robot services:{' '}
-                      {checkedHardwareComponents.map(component => (
-                        `${robotNameForPort(component.port)} (port ${component.port}) — ${
-                          component.error
-                            ? 'attention'
-                            : formatVersion(
-                              component.reported_version || component.installed.version,
-                            )
+                      {selectedDeviceManagedLocally
+                        ? `Service reports ${
+                          checkedHardwareInstallation.reported_version || 'version unavailable'
                         }`
-                      )).join(' · ')}
+                        : `Robot services: ${checkedHardwareComponents.map(component => (
+                          `${robotNameForPort(component.port)} (port ${component.port}) — ${
+                            component.error
+                              ? 'attention'
+                              : formatVersion(
+                                component.reported_version || component.installed.version,
+                              )
+                          }`
+                        )).join(' · ')}`}
                     </small>
                     {checkedHardwareComponents
                       .filter(component => Boolean(component.error))
@@ -2106,6 +2988,37 @@ export default function DevicesPanel() {
                       ))}
                   </div>
                 )}
+                {checkedHardwareComponents.length === 0 && (
+                  <div className="bn-device-update-empty">
+                    <div>
+                      <strong>No physical robot is attached to this Runtime</strong>
+                      <span>
+                        {selectedHardwareSiblingDevices.length
+                          ? `The Hardware package on this computer is managed under ${
+                            selectedHardwareSiblingDevices.map(device => device.name).join(', ')
+                          }. Open that Runtime card to check or repair its shared package installation.`
+                          : 'Attach a robot before checking or repairing the Hardware package.'}
+                      </span>
+                    </div>
+                    {selectedHardwareSiblingDevices.map(device => (
+                      <button
+                        type="button"
+                        className="bn-device-action-button"
+                        key={`open-hardware-${device.id}`}
+                        onClick={() => {
+                          setSelectedDeviceId(device.id)
+                          setUpdateCheckReport(null)
+                          setUpdateReport(null)
+                          setShowDirtySourceHelp(false)
+                          setUpdatePassword('')
+                          setShowUpdateForm(true)
+                        }}
+                      >
+                        Open {device.name} packages
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
               {updateCheckReport.warnings.length > 0 && (
                 <div className="bn-device-update-warnings">
@@ -2114,33 +3027,37 @@ export default function DevicesPanel() {
                   ))}
                 </div>
               )}
-              <div className="bn-device-update-report-actions">
-                <button
-                  type="button"
-                  className="bn-device-action-button"
-                  disabled={
-                    busy
-                    || !updatePassword
-                    || checkedSoftwareComponents.some(
-                      component => component.dirty || Boolean(component.error),
-                    )
-                  }
-                  title="Update or reinstall Runtime and the shared Robot Hardware installation together"
-                  onClick={() => void updateDevice(selectedDevice, 'all')}
-                >
-                  {checkedSoftwareComponents.some(component => component.update_available)
-                    ? 'Update all'
-                    : 'Reinstall all'}
-                </button>
-              </div>
+              {!selectedDeviceManagedLocally
+                && checkedRuntimeComponents.length > 0
+                && checkedHardwareComponents.length > 0 && (
+                <div className="bn-device-update-report-actions">
+                  <button
+                    type="button"
+                    className="bn-device-action-button"
+                    disabled={
+                      busy
+                      || !updatePassword
+                      || checkedSoftwareComponents.some(
+                        component => component.dirty || Boolean(component.error),
+                      )
+                    }
+                    title="Update or reinstall the Runtime and Hardware packages together"
+                    onClick={() => void updateDevice(selectedDevice, 'all')}
+                  >
+                    {checkedSoftwareComponents.some(component => component.update_available)
+                      ? 'Update all'
+                      : 'Reinstall all'}
+                  </button>
+                </div>
+              )}
             </section>
           )}
 
-          {updateReport && (
-            <section className="bn-device-update-report" aria-label="Runtime and Hardware update report">
+          {showUpdateForm && updateReport && showLegacyPackageManager && (
+            <section className="bn-device-update-report" aria-label="Runtime and Hardware package update report">
               <div className="bn-device-update-report-head">
                 <div>
-                  <strong>Runtime + Robot Hardware update report</strong>
+                  <strong>Runtime + Hardware package update report</strong>
                   <span>{updateReport.summary}</span>
                 </div>
                 <span>{updateReport.update.components.length} services checked</span>
@@ -2152,7 +3069,7 @@ export default function DevicesPanel() {
                     key={`${component.kind}-${component.service_name}-${component.port}`}
                   >
                     <div>
-                      <strong>Runtime</strong>
+                      <strong>Runtime package</strong>
                       <code>{component.service_name} · port {component.port}</code>
                     </div>
                     <div className="bn-device-update-version is-result">
@@ -2195,7 +3112,7 @@ export default function DevicesPanel() {
                 {updatedHardwareInstallation && (
                   <div className="bn-device-update-component" key="hardware-shared-result">
                     <div>
-                      <strong>Robot Hardware</strong>
+                      <strong>Hardware package</strong>
                       <code>
                         Shared installation · {updatedHardwareComponents.length} robot
                         {' '}service{updatedHardwareComponents.length === 1 ? '' : 's'}
@@ -2272,24 +3189,50 @@ export default function DevicesPanel() {
               }}
             >
               <div>
-                <strong>Uninstall this managed runtime</strong>
+                <strong>
+                  Uninstall this managed {
+                    selectedDeviceManagedLocally || selectedStackIsIsolated
+                      ? 'robot stack'
+                      : 'runtime'
+                  }
+                </strong>
                 <span>
-                  Stops {selectedDevice.managed_runtime.service_name}, removes only
-                  {' '}{selectedDevice.managed_runtime.runtime_dir}, its token and port
-                  {' '}{selectedDevice.managed_runtime.runtime_port} firewall rule. Other runtime
-                  instances on this computer stay untouched.
+                  {selectedDeviceManagedLocally
+                    ? selectedDevice.managed_runtime.hardware_dir
+                      ? `Stops the local Runtime on port ${selectedDevice.managed_runtime.runtime_port} and Robot Hardware on port ${selectedDevice.managed_runtime.hardware_port}.`
+                      : `Stops the local Runtime on port ${selectedDevice.managed_runtime.runtime_port}.`
+                    : `Stops ${selectedDevice.managed_runtime.service_name}, removes only ${selectedDevice.managed_runtime.runtime_dir}, its token and port ${selectedDevice.managed_runtime.runtime_port} firewall rule.`}
+                  {selectedStackIsIsolated
+                    ? ` Its instance-scoped Robot Hardware services and ${selectedDevice.managed_runtime.hardware_dir} are also removed.`
+                    : ''}
+                  {selectedDeviceManagedLocally
+                    ? selectedDevice.managed_runtime.hardware_dir
+                      ? selectedDevice.managed_runtime.owned_install
+                        && selectedDevice.managed_runtime.hardware_owned_install
+                        ? ' Both editor-created installation folders are removed.'
+                        : ' Existing source checkouts are preserved.'
+                      : selectedDevice.managed_runtime.owned_install
+                        ? ' The editor-created installation folder is removed.'
+                        : ' The existing source checkout is preserved.'
+                    : ' Other stacks on this computer stay untouched.'}
                 </span>
               </div>
-              <label>
-                <span>SSH password for {selectedDevice.managed_runtime.ssh_username}</span>
-                <input
-                  type="password"
-                  value={uninstallPassword}
-                  onChange={event => setUninstallPassword(event.target.value)}
-                  autoComplete="current-password"
-                  required
-                />
-              </label>
+              {!selectedDeviceManagedLocally && (
+                <label>
+                  <span>SSH password for {selectedDevice.managed_runtime.ssh_username}</span>
+                  <input
+                    type="password"
+                    value={uninstallPassword}
+                    onChange={event => setUninstallPassword(event.target.value)}
+                    autoComplete="current-password"
+                    disabled={busy}
+                    required
+                  />
+                </label>
+              )}
+              {actionProgress[selectedDevice.id] && (
+                <LifecycleProgress value={actionProgress[selectedDevice.id]} />
+              )}
               <div className="bn-device-form-actions">
                 <button
                   type="button"
@@ -2297,6 +3240,7 @@ export default function DevicesPanel() {
                     setShowUninstallForm(false)
                     setUninstallPassword('')
                   }}
+                  disabled={busy}
                   style={miniButton}
                 >
                   Cancel
@@ -2316,7 +3260,11 @@ export default function DevicesPanel() {
                   ? ' is-paused'
                 : selectedDeviceReady
                   ? ' is-ready'
-                  : ' is-error'
+                  : selectedCheckHasFailure
+                    ? ' is-error'
+                    : selectedCheckHasUnknown
+                      ? ' is-warning'
+                      : ''
             }`}
             role="status"
             aria-live="polite"
@@ -2329,20 +3277,50 @@ export default function DevicesPanel() {
                   : selectedDevice.paused || selectedDeviceState?.runtime?.paused
                     ? 'Device paused'
                   : selectedDeviceReady
-                    ? 'Device services connected'
-                    : 'Device needs attention'}
+                    ? 'Device services ready'
+                    : selectedCheckHasStopped
+                      ? 'Software package stopped'
+                    : selectedCheckHasFailure
+                      ? 'Device needs attention'
+                      : selectedCheckHasUnknown
+                        ? 'Connection status incomplete'
+                        : 'Device not checked'}
               </strong>
               <span>
                 {selectedDeviceChecking
-                  ? `Checking Runtime and ${selectedDevice.robots.length} Robot Hardware service${selectedDevice.robots.length === 1 ? '' : 's'}`
+                  ? `Checking installed package services and ${selectedDevice.robots.length} attached robot${selectedDevice.robots.length === 1 ? '' : 's'}`
                   : selectedDevice.paused || selectedDeviceState?.runtime?.paused
                     ? 'Deployments are stopped and attached robots are disarmed.'
-                  : selectedDeviceReady
-                    ? `${selectedServiceVersions.join(' · ')} · Last checked ${formatCheckedAt(selectedLastChecked)}`
-                    : selectedDeviceState?.runtime?.error
-                      || selectedRobotChecks.find(item => item.state?.error)?.state?.error
-                      || 'Run Check device to verify Runtime and attached Robot Hardware services.'}
+                    : selectedCheckStarted
+                      ? `${selectedReadyChecks}/${selectedServiceChecks.length} checks ready · Last checked ${formatCheckedAt(selectedLastChecked)}`
+                      : 'Run Check device to verify installed package services and attached robots.'}
               </span>
+              <div className="bn-runtime-check-services">
+                {selectedServiceChecks.map(service => (
+                  <div
+                    key={service.id}
+                    className={`bn-runtime-check-service is-${service.state}`}
+                  >
+                    <span className="bn-runtime-check-service-dot" aria-hidden="true" />
+                    <div>
+                      <strong>{service.name}</strong>
+                      <span>{service.kind} · {service.detail}</span>
+                    </div>
+                    <span className="bn-runtime-check-service-state">
+                      {service.state === 'unchecked'
+                        ? 'NOT CHECKED'
+                        : service.id.startsWith('packages:')
+                          && service.state === 'connected'
+                          ? 'READY'
+                        : service.state === 'stopped'
+                          ? 'STOPPED'
+                        : service.state === 'awaiting'
+                          ? 'AWAITING ROBOT'
+                          : service.state.toUpperCase()}
+                    </span>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
 
@@ -2431,8 +3409,26 @@ export default function DevicesPanel() {
           <div className="bn-device-robot-list">
             {selectedDevice.robots.length === 0 && !showRobotForm && (
               <div className="bn-device-robot-empty">
-                This compute device is ready. Attach its physical robot to create a
-                deployment target.
+                {selectedStackIsIsolated && selectedDevice.managed_runtime ? (
+                  <>
+                    <strong>Isolated Hardware environment ready</strong>
+                    <span>
+                      Connect the new robot, install only that serial device into this
+                      stack, then attach the pairing details here.
+                    </span>
+                    <code>
+                      cd {selectedDevice.managed_runtime.hardware_dir}
+                    </code>
+                    <code>
+                      BLACKNODE_HARDWARE_INSTANCE={selectedDevice.managed_runtime.instance_id}
+                      {' '}BLACKNODE_RUNTIME_PORT={selectedDevice.managed_runtime.runtime_port}
+                      {' '}./configure.sh --all --install
+                      {' '}--serial-port /dev/serial/by-id/NEW_ROBOT
+                    </code>
+                  </>
+                ) : (
+                  'This compute device is ready. Attach its physical robot to create a deployment target.'
+                )}
               </div>
             )}
             {selectedDevice.robots.map(robot => (
@@ -2440,12 +3436,13 @@ export default function DevicesPanel() {
                 key={robot.id}
                 robot={robot}
                 state={robotStates[robot.id]}
-                runtimeReady={deviceStates[selectedDevice.id]?.runtime?.ok === true}
                 actionProgress={actionProgress[robot.id]}
                 installedSoftwareVersion={installedHardwareVersionForPort(
                   urlPort(robot.base_url),
                 )}
-                canRestartService={Boolean(selectedDevice.managed_runtime)}
+                canRestartService={Boolean(
+                  selectedDevice.managed_runtime && !selectedDeviceManagedLocally,
+                )}
                 sshUsername={selectedDevice.managed_runtime?.ssh_username}
                 busy={busy}
                 onRefresh={() => refreshRobot(robot)}
@@ -2455,9 +3452,13 @@ export default function DevicesPanel() {
                   'blacknode:open-panel',
                   { detail: { tab: 'deployments', deviceId: robot.id } },
                 ))}
+                onMonitor={() => window.dispatchEvent(new CustomEvent(
+                  'blacknode:monitor-robot',
+                  { detail: { robotId: robot.id, robotName: robot.name } },
+                ))}
                 onStopDeployment={deploymentId => stopDeployment(robot, deploymentId)}
                 onStartDeployment={(deploymentId, deploymentName) => (
-                  restartStoredDeployment(robot, deploymentId, deploymentName)
+                  restartDeployment(robot, deploymentId, deploymentName)
                 )}
                 onReleaseTorque={() => releaseRobotTorque(robot)}
                 onControl={action => controlRobot(robot, action)}
@@ -2484,8 +3485,25 @@ function ComputeDeviceCard({
 }) {
   const paused = Boolean(device.paused || state?.runtime?.paused)
   const ready = !paused && state?.runtime?.ok === true
-  const label = state?.loading ? 'CHECKING' : paused ? 'PAUSED' : ready ? 'READY' : 'ATTENTION'
-  const color = paused ? 'var(--tx3)' : ready ? 'var(--ok)' : state?.runtime ? 'var(--warn)' : 'var(--tx3)'
+  const stopped = !paused && state?.runtime?.state === 'stopped'
+  const local = isLocalRuntimeUrl(device.runtime_url)
+  const isolated = device.managed_runtime?.stack_mode === 'isolated'
+  const label = state?.loading
+    ? 'CHECKING'
+    : paused
+      ? 'PAUSED'
+      : stopped
+        ? 'STOPPED'
+        : ready
+          ? 'READY'
+          : 'ATTENTION'
+  const color = paused || stopped
+    ? 'var(--tx3)'
+    : ready
+      ? 'var(--ok)'
+      : state?.runtime
+        ? 'var(--warn)'
+        : 'var(--tx3)'
   return (
     <button
       type="button"
@@ -2495,6 +3513,9 @@ function ComputeDeviceCard({
       aria-pressed={selected}
     >
       <span className="bn-compute-device-card-top">
+        <span className="bn-compute-device-kind">
+          {local ? 'LOCAL' : isolated ? 'REMOTE · ISOLATED' : 'REMOTE'}
+        </span>
         <span className="bn-compute-device-status">{label}</span>
       </span>
       <span className="bn-compute-device-card-body">
@@ -2505,10 +3526,132 @@ function ComputeDeviceCard({
   )
 }
 
+function SoftwarePackageSummaryCard({
+  label,
+  path,
+  detail,
+  state,
+  version,
+  installed,
+  updateAvailable,
+  busy,
+  runStopEnabled = true,
+  restartEnabled = true,
+  deleteEnabled = true,
+  onRunStop,
+  onRestart,
+  onUpdate,
+  onReinstall,
+  onDelete,
+}: {
+  label: string
+  path: string
+  detail?: string
+  state: string
+  version: string
+  installed: boolean
+  updateAvailable: boolean
+  busy: boolean
+  runStopEnabled?: boolean
+  restartEnabled?: boolean
+  deleteEnabled?: boolean
+  onRunStop: (action: 'run' | 'stop') => void
+  onRestart: () => void
+  onUpdate: () => void
+  onReinstall: () => void
+  onDelete: () => void
+}) {
+  const normalizedState = String(state || 'unchecked').toLowerCase()
+  const running = ['running', 'unreachable', 'awaiting_device', 'configured'].includes(
+    normalizedState,
+  )
+  const statusLabel = normalizedState === 'checking'
+    ? 'CHECKING'
+    : running && normalizedState !== 'unreachable'
+      ? 'RUNNING'
+      : normalizedState === 'stopped'
+        ? 'STOPPED'
+        : normalizedState === 'unreachable'
+          ? 'UNREACHABLE'
+          : normalizedState === 'unavailable'
+            ? 'NOT INSTALLED'
+            : 'NOT CHECKED'
+  const statusTone = normalizedState === 'checking'
+    ? 'checking'
+    : running && normalizedState !== 'unreachable'
+      ? 'running'
+      : normalizedState === 'stopped'
+        ? 'stopped'
+        : normalizedState === 'unavailable'
+          ? 'missing'
+          : 'attention'
+
+  return (
+    <article className="bn-local-package-card">
+      <div className="bn-local-package-card-head">
+        <div>
+          <strong>{label}</strong>
+          <span>{version}</span>
+        </div>
+        <span className={`bn-local-package-state is-${statusTone}`}>
+          <i aria-hidden="true" />
+          {statusLabel}
+        </span>
+      </div>
+      <code title={path}>{path}</code>
+      {detail && <small>{detail}</small>}
+      {updateAvailable && (
+        <div className="bn-local-package-update-available">Update available</div>
+      )}
+      <div className="bn-local-package-actions">
+        <button
+          type="button"
+          className="bn-device-action-button"
+          disabled={busy || !installed || !runStopEnabled}
+          onClick={() => onRunStop(running ? 'stop' : 'run')}
+        >
+          {running ? 'Stop' : 'Run'}
+        </button>
+        <button
+          type="button"
+          className="bn-device-action-button"
+          disabled={busy || !installed || !running || !restartEnabled}
+          onClick={onRestart}
+        >
+          Restart
+        </button>
+        <button
+          type="button"
+          className={`bn-device-action-button${updateAvailable ? ' is-primary' : ''}`}
+          disabled={busy}
+          onClick={onUpdate}
+        >
+          Update
+        </button>
+        <button
+          type="button"
+          className="bn-device-action-button"
+          disabled={busy}
+          onClick={onReinstall}
+        >
+          Reinstall
+        </button>
+        <button
+          type="button"
+          className="bn-device-action-button is-danger"
+          disabled={busy || !installed || !deleteEnabled}
+          onClick={onDelete}
+        >
+          Delete
+        </button>
+      </div>
+    </article>
+  )
+}
+
 function RobotRow({
   robot,
   state,
-  runtimeReady,
   actionProgress,
   installedSoftwareVersion,
   canRestartService,
@@ -2518,6 +3661,7 @@ function RobotRow({
   onRename,
   onRemove,
   onDeploy,
+  onMonitor,
   onStopDeployment,
   onStartDeployment,
   onReleaseTorque,
@@ -2526,7 +3670,6 @@ function RobotRow({
 }: {
   robot: HardwareDevice
   state?: RobotState
-  runtimeReady: boolean
   actionProgress?: DeviceActionProgress
   installedSoftwareVersion: string
   canRestartService: boolean
@@ -2536,6 +3679,7 @@ function RobotRow({
   onRename: () => void
   onRemove: () => void
   onDeploy: () => void
+  onMonitor: () => void
   onStopDeployment: (deploymentId: string) => void
   onStartDeployment: (deploymentId: string, deploymentName: string) => void
   onReleaseTorque: () => void
@@ -2544,13 +3688,14 @@ function RobotRow({
 }) {
   const [expanded, setExpanded] = useState(false)
   const [showRestart, setShowRestart] = useState(false)
-  const [showMonitor, setShowMonitor] = useState(false)
   const [showTorqueDetails, setShowTorqueDetails] = useState(false)
   const [restartPassword, setRestartPassword] = useState('')
   const status = state?.status
   const deploymentLease = status?.deployment_lease
   const runningDeployment = deploymentLease ?? status?.running_deployment
-  const storedDeployment = runningDeployment ? undefined : status?.stored_deployment
+  const inactiveDeployment = runningDeployment
+    ? undefined
+    : status?.inactive_deployment ?? status?.stored_deployment
   const torqueReleaseSupported = Boolean(
     status?.service_features?.includes('torque_release_v1'),
   )
@@ -2560,56 +3705,58 @@ function RobotRow({
       : 'Robot Hardware did not receive a valid torque-register reading from every configured servo.')
   const mqttTelemetry = status?.telemetry?.sinks.find(sink => sink.name === 'mqtt')
   const paused = Boolean(robot.paused || status?.paused)
-  const leased = Boolean(status?.leased_to_deployment || deploymentLease)
   const connected = Boolean(status?.connected)
   const armed = Boolean(status?.armed)
-  const ready = !paused && !armed && runtimeReady && (connected || leased)
-  const color = paused
-    ? 'var(--tx3)'
-    : armed
-      ? 'var(--warn)'
-      : ready
-        ? 'var(--ok)'
-        : status
-          ? 'var(--warn)'
-          : 'var(--err)'
-  const label = state?.loading
-    ? 'CHECK'
-    : paused
-      ? 'PAUSED'
-    : deploymentLease
-      ? 'ACTIVE'
-      : runningDeployment
-        ? 'RUNNING'
-      : armed
-        ? 'ARMED'
-      : storedDeployment
-        ? 'STORED'
-      : ready
-        ? 'CONNECTED'
-        : 'OFF'
+  const connectionState = state?.loading
+    ? 'checking'
+    : !status
+      ? 'unreachable'
+      : connected
+        ? 'connected'
+        : 'disconnected'
+  const connectionLabel = {
+    checking: 'CHECKING',
+    connected: 'CONNECTED',
+    disconnected: 'DISCONNECTED',
+    unreachable: 'UNREACHABLE',
+  }[connectionState]
+  const connectionColor = {
+    checking: 'var(--accent)',
+    connected: 'var(--ok)',
+    disconnected: 'var(--err)',
+    unreachable: 'var(--err)',
+  }[connectionState]
+  const deploymentState = runningDeployment ? 'running' : inactiveDeployment?.state
+  const deploymentLabel = deploymentState === 'running'
+    ? 'ACTIVE'
+    : deploymentState === 'failed'
+      ? 'FAILED'
+      : deploymentState === 'exited'
+        ? 'COMPLETED'
+        : deploymentState
+          ? 'INACTIVE'
+          : 'NONE'
+  const deploymentColor = deploymentState === 'running'
+    ? 'var(--ok)'
+    : deploymentState === 'failed'
+      ? 'var(--err)'
+      : deploymentState === 'exited'
+        ? 'var(--tx2)'
+        : 'var(--tx3)'
   const summary = state?.loading
     ? 'Checking robot hardware…'
-    : paused
-      ? 'Stopped and disarmed'
-    : deploymentLease
-      ? `Deployment “${deploymentLease.name}” is running`
-      : runningDeployment
-        ? `Deployment “${runningDeployment.name}” is running · motion control not held`
-      : armed
-        ? 'Robot motion is armed'
-      : storedDeployment
-        ? `Deployment “${storedDeployment.name}” is stored · ${storedDeployment.state}`
-      : ready
-        ? 'Hardware monitoring connected · Blacknode motion disarmed'
-        : status
-          ? 'Robot needs attention'
-          : 'Robot Hardware service unavailable'
+    : !status
+      ? 'Robot Hardware service unreachable'
+      : connected
+        ? `Hardware connected · motion ${armed ? 'armed' : 'disarmed'}${paused ? ' · paused' : ''}`
+        : status.connection_reported === false && status.notice
+          ? status.notice
+          : `Hardware disconnected${paused ? ' · robot paused and disarmed' : ''}`
 
   return (
     <div
       className={`bn-run-row bn-device-card${expanded ? ' is-expanded' : ''}`}
-      style={{ '--run-status': color } as CSSProperties}
+      style={{ '--run-status': connectionColor } as CSSProperties}
     >
       <button
         type="button"
@@ -2622,7 +3769,22 @@ function RobotRow({
           <strong>{robot.name}</strong>
           <span>{summary}</span>
         </span>
-        <span className="bn-device-card-state">{label}</span>
+        <span className="bn-device-card-statuses">
+          <span
+            className="bn-device-card-state"
+            style={{ '--device-status-color': connectionColor } as CSSProperties}
+          >
+            <small>Connection</small>
+            {connectionLabel}
+          </span>
+          <span
+            className="bn-device-card-state"
+            style={{ '--device-status-color': deploymentColor } as CSSProperties}
+          >
+            <small>Deployment</small>
+            {deploymentLabel}
+          </span>
+        </span>
         <span className="bn-device-card-chevron" aria-hidden="true">›</span>
       </button>
       {expanded && (
@@ -2646,8 +3808,8 @@ function RobotRow({
                 ? ' is-active'
                 : runningDeployment
                   ? ' is-running'
-                  : storedDeployment
-                    ? ' is-stored'
+                  : inactiveDeployment
+                    ? ' is-inactive'
                     : ''
             }`}
             role="status"
@@ -2658,8 +3820,8 @@ function RobotRow({
                 ? status?.notice || `“${deploymentLease.name}” is running.`
                 : runningDeployment
                   ? status?.notice || `“${runningDeployment.name}” is running without motion control.`
-                : storedDeployment
-                  ? status?.notice || `“${storedDeployment.name}” remains stored on the Runtime and can be restarted.`
+                : inactiveDeployment
+                  ? status?.notice || `“${inactiveDeployment.name}” is ${inactiveDeployment.state} and can be restarted.`
                 : 'No deployment currently controls this robot.'}
             </span>
           </div>
@@ -2701,7 +3863,7 @@ function RobotRow({
                   ? `v${installedSoftwareVersion} (installed)`
                   : 'Not reported'}
             />
-            <DeviceFact label="Connection" value={connected || leased ? 'Connected' : 'Unavailable'} />
+            <DeviceFact label="Connection" value={connectionLabel} warn={!connected} />
             {mqttTelemetry && (
               <DeviceFact
                 label="MQTT telemetry"
@@ -2766,8 +3928,8 @@ function RobotRow({
           <div className="bn-run-detail-actions bn-robot-card-actions is-primary">
             <button
               onClick={() => {
-                if (storedDeployment?.id) {
-                  onStartDeployment(storedDeployment.id, storedDeployment.name)
+                if (inactiveDeployment?.id) {
+                  onStartDeployment(inactiveDeployment.id, inactiveDeployment.name)
                 } else {
                   onDeploy()
                 }
@@ -2776,21 +3938,21 @@ function RobotRow({
               className="bn-device-action-button is-primary"
               title={paused
                 ? `Resume this robot before ${
-                  storedDeployment ? 'restarting its stored deployment' : 'deploying a workflow'
+                  inactiveDeployment ? 'restarting its deployment' : 'deploying a workflow'
                 }`
-                : storedDeployment
-                  ? `Start the stored ${storedDeployment.state} deployment`
+                : inactiveDeployment
+                  ? `Start the ${inactiveDeployment.state} deployment`
                   : 'Open deployment setup and history for this robot'}
             >
-              {storedDeployment ? 'Restart deployment' : 'Deploy workflow'}
+              {inactiveDeployment ? 'Restart deployment' : 'Deploy workflow'}
             </button>
             <button
               type="button"
-              onClick={() => setShowMonitor(value => !value)}
-              className={`bn-device-action-button${showMonitor ? ' is-primary' : ''}`}
-              aria-pressed={showMonitor}
+              onClick={onMonitor}
+              className="bn-device-action-button"
+              title="Open or focus this robot's live monitor node on the canvas"
             >
-              {showMonitor ? 'Close monitor' : 'Monitor live'}
+              Monitor
             </button>
             <button
               onClick={() => onControl(paused ? 'resume' : 'pause')}
@@ -2803,22 +3965,21 @@ function RobotRow({
               onClick={() => {
                 if (runningDeployment?.id) {
                   onStopDeployment(runningDeployment.id)
-                } else if (storedDeployment) {
+                } else if (inactiveDeployment) {
                   onDeploy()
                 }
               }}
-              disabled={busy || state?.loading || (!runningDeployment?.id && !storedDeployment)}
+              disabled={busy || state?.loading || (!runningDeployment?.id && !inactiveDeployment)}
               title={runningDeployment?.id
                 ? 'Stop the workflow running on this robot'
-                : storedDeployment
-                  ? 'Open this robot’s stored deployment and revision history'
-                  : 'No deployment is stored on this robot'}
+                : inactiveDeployment
+                  ? 'Open this robot’s deployment and revision history'
+                  : 'No deployment exists for this robot'}
               className="bn-device-action-button"
             >
-              {storedDeployment ? 'Deployment details' : 'Stop deployment'}
+              {inactiveDeployment ? 'Deployment details' : 'Stop deployment'}
             </button>
           </div>
-          {showMonitor && <RobotMonitor robot={robot} />}
           <div className="bn-run-detail-actions bn-robot-card-actions is-secondary">
             <button
               onClick={onRefresh}
@@ -2904,228 +4065,6 @@ function RobotRow({
       )}
     </div>
   )
-}
-
-type JointTrace = {
-  position: number[]
-  velocity: number[]
-}
-
-function RobotMonitor({ robot }: { robot: HardwareDevice }) {
-  const [sample, setSample] = useState<RobotTelemetrySample | null>(null)
-  const [connection, setConnection] = useState<'connecting' | 'live' | 'offline'>('connecting')
-  const [traces, setTraces] = useState<Record<string, JointTrace>>({})
-  const previous = useRef<Record<string, { position: number; at: number }>>({})
-  const activeSource = useRef('')
-
-  useEffect(() => {
-    let stopped = false
-    let socket: WebSocket | null = null
-    let reconnectTimer: number | undefined
-
-    const connect = () => {
-      if (stopped) return
-      setConnection('connecting')
-      socket = new WebSocket(deviceMonitorSocketUrl(robot.id))
-      socket.onopen = () => setConnection('live')
-      socket.onmessage = event => {
-        let next: RobotTelemetrySample
-        try {
-          next = JSON.parse(String(event.data)) as RobotTelemetrySample
-        } catch {
-          return
-        }
-        const sourceKey = `${next.source || 'unknown'}:${next.source_label || ''}`
-        if (activeSource.current && activeSource.current !== sourceKey) {
-          previous.current = {}
-          setTraces({})
-        }
-        activeSource.current = sourceKey
-        const receivedAt = Date.now()
-        if (next.available && next.payload?.joints) {
-          const normalized = next.payload.joints.map(joint => {
-            const prior = previous.current[joint.name]
-            const elapsed = prior ? (receivedAt - prior.at) / 1000 : 0
-            const derivedVelocity = elapsed > 0
-              ? (joint.position - prior.position) / elapsed
-              : 0
-            previous.current[joint.name] = {
-              position: joint.position,
-              at: receivedAt,
-            }
-            return {
-              ...joint,
-              velocity: next.source === 'hardware'
-                ? derivedVelocity
-                : Number.isFinite(joint.velocity) ? joint.velocity : derivedVelocity,
-            }
-          })
-          next = {
-            ...next,
-            payload: {
-              ...next.payload,
-              joints: normalized,
-            },
-          }
-          setTraces(current => {
-            const updated = { ...current }
-            for (const joint of normalized) {
-              const trace = updated[joint.name] || { position: [], velocity: [] }
-              updated[joint.name] = {
-                position: [...trace.position, joint.position].slice(-80),
-                velocity: [...trace.velocity, joint.velocity].slice(-80),
-              }
-            }
-            return updated
-          })
-        }
-        setSample(next)
-      }
-      socket.onerror = () => socket?.close()
-      socket.onclose = () => {
-        if (stopped) return
-        setConnection('offline')
-        reconnectTimer = window.setTimeout(connect, 1200)
-      }
-    }
-
-    connect()
-    return () => {
-      stopped = true
-      if (reconnectTimer !== undefined) window.clearTimeout(reconnectTimer)
-      socket?.close()
-    }
-  }, [robot.id])
-
-  const joints = sample?.payload?.joints || []
-  const sourceLabel = sample?.source === 'deployment'
-    ? `Deployed · ${sample.source_label || 'workflow'}`
-    : 'Local · Robot Hardware'
-  const torque = sample?.payload?.torque_enabled
-  const stateLabel = connection !== 'live'
-    ? connection
-    : sample?.stale
-      ? 'stale'
-      : sample?.available
-        ? 'live'
-        : 'waiting'
-
-  return (
-    <section className="bn-robot-monitor" aria-label={`Live monitoring for ${robot.name}`}>
-      <div className="bn-robot-monitor-head">
-        <div>
-          <span className={`bn-robot-monitor-pulse is-${stateLabel}`} aria-hidden="true" />
-          <div>
-            <strong>Live robot state</strong>
-            <span>{sourceLabel}</span>
-          </div>
-        </div>
-        <div className="bn-robot-monitor-status">
-          <span className={`is-${stateLabel}`}>{stateLabel.toUpperCase()}</span>
-          <span>
-            Torque {torque == null ? 'unknown' : torque ? 'on' : 'off'}
-          </span>
-        </div>
-      </div>
-
-      {!sample?.available || joints.length === 0 ? (
-        <div className="bn-robot-monitor-empty" role="status">
-          <strong>
-            {connection === 'connecting'
-              ? 'Connecting to robot…'
-              : connection === 'offline'
-                ? 'Reconnecting…'
-                : 'Waiting for joint state'}
-          </strong>
-          <span>
-            {sample?.message
-              || 'The monitor will start as soon as this robot reports joint positions.'}
-          </span>
-        </div>
-      ) : (
-        <>
-          <div className="bn-robot-monitor-meta">
-            <span>{joints.length} joints</span>
-            <span>{sample.payload?.position_unit || 'degree'}</span>
-            <span>
-              Updated {sample.received_at
-                ? new Date(sample.received_at).toLocaleTimeString()
-                : 'now'}
-            </span>
-          </div>
-          <div className="bn-robot-monitor-grid">
-            {joints.map(joint => (
-              <JointMonitorCard
-                key={joint.name}
-                joint={joint}
-                trace={traces[joint.name]}
-                positionUnit={sample.payload?.position_unit || 'degree'}
-                velocityUnit={sample.payload?.velocity_unit || 'degree/s'}
-              />
-            ))}
-          </div>
-        </>
-      )}
-    </section>
-  )
-}
-
-function JointMonitorCard({
-  joint,
-  trace,
-  positionUnit,
-  velocityUnit,
-}: {
-  joint: RobotTelemetryJoint
-  trace?: JointTrace
-  positionUnit: string
-  velocityUnit: string
-}) {
-  return (
-    <article className="bn-joint-monitor-card">
-      <div className="bn-joint-monitor-title">
-        <strong title={joint.name}>{joint.name.replace(/_/g, ' ')}</strong>
-        <span>{joint.position.toFixed(2)} {shortUnit(positionUnit)}</span>
-      </div>
-      <TelemetrySparkline values={trace?.position || []} />
-      <div className="bn-joint-monitor-speed">
-        <span>Speed</span>
-        <strong>{joint.velocity.toFixed(2)} {shortUnit(velocityUnit)}</strong>
-      </div>
-    </article>
-  )
-}
-
-function TelemetrySparkline({ values }: { values: number[] }) {
-  const width = 180
-  const height = 44
-  const finite = values.filter(Number.isFinite)
-  const minimum = finite.length ? Math.min(...finite) : 0
-  const maximum = finite.length ? Math.max(...finite) : 0
-  const range = Math.max(maximum - minimum, 0.001)
-  const points = finite.map((value, index) => {
-    const x = finite.length <= 1 ? width : index * width / (finite.length - 1)
-    const y = height - 4 - ((value - minimum) / range) * (height - 8)
-    return `${x.toFixed(1)},${y.toFixed(1)}`
-  }).join(' ')
-  return (
-    <svg
-      className="bn-joint-monitor-chart"
-      viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="none"
-      role="img"
-      aria-label="Recent joint position"
-    >
-      <line x1="0" y1={height / 2} x2={width} y2={height / 2} />
-      {points && <polyline points={points} />}
-    </svg>
-  )
-}
-
-function shortUnit(unit: string): string {
-  return unit
-    .replace('degree', '°')
-    .replace('/s', '/s')
 }
 
 function LifecycleProgress({

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -228,6 +228,12 @@ export default function NodePalette() {
   })
 
   useEffect(() => {
+    const handleClosePanel = () => setActiveTab(null)
+    window.addEventListener('blacknode:close-panel', handleClosePanel)
+    return () => window.removeEventListener('blacknode:close-panel', handleClosePanel)
+  }, [])
+
+  useEffect(() => {
     const handleViewportResize = () => {
       setPanelWidth(width => clampPanelWidth(width))
     }

--- a/editor/src/components/RobotMonitorNode.tsx
+++ b/editor/src/components/RobotMonitorNode.tsx
@@ -1,0 +1,433 @@
+import { useEffect, useRef, useState } from 'react'
+import { Handle, Position, type NodeProps } from 'reactflow'
+
+import {
+  api,
+  deviceMonitorSocketUrl,
+  type HardwareDevice,
+  type RobotTelemetryJoint,
+  type RobotTelemetrySample,
+} from '../api'
+import { useStore, type NodeData } from '../store'
+import NodeFrame from './NodeFrame'
+
+type MonitorConnection = 'idle' | 'connecting' | 'live' | 'offline'
+
+type JointTrace = {
+  position: number[]
+  velocity: number[]
+}
+
+export default function RobotMonitorNode({ id, data, selected }: NodeProps<NodeData>) {
+  const updateParam = useStore(state => state.updateParam)
+  const [robots, setRobots] = useState<HardwareDevice[]>([])
+  const [listError, setListError] = useState('')
+  const robotId = String(data.params?.robot_id || '').trim()
+  const savedName = String(data.params?.robot_name || '').trim()
+  const selectedRobot = robots.find(robot => robot.id === robotId)
+  const robotName = selectedRobot?.name || savedName || 'Choose a robot'
+
+  useEffect(() => {
+    let active = true
+    api.listDevices()
+      .then(result => {
+        if (!active) return
+        setRobots(result.devices)
+        setListError('')
+      })
+      .catch(error => {
+        if (!active) return
+        setListError(error instanceof Error ? error.message : String(error))
+      })
+    return () => { active = false }
+  }, [])
+
+  const chooseRobot = async (nextId: string) => {
+    const robot = robots.find(item => item.id === nextId)
+    await updateParam(id, 'robot_id', nextId)
+    await updateParam(id, 'robot_name', robot?.name || '')
+  }
+
+  return (
+    <NodeFrame
+      id={id}
+      data={data}
+      selected={selected}
+      color="#00b8d9"
+      nodeType={data.type}
+      style={{ width: '100%', minWidth: 620 }}
+    >
+      <header className="bn-robot-monitor-node-title">
+        <div>
+          <span>ROBOT MONITOR</span>
+          <strong>{robotName}</strong>
+        </div>
+        <label
+          className="nodrag"
+          onMouseDown={event => event.stopPropagation()}
+          onClick={event => event.stopPropagation()}
+        >
+          <span>Robot</span>
+          <select
+            value={robotId}
+            onChange={event => void chooseRobot(event.target.value)}
+            aria-label="Robot to monitor"
+          >
+            <option value="">Choose a robot…</option>
+            {robots.map(robot => (
+              <option key={robot.id} value={robot.id}>{robot.name}</option>
+            ))}
+            {robotId && !selectedRobot && (
+              <option value={robotId}>{savedName || robotId} (unavailable)</option>
+            )}
+          </select>
+        </label>
+      </header>
+
+      <RobotLiveMonitor
+        robotId={robotId}
+        robotName={robotName}
+        emptyMessage={listError}
+      />
+
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="robot"
+        title="robot · Dict"
+        style={{ background: '#a855f7', width: 10, height: 10 }}
+      />
+    </NodeFrame>
+  )
+}
+
+function RobotLiveMonitor({
+  robotId,
+  robotName,
+  emptyMessage,
+}: {
+  robotId: string
+  robotName: string
+  emptyMessage: string
+}) {
+  const [sample, setSample] = useState<RobotTelemetrySample | null>(null)
+  const [connection, setConnection] = useState<MonitorConnection>(
+    robotId ? 'connecting' : 'idle',
+  )
+  const [traces, setTraces] = useState<Record<string, JointTrace>>({})
+  const previous = useRef<Record<string, { position: number; at: number }>>({})
+  const activeSource = useRef('')
+
+  useEffect(() => {
+    setSample(null)
+    setTraces({})
+    previous.current = {}
+    activeSource.current = ''
+    if (!robotId) {
+      setConnection('idle')
+      return
+    }
+
+    let stopped = false
+    let socket: WebSocket | null = null
+    let reconnectTimer: number | undefined
+
+    const connect = () => {
+      if (stopped) return
+      setConnection('connecting')
+      socket = new WebSocket(deviceMonitorSocketUrl(robotId))
+      socket.onopen = () => setConnection('live')
+      socket.onmessage = event => {
+        let next: RobotTelemetrySample
+        try {
+          next = JSON.parse(String(event.data)) as RobotTelemetrySample
+        } catch {
+          return
+        }
+        const sourceKey = `${next.source || 'unknown'}:${next.source_label || ''}`
+        if (activeSource.current && activeSource.current !== sourceKey) {
+          previous.current = {}
+          setTraces({})
+        }
+        activeSource.current = sourceKey
+        const receivedAt = Date.now()
+        if (next.available && next.payload?.joints) {
+          const normalized = next.payload.joints.map(joint => {
+            const prior = previous.current[joint.name]
+            const elapsed = prior ? (receivedAt - prior.at) / 1000 : 0
+            const derivedVelocity = elapsed > 0
+              ? (joint.position - prior.position) / elapsed
+              : 0
+            previous.current[joint.name] = {
+              position: joint.position,
+              at: receivedAt,
+            }
+            return {
+              ...joint,
+              velocity: next.source === 'hardware'
+                ? derivedVelocity
+                : Number.isFinite(joint.velocity) ? joint.velocity : derivedVelocity,
+            }
+          })
+          next = {
+            ...next,
+            payload: {
+              ...next.payload,
+              joints: normalized,
+            },
+          }
+          setTraces(current => {
+            const updated = { ...current }
+            for (const joint of normalized) {
+              const trace = updated[joint.name] || { position: [], velocity: [] }
+              updated[joint.name] = {
+                position: [...trace.position, joint.position].slice(-80),
+                velocity: [...trace.velocity, joint.velocity].slice(-80),
+              }
+            }
+            return updated
+          })
+        }
+        setSample(next)
+      }
+      socket.onerror = () => socket?.close()
+      socket.onclose = () => {
+        if (stopped) return
+        setConnection('offline')
+        reconnectTimer = window.setTimeout(connect, 1200)
+      }
+    }
+
+    connect()
+    return () => {
+      stopped = true
+      if (reconnectTimer !== undefined) window.clearTimeout(reconnectTimer)
+      socket?.close()
+    }
+  }, [robotId])
+
+  const joints = sample?.payload?.joints || []
+  const cameras = sample?.payload?.camera_streams || []
+  const sourceLabel = sample?.source === 'deployment'
+    ? `Deployment · ${sample.source_label || sample.deployment?.name || 'workflow'}`
+    : 'Robot Hardware'
+  const stateLabel = connection !== 'live'
+    ? connection
+    : sample?.stale
+      ? 'stale'
+      : sample?.available
+        ? 'live'
+        : 'waiting'
+  const connected = sample?.payload?.connected
+  const armed = sample?.payload?.armed
+  const torque = sample?.payload?.torque_enabled
+  const battery = sample?.payload?.battery
+
+  return (
+    <section
+      className="bn-robot-monitor bn-robot-monitor-node-panel"
+      aria-label={`Live monitoring for ${robotName}`}
+    >
+      <div className="bn-robot-monitor-head">
+        <div>
+          <span className={`bn-robot-monitor-pulse is-${stateLabel}`} aria-hidden="true" />
+          <div>
+            <strong>Live robot state</strong>
+            <span>{robotId ? sourceLabel : 'Select a registered robot above'}</span>
+          </div>
+        </div>
+        <div className="bn-robot-monitor-status">
+          <span className={`is-${stateLabel}`}>{stateLabel.toUpperCase()}</span>
+          {sample?.sequence != null && <span>#{sample.sequence}</span>}
+        </div>
+      </div>
+
+      {robotId && (
+        <div className="bn-robot-monitor-overview">
+          <MonitorFact
+            label="Hardware"
+            value={connected == null ? 'Waiting' : connected ? 'Connected' : 'Disconnected'}
+            tone={connected == null ? 'muted' : connected ? 'ok' : 'error'}
+          />
+          <MonitorFact
+            label="Motion"
+            value={armed == null ? 'Unknown' : armed ? 'Armed' : 'Disarmed'}
+            tone={armed ? 'warning' : armed === false ? 'ok' : 'muted'}
+          />
+          <MonitorFact
+            label="Torque"
+            value={torque == null ? 'Unknown' : torque ? 'On' : 'Off'}
+            tone={torque ? 'warning' : torque === false ? 'ok' : 'muted'}
+          />
+          <MonitorFact
+            label="Telemetry"
+            value={sample?.stale ? 'Stale' : sample?.available ? 'Streaming' : 'Waiting'}
+            tone={sample?.stale ? 'warning' : sample?.available ? 'live' : 'muted'}
+          />
+          {battery && (
+            <MonitorFact
+              label="Battery"
+              value={formatBattery(battery)}
+              tone={battery.level != null && battery.level <= 0.2 ? 'warning' : 'ok'}
+            />
+          )}
+          <MonitorFact
+            label="Source"
+            value={sample?.source === 'deployment' ? 'Deployment' : 'Hardware'}
+            tone="live"
+          />
+        </div>
+      )}
+
+      {!robotId || !sample?.available ? (
+        <div className="bn-robot-monitor-empty" role="status">
+          <strong>
+            {!robotId
+              ? 'Choose a robot to start monitoring'
+              : connection === 'connecting'
+                ? 'Connecting to robot…'
+                : connection === 'offline'
+                  ? 'Reconnecting…'
+                  : 'Waiting for live telemetry'}
+          </strong>
+          <span>
+            {emptyMessage
+              || sample?.message
+              || (robotId
+                ? 'Live data appears here as soon as Robot Hardware or its active deployment reports it.'
+                : 'This node remembers the selected robot with the workflow.')}
+          </span>
+        </div>
+      ) : (
+        <>
+          <div className="bn-robot-monitor-meta">
+            <span>{joints.length} joints</span>
+            <span>{cameras.length} streams</span>
+            <span>{sample.payload?.position_unit || 'degree'}</span>
+            <span>
+              Updated {sample.received_at
+                ? new Date(sample.received_at).toLocaleTimeString()
+                : 'now'}
+            </span>
+          </div>
+
+          {cameras.length > 0 && (
+            <div className="bn-robot-monitor-cameras">
+              {cameras.map(camera => (
+                <article key={camera.id}>
+                  <strong>{camera.label || camera.id}</strong>
+                  {camera.url
+                    ? <img src={camera.url} alt={`${camera.label || camera.id} live stream`} />
+                    : <span>Stream URL unavailable</span>}
+                </article>
+              ))}
+            </div>
+          )}
+
+          {joints.length > 0 ? (
+            <div className="bn-robot-monitor-grid">
+              {joints.map(joint => (
+                <JointMonitorCard
+                  key={joint.name}
+                  joint={joint}
+                  trace={traces[joint.name]}
+                  positionUnit={sample.payload?.position_unit || 'degree'}
+                  velocityUnit={sample.payload?.velocity_unit || 'degree/s'}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="bn-robot-monitor-empty" role="status">
+              <strong>Telemetry is live</strong>
+              <span>This robot is not reporting joint positions yet.</span>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+function MonitorFact({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: string
+  tone: 'ok' | 'warning' | 'error' | 'live' | 'muted'
+}) {
+  return (
+    <div className={`bn-robot-monitor-fact is-${tone}`}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  )
+}
+
+function JointMonitorCard({
+  joint,
+  trace,
+  positionUnit,
+  velocityUnit,
+}: {
+  joint: RobotTelemetryJoint
+  trace?: JointTrace
+  positionUnit: string
+  velocityUnit: string
+}) {
+  return (
+    <article className="bn-joint-monitor-card">
+      <div className="bn-joint-monitor-title">
+        <strong title={joint.name}>{joint.name.replace(/_/g, ' ')}</strong>
+        <span>{joint.position.toFixed(2)} {shortUnit(positionUnit)}</span>
+      </div>
+      <TelemetrySparkline values={trace?.position || []} />
+      <div className="bn-joint-monitor-speed">
+        <span>Speed</span>
+        <strong>{joint.velocity.toFixed(2)} {shortUnit(velocityUnit)}</strong>
+      </div>
+    </article>
+  )
+}
+
+function TelemetrySparkline({ values }: { values: number[] }) {
+  const width = 180
+  const height = 44
+  const finite = values.filter(Number.isFinite)
+  const minimum = finite.length ? Math.min(...finite) : 0
+  const maximum = finite.length ? Math.max(...finite) : 0
+  const range = Math.max(maximum - minimum, 0.001)
+  const points = finite.map((value, index) => {
+    const x = finite.length <= 1 ? width : index * width / (finite.length - 1)
+    const y = height - 4 - ((value - minimum) / range) * (height - 8)
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  }).join(' ')
+  return (
+    <svg
+      className="bn-joint-monitor-chart"
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="Recent joint position"
+    >
+      <line x1="0" y1={height / 2} x2={width} y2={height / 2} />
+      {points && <polyline points={points} />}
+    </svg>
+  )
+}
+
+function formatBattery(battery: NonNullable<NonNullable<RobotTelemetrySample['payload']>['battery']>) {
+  const parts: string[] = []
+  if (battery.level != null) {
+    const percentage = battery.level <= 1 ? battery.level * 100 : battery.level
+    parts.push(`${Math.round(percentage)}%`)
+  }
+  if (battery.voltage != null) parts.push(`${battery.voltage.toFixed(1)} V`)
+  if (battery.charging) parts.push('Charging')
+  return parts.join(' · ') || 'Reported'
+}
+
+function shortUnit(unit: string): string {
+  return unit.replace('degree', '°')
+}

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -972,7 +972,7 @@ html[data-theme="dark"] .bn-brand-logo {
 
 .bn-device-mode-tabs {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   padding: 3px;
   border: 1px solid var(--line);
   border-radius: 6px;
@@ -995,6 +995,235 @@ html[data-theme="dark"] .bn-brand-logo {
   background: var(--menu-active);
   color: var(--tx1);
   box-shadow: inset 0 0 0 1px var(--line2);
+}
+
+.bn-device-path-field {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.bn-device-path-field input {
+  min-width: 0;
+  flex: 1;
+}
+
+.bn-device-path-field button {
+  flex: 0 0 auto;
+}
+
+.bn-device-local-capabilities,
+.bn-device-local-note {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--line2));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--panel));
+}
+
+.bn-device-local-capabilities strong,
+.bn-device-local-note strong {
+  color: var(--tx1);
+  font-size: 12px;
+}
+
+.bn-device-local-capabilities span,
+.bn-device-local-capabilities small,
+.bn-device-local-note span {
+  color: var(--tx2);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.bn-device-local-capabilities small {
+  color: var(--tx3);
+}
+
+.bn-device-local-note {
+  margin: 10px;
+}
+
+.bn-local-package-summary-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.bn-local-package-summary-head > div {
+  min-width: 0;
+}
+
+.bn-local-package-summary-head > div > strong,
+.bn-local-package-summary-head > div > span {
+  display: block;
+}
+
+.bn-local-package-summary-head > div > span {
+  margin-top: 2px;
+  color: var(--tx3);
+}
+
+.bn-local-package-password {
+  display: flex;
+  min-width: 230px;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.bn-local-package-password > span {
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-local-package-password input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid var(--line2);
+  border-radius: 5px;
+  outline: none;
+  background: var(--panel);
+  color: var(--tx1);
+  font-family: var(--font-ui);
+  font-size: 12px;
+}
+
+.bn-local-package-password input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.bn-local-package-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+  margin: 5px 0;
+}
+
+.bn-local-package-card,
+.bn-local-package-missing {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--line2);
+  border-radius: 7px;
+  background: var(--panel);
+}
+
+.bn-local-package-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.bn-local-package-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.bn-local-package-card-head > div {
+  min-width: 0;
+}
+
+.bn-local-package-card-head > div > strong,
+.bn-local-package-card-head > div > span {
+  display: block;
+}
+
+.bn-local-package-card-head > div > span {
+  margin-top: 2px;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+}
+
+.bn-local-package-state {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 5px;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: .04em;
+}
+
+.bn-local-package-state i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 13%, transparent);
+}
+
+.bn-local-package-state.is-running {
+  color: var(--ok);
+}
+
+.bn-local-package-state.is-stopped,
+.bn-local-package-state.is-missing {
+  color: var(--tx3);
+}
+
+.bn-local-package-state.is-checking {
+  color: var(--accent);
+}
+
+.bn-local-package-state.is-attention {
+  color: var(--err);
+}
+
+.bn-local-package-card > code {
+  display: block;
+  margin-top: 8px;
+  overflow: hidden;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-local-package-card > small {
+  display: block;
+  margin-top: 3px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-local-package-update-available {
+  margin-top: 7px;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 750;
+}
+
+.bn-local-package-actions {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+  margin-top: auto;
+  padding-top: 9px;
+}
+
+.bn-local-package-actions .bn-device-action-button {
+  min-width: 0;
+  min-height: 30px;
+  justify-content: center;
+  padding-inline: 6px;
+}
+
+.bn-local-package-missing strong,
+.bn-local-package-missing span {
+  display: block;
+}
+
+.bn-local-package-missing span {
+  margin-top: 4px;
+  color: var(--tx3);
 }
 
 .bn-device-ssh-grid {
@@ -1695,10 +1924,18 @@ button.bn-compute-device-card:active:not(:disabled) {
 
 .bn-compute-device-card-top {
   align-items: flex-start;
-  justify-content: flex-end;
+  justify-content: flex-start;
+}
+
+.bn-compute-device-kind {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: .055em;
 }
 
 .bn-compute-device-status {
+  margin-left: auto;
   color: var(--device-status);
   font-size: 11px;
   font-weight: 800;
@@ -1996,6 +2233,11 @@ button.bn-compute-device-card:active:not(:disabled) {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--warn) 14%, transparent);
 }
 
+.bn-runtime-check-result.is-warning .bn-runtime-check-dot {
+  background: var(--warn);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--warn) 14%, transparent);
+}
+
 .bn-runtime-check-result.is-checking .bn-runtime-check-dot {
   background: var(--accent);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
@@ -2017,6 +2259,82 @@ button.bn-compute-device-card:active:not(:disabled) {
   color: var(--tx3);
   font-size: 11px;
   line-height: 1.4;
+}
+
+.bn-runtime-check-services {
+  display: grid;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.bn-runtime-check-service {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 7px;
+  border: 1px solid var(--line2);
+  border-radius: 5px;
+  background: var(--lift);
+}
+
+.bn-runtime-check-service-dot {
+  width: 7px;
+  height: 7px;
+  margin: 0;
+  border-radius: 50%;
+  background: var(--tx3);
+}
+
+.bn-runtime-check-service.is-connected .bn-runtime-check-service-dot,
+.bn-runtime-check-service.is-awaiting .bn-runtime-check-service-dot {
+  background: var(--ok);
+}
+
+.bn-runtime-check-service.is-disconnected .bn-runtime-check-service-dot,
+.bn-runtime-check-service.is-unreachable .bn-runtime-check-service-dot {
+  background: var(--err);
+}
+
+.bn-runtime-check-service.is-unknown .bn-runtime-check-service-dot {
+  background: var(--warn);
+}
+
+.bn-runtime-check-service.is-checking .bn-runtime-check-service-dot {
+  background: var(--accent);
+}
+
+.bn-runtime-check-service > div {
+  min-width: 0;
+}
+
+.bn-runtime-check-service > div strong,
+.bn-runtime-check-service > div span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-runtime-check-service-state {
+  margin: 0 !important;
+  color: var(--tx2) !important;
+  font-size: 11px !important;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.bn-runtime-check-service.is-connected .bn-runtime-check-service-state,
+.bn-runtime-check-service.is-awaiting .bn-runtime-check-service-state {
+  color: var(--ok) !important;
+}
+
+.bn-runtime-check-service.is-disconnected .bn-runtime-check-service-state,
+.bn-runtime-check-service.is-unreachable .bn-runtime-check-service-state {
+  color: var(--err) !important;
+}
+
+.bn-runtime-check-service.is-unknown .bn-runtime-check-service-state {
+  color: var(--warn) !important;
 }
 
 .bn-device-update-form {
@@ -2282,6 +2600,71 @@ button.bn-compute-device-card:active:not(:disabled) {
   color: var(--warn);
 }
 
+.bn-device-update-dirty-help {
+  display: grid;
+  grid-column: 1 / -1;
+  gap: 5px;
+  padding: 8px;
+  border: 1px solid color-mix(in srgb, var(--warn) 55%, var(--line2));
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--warn) 7%, var(--lift));
+}
+
+.bn-device-update-dirty-help strong {
+  color: var(--warn);
+  font-size: 12px;
+}
+
+.bn-device-update-dirty-help span,
+.bn-device-update-dirty-help code {
+  margin: 0;
+  color: var(--tx2);
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.bn-device-update-dirty-help code {
+  padding: 4px 6px;
+  border: 1px solid var(--line2);
+  border-radius: 4px;
+  background: var(--surface);
+}
+
+.bn-device-update-empty {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px;
+  border: 1px dashed var(--line2);
+  border-radius: 6px;
+  background: var(--lift);
+}
+
+.bn-device-update-empty > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.bn-device-update-empty strong {
+  color: var(--tx1);
+  font-size: 12px;
+}
+
+.bn-device-update-empty span {
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.bn-device-update-empty .bn-device-action-button {
+  flex: 0 0 auto;
+}
+
 .bn-device-update-warnings {
   display: grid;
   gap: 4px;
@@ -2369,6 +2752,9 @@ button.bn-compute-device-card:active:not(:disabled) {
 }
 
 .bn-device-robot-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   padding: 14px;
   border: 1px dashed var(--line2);
   border-radius: 6px;
@@ -2376,6 +2762,26 @@ button.bn-compute-device-card:active:not(:disabled) {
   font-size: 12px;
   line-height: 1.45;
   text-align: center;
+}
+
+.bn-device-robot-empty strong {
+  color: var(--tx1);
+}
+
+.bn-device-robot-empty span {
+  color: var(--tx2);
+}
+
+.bn-device-robot-empty code {
+  overflow-wrap: anywhere;
+  padding: 6px 8px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--panel);
+  color: var(--tx2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: left;
 }
 
 .bn-device-card-summary {
@@ -2458,14 +2864,31 @@ button.bn-compute-device-card:active:not(:disabled) {
 }
 
 .bn-device-card-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 2px 6px;
-  border: 1px solid color-mix(in srgb, var(--run-status) 70%, var(--line2));
+  border: 1px solid color-mix(in srgb, var(--device-status-color, var(--run-status)) 70%, var(--line2));
   border-radius: 999px;
-  color: var(--run-status);
+  color: var(--device-status-color, var(--run-status));
   font-size: 11px;
   font-weight: 800;
   letter-spacing: .03em;
   white-space: nowrap;
+}
+
+.bn-device-card-statuses {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.bn-device-card-state small {
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
 }
 
 .bn-device-card-chevron {
@@ -2516,6 +2939,81 @@ button.bn-compute-device-card:active:not(:disabled) {
     radial-gradient(circle at 0 0, color-mix(in srgb, #00d2ff 9%, transparent), transparent 38%),
     color-mix(in srgb, var(--panel) 94%, #00151b);
   box-shadow: inset 0 1px 0 color-mix(in srgb, #00d2ff 14%, transparent);
+}
+
+.bn-robot-monitor-node-title {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 11px 13px;
+  border-bottom: 1px solid var(--line2);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, #00b8d9 18%, transparent), transparent 55%),
+    var(--lift);
+}
+
+.bn-robot-monitor-node-title > div {
+  min-width: 0;
+}
+
+.bn-robot-monitor-node-title > div span,
+.bn-robot-monitor-node-title > div strong {
+  display: block;
+}
+
+.bn-robot-monitor-node-title > div span {
+  color: #00d2ff;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: .1em;
+}
+
+.bn-robot-monitor-node-title > div strong {
+  margin-top: 3px;
+  overflow: hidden;
+  color: var(--tx1);
+  font-size: 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-robot-monitor-node-title label {
+  display: flex;
+  min-width: 250px;
+  flex-direction: column;
+  gap: 3px;
+  color: var(--tx3);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.bn-robot-monitor-node-title select {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--line2);
+  border-radius: 5px;
+  outline: none;
+  background: var(--panel);
+  color: var(--tx1);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  text-transform: none;
+}
+
+.bn-robot-monitor-node-title select:focus {
+  border-color: #00b8d9;
+  box-shadow: 0 0 0 2px color-mix(in srgb, #00b8d9 22%, transparent);
+}
+
+.bn-robot-monitor.bn-robot-monitor-node-panel {
+  margin-top: 0;
+  border: 0;
+  border-radius: 0 0 8px 8px;
+  box-shadow: none;
 }
 
 .bn-robot-monitor-head {
@@ -2604,6 +3102,61 @@ button.bn-compute-device-card:active:not(:disabled) {
   color: #00d2ff;
 }
 
+.bn-robot-monitor-overview {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 1px;
+  padding: 1px 0;
+  border-bottom: 1px solid color-mix(in srgb, #00d2ff 20%, var(--line));
+  background: var(--line);
+}
+
+.bn-robot-monitor-fact {
+  min-width: 0;
+  padding: 8px 9px;
+  background: color-mix(in srgb, var(--panel) 95%, #00151b);
+}
+
+.bn-robot-monitor-fact span,
+.bn-robot-monitor-fact strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-robot-monitor-fact span {
+  color: var(--tx3);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.bn-robot-monitor-fact strong {
+  margin-top: 3px;
+  color: var(--tx2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.bn-robot-monitor-fact.is-live strong {
+  color: #00d2ff;
+}
+
+.bn-robot-monitor-fact.is-ok strong {
+  color: var(--ok);
+}
+
+.bn-robot-monitor-fact.is-warning strong {
+  color: var(--warn);
+}
+
+.bn-robot-monitor-fact.is-error strong {
+  color: var(--err);
+}
+
 .bn-robot-monitor-meta {
   display: flex;
   gap: 12px;
@@ -2617,6 +3170,36 @@ button.bn-compute-device-card:active:not(:disabled) {
   margin-right: 12px;
   color: #737373;
   content: "·";
+}
+
+.bn-robot-monitor-cameras {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 8px;
+  padding: 9px 10px 0;
+}
+
+.bn-robot-monitor-cameras article {
+  overflow: hidden;
+  border: 1px solid #737373;
+  border-radius: 6px;
+  background: var(--lift);
+}
+
+.bn-robot-monitor-cameras strong,
+.bn-robot-monitor-cameras span {
+  display: block;
+  padding: 6px 8px;
+  color: var(--tx2);
+  font-size: 11px;
+}
+
+.bn-robot-monitor-cameras img {
+  display: block;
+  width: 100%;
+  max-height: 220px;
+  object-fit: contain;
+  background: #050708;
 }
 
 .bn-robot-monitor-grid {
@@ -2882,6 +3465,19 @@ button.bn-device-fact {
 }
 
 @container devices-panel (max-width: 700px) {
+  .bn-local-package-summary-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .bn-local-package-password {
+    min-width: 0;
+  }
+
+  .bn-local-package-summary {
+    grid-template-columns: 1fr;
+  }
+
   .bn-device-update-component {
     grid-template-areas:
       "identity actions"
@@ -3038,6 +3634,10 @@ button.bn-device-fact {
 }
 
 @container devices-panel (max-width: 280px) {
+  .bn-device-mode-tabs {
+    grid-template-columns: 1fr;
+  }
+
   .bn-device-facts {
     grid-template-columns: 1fr;
   }
@@ -3078,7 +3678,7 @@ button.bn-device-fact {
     grid-template-columns: 9px minmax(0, 1fr) 12px;
   }
 
-  .bn-device-card-state {
+  .bn-device-card-statuses {
     display: none;
   }
 }
@@ -3900,12 +4500,12 @@ button.bn-device-fact {
   color: #00d2ff;
 }
 
-.bn-device-lease-notice.is-stored {
+.bn-device-lease-notice.is-inactive {
   border-color: color-mix(in srgb, #00d2ff 34%, var(--line2));
   background: color-mix(in srgb, #00d2ff 5%, transparent);
 }
 
-.bn-device-lease-notice.is-stored strong {
+.bn-device-lease-notice.is-inactive strong {
   color: color-mix(in srgb, #00d2ff 76%, var(--tx2));
 }
 

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -330,6 +330,7 @@ function reactNodeType(typeName: string): string {
   if (SUBGRAPH_NODE_TYPES.has(typeName)) return 'subnetnode'
   if (typeName === 'SubnetInput') return 'subnetinput'
   if (typeName === 'SubnetOutput') return 'subnetoutput'
+  if (typeName === 'RobotMonitor') return 'robotmonitor'
   return OUTPUT_NODE_TYPES.has(typeName) ? 'outputnode' : MODEL_NODE_TYPES.has(typeName) ? 'modelnode' : VALUE_NODE_TYPES.has(typeName) ? 'valuenode' : 'blacknode'
 }
 
@@ -386,6 +387,7 @@ function makeReactNode(meta: BnNodeMeta): Node<NodeData> {
     ...(meta.type === 'ROS2VisualDashboard' ? { style: { width: 840, height: 760 } } : {}),
     ...(meta.type === 'ROS2Run' ? { style: { width: 520, height: 360 } } : {}),
     ...(meta.type === 'ROS2MotionDashboard' ? { style: { width: 860, height: 720 } } : {}),
+    ...(meta.type === 'RobotMonitor' ? { style: { width: 760 } } : {}),
   }
 }
 

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -489,6 +489,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "node_types": [
                         "RobotConnectionDashboard",
                         "RobotDiscovery",
+                        "RobotMonitor",
                         "RobotROSInterfaceCheck",
                         "RobotUSBDiscovery"
                     ]
@@ -512,6 +513,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "RobotDriverPreset",
                 "RobotJointDefinition",
                 "RobotJointList",
+                "RobotMonitor",
                 "RobotProfileDuplicate",
                 "RobotProfileList",
                 "RobotProfileLoad",

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import base64
 import io
 import json
+import os
+import stat
 import subprocess
 import sys
 import tempfile
@@ -24,6 +26,7 @@ if str(EDITOR_SERVER_DIR) not in sys.path:
 
 import device_registry  # noqa: E402
 import device_installer  # noqa: E402
+import local_runtime  # noqa: E402
 import server  # noqa: E402
 
 
@@ -391,6 +394,9 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn("sock.bind((\"0.0.0.0\", candidate))", script)
         self.assertIn("'blacknode-runtime*.service' 'blacknode-hardware*.service'", script)
         self.assertIn('sudo systemctl start "$sibling_service"', script)
+        self.assertIn('hardware_dir="$HOME/blacknode-hardware-instances/$instance"', script)
+        self.assertIn('BLACKNODE_HARDWARE_INSTANCE="$service_instance"', script)
+        self.assertIn("does not support isolated stacks yet", script)
         self.assertNotIn("keep_sudo_alive", script)
 
         self.assertIn(
@@ -457,6 +463,79 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(result["runtime_port"], 8769)
         self.assertIn("replace instance-2 8768", commands[0])
 
+    def test_isolated_stack_uninstall_streams_remote_cleanup_progress(self):
+        uploaded = []
+
+        class RemoteFile(io.StringIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                uploaded.append(self.getvalue())
+                self.close()
+                return False
+
+        class Sftp:
+            def file(self, _path, _mode):
+                return RemoteFile()
+
+            def chmod(self, _path, _mode):
+                return None
+
+            def close(self):
+                return None
+
+        connection = SimpleNamespace(
+            client=SimpleNamespace(open_sftp=lambda: Sftp()),
+            fingerprint="SHA256:trusted-device-key",
+            close=lambda: None,
+        )
+        inspection = {
+            "instances": [{
+                "instance_id": "instance-2",
+                "port": 8768,
+                "healthy": True,
+            }],
+        }
+
+        def fake_run(_connection, command, **kwargs):
+            if "sudo -S -p '' -v" in command:
+                kwargs["on_output"](
+                    "__BLACKNODE_UNINSTALL_PROGRESS__=60|"
+                    "Stopping isolated Robot Hardware services"
+                )
+            return ""
+
+        progress = []
+        with (
+            patch.object(device_installer, "_connect", return_value=connection),
+            patch.object(device_installer, "_inspect_connection", return_value=inspection),
+            patch.object(device_installer, "_run", side_effect=fake_run),
+        ):
+            result = device_installer.uninstall_runtime(
+                host="192.168.1.87",
+                port=22,
+                username="robot",
+                password="ssh-password",
+                host_fingerprint="SHA256:trusted-device-key",
+                instance_id="instance-2",
+                runtime_port=8768,
+                stack_mode="isolated",
+                progress=progress.append,
+            )
+
+        self.assertEqual(result["stack_mode"], "isolated")
+        self.assertTrue(any(item["progress"] == 60 for item in progress))
+        self.assertIn(
+            'progress 48 "Finding isolated Robot Hardware services"',
+            uploaded[0],
+        )
+        self.assertIn(
+            'progress 74 "Removing isolated Robot Hardware files"',
+            uploaded[0],
+        )
+        self.assertNotIn("ssh-password", uploaded[0])
+
     def test_robot_service_restart_resolves_exact_systemd_unit_by_port(self):
         uploaded = []
 
@@ -513,11 +592,12 @@ class EditorDeviceApiTests(unittest.TestCase):
             "ok": True,
             "hardware_port": 8767,
             "service_name": "blacknode-hardware-follower.service",
+            "action": "restart",
             "state": "active",
         })
-        self.assertIn(" 8767", commands[0])
+        self.assertIn(" 8767 restart", commands[0])
         self.assertIn("systemctl list-unit-files 'blacknode-hardware*.service'", uploaded[0])
-        self.assertIn('systemctl restart "$service_name"', uploaded[0])
+        self.assertIn('systemctl "$action" "$service_name"', uploaded[0])
         self.assertNotIn("ssh-password", uploaded[0])
 
     def test_managed_update_uses_trusted_clean_checkouts_and_returns_versions(self):
@@ -594,12 +674,13 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(result["host_fingerprint"], "SHA256:trusted-device-key")
         self.assertIn(" default 8766 ", commands[0])
         targets = json.loads(base64.urlsafe_b64decode(
-            commands[0].split()[-1]
+            commands[0].split()[-2]
         ).decode("utf-8"))
         self.assertEqual(targets, [{
             "port": 8767,
             "device_id": "follower-device",
         }])
+        self.assertEqual(commands[0].split()[-1], "runtime_only")
         self.assertIn("status --porcelain --untracked-files=normal", uploaded[0])
         self.assertIn("merge --ff-only '@{upstream}'", uploaded[0])
         self.assertIn("temiroff/{repository}", uploaded[0])
@@ -775,7 +856,9 @@ class EditorDeviceApiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["runtime"]["ok"])
+        self.assertEqual(response.json()["runtime"]["state"], "running")
         self.assertTrue(runtime_status.json()["ok"])
+        self.assertEqual(runtime_status.json()["state"], "running")
         device = response.json()["device"]
         self.assertNotIn("token", device)
         self.assertNotIn("runtime_token", device)
@@ -825,6 +908,7 @@ class EditorDeviceApiTests(unittest.TestCase):
 
         self.assertEqual(paired_host.status_code, 200)
         self.assertEqual(paired_host.json()["device"]["robots"], [])
+        self.assertEqual(paired_host.json()["runtime"]["state"], "running")
         self.assertNotIn(runtime.token, paired_host.text)
         self.assertEqual(paired_robot.status_code, 200)
         self.assertEqual(paired_robot.json()["robot"]["host_id"], host_id)
@@ -842,6 +926,603 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(saved["schema_version"], 2)
         self.assertEqual(saved["hosts"][host_id]["runtime_token"], runtime.token)
         self.assertEqual(saved["devices"]["workshop-arm"]["token"], robot.token)
+
+    def test_local_compute_device_pairs_over_loopback_without_ssh_management(self):
+        runtime = _HardwareService("local-runtime-token")
+
+        with patch("device_registry.urllib.request.urlopen", side_effect=runtime):
+            paired = self.client.post("/device-hosts", json={
+                "name": "Local computer",
+                "runtime_url": "http://127.0.0.1:8766",
+                "runtime_token": runtime.token,
+            })
+            listed = self.client.get("/device-hosts")
+
+        self.assertEqual(paired.status_code, 200)
+        device = paired.json()["device"]
+        self.assertEqual(device["name"], "Local computer")
+        self.assertEqual(device["runtime_url"], "http://127.0.0.1:8766")
+        self.assertNotIn("managed_runtime", device)
+        self.assertNotIn(runtime.token, paired.text)
+        self.assertEqual(
+            listed.json()["devices"][0]["runtime_url"],
+            "http://127.0.0.1:8766",
+        )
+        self.assertNotIn(runtime.token, listed.text)
+        manifest_requests = [
+            request for request in runtime.requests if request[1] == "/manifest"
+        ]
+        self.assertTrue(manifest_requests)
+        self.assertTrue(all(
+            authorization == f"Bearer {runtime.token}"
+            for _method, _path, authorization, _body in manifest_requests
+        ))
+
+    def test_local_compute_device_install_stream_configures_complete_stack(self):
+        install_result = {
+            "ok": True,
+            "runtime_token": "generated-local-runtime-token-" + "x" * 24,
+            "runtime_url": "http://127.0.0.1:8766",
+            "manifest": {
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "workstation-local",
+                "runtime_version": "0.3.10",
+            },
+            "runtime_port": 8766,
+            "runtime_dir": r"E:\Blacknode\blacknode-runtime",
+            "service_name": "blacknode-runtime-local-process",
+            "instance_id": "local",
+            "stack_mode": "runtime_only",
+            "hardware_dir": r"E:\Blacknode\blacknode-hardware",
+            "hardware_port": 8765,
+            "hardware_service_name": "blacknode-hardware-local-awaiting-device",
+            "hardware_state": "awaiting_device",
+            "hardware_configured": False,
+            "hardware_pid_file": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\hardware.pid",
+            "hardware_token_file": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\auth.token",
+            "hardware_log_path": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\hardware.log",
+            "hardware_owned_install": True,
+            "management_mode": "local",
+            "config_path": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.json",
+            "pid_file": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.pid",
+            "log_path": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.log",
+            "owned_install": True,
+            "elapsed_seconds": 8.2,
+        }
+
+        def install(**kwargs):
+            kwargs["progress"]({
+                "progress": 82,
+                "message": "Starting the local Runtime",
+            })
+            return install_result
+
+        with patch.object(server, "install_local_runtime", side_effect=install) as local_install:
+            response = self.client.post(
+                "/device-hosts/local-install-stream",
+                json={
+                    "name": "Local computer",
+                    "install_dir": r"E:\Blacknode",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        events = [json.loads(line) for line in response.text.splitlines() if line]
+        self.assertTrue(any(
+            event.get("progress") == 82
+            and event.get("message") == "Starting the local Runtime"
+            for event in events
+        ))
+        self.assertEqual(events[-1]["type"], "done")
+        device = events[-1]["result"]["device"]
+        self.assertEqual(device["runtime_url"], "http://127.0.0.1:8766")
+        self.assertEqual(device["managed_runtime"]["management_mode"], "local")
+        self.assertEqual(
+            device["managed_runtime"]["runtime_dir"],
+            r"E:\Blacknode\blacknode-runtime",
+        )
+        self.assertEqual(
+            device["managed_runtime"]["hardware_dir"],
+            r"E:\Blacknode\blacknode-hardware",
+        )
+        self.assertEqual(device["managed_runtime"]["hardware_port"], 8765)
+        self.assertEqual(
+            device["managed_runtime"]["hardware_state"],
+            "awaiting_device",
+        )
+        self.assertNotIn(install_result["runtime_token"], response.text)
+        local_install.assert_called_once()
+        self.assertEqual(
+            local_install.call_args.kwargs["install_dir"],
+            r"E:\Blacknode",
+        )
+
+    def test_local_uninstall_removes_read_only_git_pack_file(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            checkout = Path(temporary) / "blacknode-runtime"
+            pack_dir = checkout / ".git" / "objects" / "pack"
+            pack_dir.mkdir(parents=True)
+            pack_file = pack_dir / "pack-test.idx"
+            pack_file.write_bytes(b"git index")
+            os.chmod(pack_file, stat.S_IREAD)
+
+            local_runtime._remove_tree(checkout)
+
+            self.assertFalse(checkout.exists())
+
+    def test_windows_background_services_use_pythonw(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            scripts = Path(temporary) / ".venv" / "Scripts"
+            scripts.mkdir(parents=True)
+            python = scripts / "python.exe"
+            pythonw = scripts / "pythonw.exe"
+            python.touch()
+            pythonw.touch()
+
+            with patch.object(local_runtime.os, "name", "nt"):
+                selected = local_runtime._background_python(python)
+
+            self.assertEqual(selected, pythonw)
+
+    def test_local_package_inspection_does_not_start_stopped_services(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            stack = Path(temporary)
+            runtime_dir = stack / "blacknode-runtime"
+            hardware_dir = stack / "blacknode-hardware"
+            (runtime_dir / "scripts").mkdir(parents=True)
+            (hardware_dir / "scripts").mkdir(parents=True)
+            (runtime_dir / "scripts" / "runtime_service.py").write_text(
+                "# runtime\n",
+                encoding="utf-8",
+            )
+            (hardware_dir / "scripts" / "hardware_service.py").write_text(
+                "# hardware\n",
+                encoding="utf-8",
+            )
+            (runtime_dir / "pyproject.toml").write_text(
+                '[project]\nname = "blacknode-runtime"\nversion = "0.3.9"\n',
+                encoding="utf-8",
+            )
+            (hardware_dir / "pyproject.toml").write_text(
+                '[project]\nname = "blacknode-hardware"\nversion = "0.1.1"\n',
+                encoding="utf-8",
+            )
+            runtime_state = runtime_dir / ".blacknode-runtime"
+            hardware_state = hardware_dir / ".blacknode-hardware"
+            runtime_state.mkdir()
+            hardware_state.mkdir()
+            managed = {
+                "runtime_dir": str(runtime_dir),
+                "runtime_port": 8766,
+                "config_path": str(runtime_state / "runtime.json"),
+                "pid_file": str(runtime_state / "runtime.pid"),
+                "hardware_dir": str(hardware_dir),
+                "hardware_port": 8765,
+                "hardware_token_file": str(hardware_state / "auth.token"),
+                "hardware_pid_file": str(hardware_state / "hardware.pid"),
+            }
+            with (
+                patch.object(local_runtime, "_spawn_runtime") as spawn_runtime,
+                patch.object(local_runtime, "_spawn_hardware") as spawn_hardware,
+            ):
+                runtime_report = local_runtime.inspect_local_runtime(managed)
+                hardware_report = local_runtime.inspect_local_hardware(managed)
+
+            self.assertEqual(runtime_report["state"], "stopped")
+            self.assertEqual(runtime_report["installed_version"], "0.3.9")
+            self.assertEqual(hardware_report["state"], "stopped")
+            self.assertEqual(hardware_report["installed_version"], "0.1.1")
+            spawn_runtime.assert_not_called()
+            spawn_hardware.assert_not_called()
+
+    def test_local_runtime_status_reports_unattached_managed_hardware_service(self):
+        runtime = _HardwareService("local-runtime-token")
+        host = server._device_registry.pair_host(
+            name="Local computer",
+            runtime_url="http://127.0.0.1:8766",
+            runtime_token=runtime.token,
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "workstation-local",
+            },
+            managed_runtime={
+                "management_mode": "local",
+                "instance_id": "local",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime-local-process",
+                "runtime_dir": r"E:\Blacknode\blacknode-runtime",
+                "stack_mode": "runtime_only",
+                "hardware_dir": r"E:\Blacknode\blacknode-hardware",
+                "hardware_port": 8765,
+                "hardware_service_name": "blacknode-hardware-local-awaiting-device",
+                "hardware_state": "awaiting_device",
+                "hardware_configured": False,
+                "hardware_pid_file": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\hardware.pid",
+                "hardware_token_file": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\auth.token",
+                "hardware_log_path": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\hardware.log",
+                "hardware_owned_install": True,
+                "config_path": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.json",
+                "pid_file": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.pid",
+                "log_path": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.log",
+                "owned_install": True,
+            },
+        )
+        safe_status = {
+            "device_id": "workstation-hardware-awaiting-device",
+            "software_version": "0.2.0",
+            "connected": False,
+            "armed": False,
+        }
+        with (
+            patch.object(
+                server,
+                "inspect_local_hardware",
+                return_value={
+                    "ok": True,
+                    "kind": "hardware",
+                    "state": "running",
+                    "installed": True,
+                    "installed_version": "0.2.0",
+                    "service_url": "http://127.0.0.1:8765",
+                    "service_name": "blacknode-hardware-local-awaiting-device",
+                    "status": safe_status,
+                },
+            ) as inspect_hardware,
+            patch.object(
+                server,
+                "inspect_local_runtime",
+                return_value={
+                    "ok": True,
+                    "kind": "runtime",
+                    "state": "running",
+                    "installed": True,
+                    "installed_version": "0.3.10",
+                    "manifest": {
+                        "service": "blacknode-runtime",
+                        "protocol_version": 1,
+                        "runtime_version": "0.3.10",
+                    },
+                },
+            ) as inspect_runtime,
+            patch.object(server, "ensure_local_runtime") as ensure_runtime,
+        ):
+            response = self.client.get(
+                f"/device-hosts/{host['id']}/runtime-status",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["hardware"], {
+            "ok": True,
+            "kind": "hardware",
+            "installed": True,
+            "installed_version": "0.2.0",
+            "service_url": "http://127.0.0.1:8765",
+            "service_name": "blacknode-hardware-local-awaiting-device",
+            "state": "running",
+            "status": safe_status,
+        })
+        self.assertTrue(inspect_hardware.called)
+        self.assertTrue(inspect_runtime.called)
+        ensure_runtime.assert_not_called()
+
+    def test_local_package_version_check_needs_no_ssh_and_keeps_services_stopped(self):
+        managed = {
+            "management_mode": "local",
+            "runtime_dir": r"E:\Blacknode\blacknode-runtime",
+            "hardware_dir": r"E:\Blacknode\blacknode-hardware",
+        }
+        host = {
+            "id": "local-computer",
+            "name": "Local computer",
+            "managed_runtime": managed,
+            "robots": [],
+        }
+        checked = {
+            "ok": True,
+            "components": [
+                {
+                    "kind": "runtime",
+                    "installed": {"version": "0.3.9", "commit": "aaa"},
+                    "latest": {"version": "0.3.10", "commit": "bbb"},
+                    "update_available": True,
+                    "error": "",
+                    "state": "stopped",
+                },
+                {
+                    "kind": "hardware",
+                    "installed": {"version": "0.1.1", "commit": "ccc"},
+                    "latest": {"version": "0.1.1", "commit": "ccc"},
+                    "update_available": False,
+                    "error": "",
+                    "state": "stopped",
+                },
+            ],
+        }
+        with (
+            patch.object(server._device_registry, "get_host_public", return_value=host),
+            patch.object(
+                server,
+                "inspect_local_package_updates",
+                return_value=checked,
+            ) as inspect,
+            patch.object(server, "ensure_local_runtime") as ensure,
+        ):
+            result = server._check_device_host_updates_payload(
+                host["id"],
+                server.UpdateManagedDeviceReq(password=""),
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertIn("1 of 2 packages", result["summary"])
+        inspect.assert_called_once()
+        ensure.assert_not_called()
+
+    def test_local_package_restart_stops_and_starts_only_selected_service(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            stack = Path(temporary)
+            runtime_dir = stack / "blacknode-runtime"
+            hardware_dir = stack / "blacknode-hardware"
+            (runtime_dir / "scripts").mkdir(parents=True)
+            (hardware_dir / "scripts").mkdir(parents=True)
+            (runtime_dir / "scripts" / "runtime_service.py").write_text(
+                "# runtime\n",
+                encoding="utf-8",
+            )
+            (hardware_dir / "scripts" / "hardware_service.py").write_text(
+                "# hardware\n",
+                encoding="utf-8",
+            )
+            (runtime_dir / "pyproject.toml").write_text(
+                '[project]\nname = "blacknode-runtime"\nversion = "0.3.9"\n',
+                encoding="utf-8",
+            )
+            (hardware_dir / "pyproject.toml").write_text(
+                '[project]\nname = "blacknode-hardware"\nversion = "0.1.1"\n',
+                encoding="utf-8",
+            )
+            managed = {
+                "runtime_dir": str(runtime_dir),
+                "hardware_dir": str(hardware_dir),
+            }
+            with (
+                patch.object(
+                    local_runtime,
+                    "inspect_local_runtime",
+                    return_value={"state": "running"},
+                ),
+                patch.object(
+                    local_runtime,
+                    "inspect_local_hardware",
+                    return_value={"state": "running"},
+                ),
+                patch.object(
+                    local_runtime,
+                    "stop_local_runtime",
+                    return_value={"state": "inactive"},
+                ) as stop_runtime,
+                patch.object(
+                    local_runtime,
+                    "ensure_local_runtime",
+                    return_value={"state": "active"},
+                ) as start_runtime,
+                patch.object(
+                    local_runtime,
+                    "stop_local_hardware",
+                    return_value={"state": "inactive"},
+                ) as stop_hardware,
+                patch.object(
+                    local_runtime,
+                    "ensure_local_hardware",
+                    return_value={"state": "active"},
+                ) as start_hardware,
+            ):
+                runtime_result = local_runtime.manage_local_package(
+                    managed,
+                    kind="runtime",
+                    action="restart",
+                    core_root=stack,
+                )
+                self.assertTrue(runtime_result["restarted"])
+                stop_runtime.assert_called_once()
+                start_runtime.assert_called_once()
+                stop_hardware.assert_not_called()
+                start_hardware.assert_not_called()
+
+                stop_runtime.reset_mock()
+                start_runtime.reset_mock()
+                hardware_result = local_runtime.manage_local_package(
+                    managed,
+                    kind="hardware",
+                    action="restart",
+                    core_root=stack,
+                )
+                self.assertTrue(hardware_result["restarted"])
+                stop_hardware.assert_called_once()
+                start_hardware.assert_called_once()
+                stop_runtime.assert_not_called()
+                start_runtime.assert_not_called()
+
+    def test_local_package_action_is_independent_and_needs_no_ssh(self):
+        managed = {
+            "management_mode": "local",
+            "runtime_dir": r"E:\Blacknode\blacknode-runtime",
+            "hardware_dir": r"E:\Blacknode\blacknode-hardware",
+        }
+        host = {
+            "id": "local-computer",
+            "name": "Local computer",
+            "managed_runtime": managed,
+            "robots": [],
+        }
+        with (
+            patch.object(server._device_registry, "get_host_public", return_value=host),
+            patch.object(
+                server,
+                "manage_local_package",
+                return_value={"ok": True, "kind": "hardware", "action": "restart"},
+            ) as manage,
+            patch.object(
+                server,
+                "_device_host_runtime_status",
+                return_value={"ok": True, "runtime_url": "http://127.0.0.1:8766"},
+            ),
+        ):
+            result = server._manage_local_package_payload(
+                host["id"],
+                "hardware",
+                server.LocalPackageActionReq(action="restart"),
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["kind"], "hardware")
+        self.assertEqual(manage.call_args.kwargs["kind"], "hardware")
+        self.assertEqual(manage.call_args.kwargs["action"], "restart")
+
+    def test_remote_hardware_package_stop_controls_exact_robot_services(self):
+        managed = {
+            "ssh_host": "192.168.1.87",
+            "ssh_port": 22,
+            "ssh_username": "robot",
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "instance_id": "default",
+            "runtime_port": 8766,
+            "service_name": "blacknode-runtime.service",
+            "runtime_dir": "~/blacknode-runtime",
+        }
+        host = {
+            "id": "robot-computer",
+            "name": "Robot computer",
+            "managed_runtime": managed,
+            "robots": [{
+                "id": "follower",
+                "name": "Follower",
+                "base_url": "http://192.168.1.87:8767",
+            }],
+        }
+        with (
+            patch.object(server._device_registry, "get_host_public", return_value=host),
+            patch.object(server, "_control_robot_lifecycle_payload") as safe_stop,
+            patch.object(server, "restart_hardware_service", return_value={
+                "ok": True,
+                "hardware_port": 8767,
+                "service_name": "blacknode-hardware-follower.service",
+                "action": "stop",
+                "state": "inactive",
+            }) as control_service,
+            patch.object(server._device_registry, "set_device_paused") as set_paused,
+            patch.object(server._device_registry, "set_host_management", return_value=host) as set_management,
+        ):
+            result = server._manage_remote_hardware_package_payload(
+                host["id"],
+                server.RemoteHardwarePackageActionReq(
+                    action="stop",
+                    password="ssh-password",
+                ),
+            )
+
+        self.assertEqual(result["state"], "stopped")
+        safe_stop.assert_called_once()
+        self.assertEqual(control_service.call_args.kwargs["hardware_port"], 8767)
+        self.assertEqual(control_service.call_args.kwargs["action"], "stop")
+        set_paused.assert_called_once_with("follower", True)
+        self.assertEqual(
+            set_management.call_args.args[1]["hardware_state"],
+            "stopped",
+        )
+
+    def test_local_compute_device_pause_resume_and_uninstall_use_local_process(self):
+        token = "generated-local-runtime-token-" + "x" * 24
+        host = server._device_registry.pair_host(
+            name="Local computer",
+            runtime_url="http://127.0.0.1:8766",
+            runtime_token=token,
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "workstation-local",
+            },
+            managed_runtime={
+                "management_mode": "local",
+                "instance_id": "local",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime-local-process",
+                "runtime_dir": r"E:\Blacknode\blacknode-runtime",
+                "stack_mode": "runtime_only",
+                "hardware_dir": "",
+                "config_path": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.json",
+                "pid_file": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.pid",
+                "log_path": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.log",
+                "owned_install": True,
+            },
+        )
+        paused = {
+            "ok": True,
+            "action": "pause",
+            "state": "inactive",
+            "service_name": "blacknode-runtime-local-process",
+        }
+        resumed = {
+            "ok": True,
+            "action": "resume",
+            "state": "active",
+            "service_name": "blacknode-runtime-local-process",
+        }
+        with (
+            patch.object(
+                server._device_registry,
+                "host_client",
+                return_value=SimpleNamespace(list_deployments=lambda: {"deployments": []}),
+            ),
+            patch.object(server, "stop_local_runtime", return_value=paused) as stop,
+        ):
+            pause_response = self.client.post(
+                f"/device-hosts/{host['id']}/lifecycle-stream",
+                json={"action": "pause", "password": ""},
+            )
+        self.assertEqual(pause_response.status_code, 200)
+        self.assertTrue(stop.called)
+
+        with patch.object(server, "ensure_local_runtime", return_value=resumed) as start:
+            resume_response = self.client.post(
+                f"/device-hosts/{host['id']}/lifecycle-stream",
+                json={"action": "resume", "password": ""},
+            )
+        self.assertEqual(resume_response.status_code, 200)
+        self.assertTrue(start.called)
+
+        uninstall_result = {
+            "ok": True,
+            "instance_id": "local",
+            "runtime_port": 8766,
+            "already_absent": False,
+            "stack_mode": "runtime_only",
+            "source_preserved": False,
+        }
+        with patch.object(
+            server,
+            "uninstall_local_runtime",
+            return_value=uninstall_result,
+        ) as uninstall:
+            uninstall_response = self.client.post(
+                f"/device-hosts/{host['id']}/uninstall-stream",
+                json={"password": ""},
+            )
+        self.assertEqual(uninstall_response.status_code, 200)
+        uninstall_events = [
+            json.loads(line)
+            for line in uninstall_response.text.splitlines()
+            if line
+        ]
+        self.assertEqual(
+            uninstall_events[-1]["result"]["summary"],
+            "Local Runtime uninstalled",
+        )
+        self.assertTrue(uninstall.called)
+        self.assertEqual(self.client.get("/device-hosts").json()["devices"], [])
 
     def test_existing_robot_pairings_are_grouped_into_compute_devices(self):
         hardware = _HardwareService()
@@ -947,6 +1628,49 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(events[-1]["result"]["device"]["managed_runtime"]["instance_id"], "instance-2")
         self.assertNotIn("ssh-password", response.text)
         self.assertNotIn(runtime.token, response.text)
+
+    def test_automatic_isolated_stack_records_separate_hardware_installation(self):
+        runtime = _HardwareService("isolated-runtime-token")
+        install_result = {
+            "ok": True,
+            "runtime_token": runtime.token,
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "elapsed_seconds": 20.0,
+            "action": "isolated_stack",
+            "instance_id": "instance-2",
+            "runtime_port": 8768,
+            "service_name": "blacknode-runtime-instance-2.service",
+            "runtime_dir": "~/blacknode-runtimes/instance-2",
+            "stack_mode": "isolated",
+            "hardware_dir": "~/blacknode-hardware-instances/instance-2",
+        }
+        with (
+            patch.object(server, "install_runtime", return_value=install_result),
+            patch("device_registry.urllib.request.urlopen", side_effect=runtime),
+        ):
+            response = self.client.post("/device-hosts/install", json={
+                "name": "Isolated robot stack",
+                "host": "192.168.1.87",
+                "port": 22,
+                "username": "robot",
+                "password": "ssh-password",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "action": "isolated_stack",
+                "instance_id": "instance-2",
+            })
+
+        self.assertEqual(response.status_code, 200)
+        managed = response.json()["device"]["managed_runtime"]
+        self.assertEqual(managed["stack_mode"], "isolated")
+        self.assertEqual(
+            managed["hardware_dir"],
+            "~/blacknode-hardware-instances/instance-2",
+        )
+        self.assertEqual(response.json()["device"]["robots"], [])
+        self.assertNotIn(runtime.token, response.text)
+        saved = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        saved_management = next(iter(saved["hosts"].values()))["managed_runtime"]
+        self.assertEqual(saved_management["stack_mode"], "isolated")
 
     def test_ssh_inspection_reports_existing_instances_without_credentials(self):
         inspection = {
@@ -1236,7 +1960,66 @@ class EditorDeviceApiTests(unittest.TestCase):
             host_fingerprint="SHA256:trusted-device-key",
             instance_id="instance-2",
             runtime_port=8767,
+            stack_mode="runtime_only",
+            progress=None,
         )
+
+    def test_managed_runtime_uninstall_stream_reports_progress_until_registry_cleanup(self):
+        host = server._device_registry.pair_host(
+            name="Isolated robot stack",
+            runtime_url="http://192.168.1.87:8768",
+            runtime_token="runtime-token",
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "robot-computer-instance-2",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.1.87",
+                "ssh_port": 22,
+                "ssh_username": "robot",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "instance-2",
+                "runtime_port": 8768,
+                "service_name": "blacknode-runtime-instance-2.service",
+                "runtime_dir": "~/blacknode-runtimes/instance-2",
+                "stack_mode": "isolated",
+                "hardware_dir": "~/blacknode-hardware-instances/instance-2",
+            },
+        )
+
+        def uninstall(**kwargs):
+            kwargs["progress"]({
+                "progress": 60,
+                "message": "Stopping isolated Robot Hardware services",
+            })
+            return {
+                "ok": True,
+                "instance_id": "instance-2",
+                "runtime_port": 8768,
+                "already_absent": False,
+                "stack_mode": "isolated",
+            }
+
+        with patch.object(server, "uninstall_runtime", side_effect=uninstall):
+            response = self.client.post(
+                f"/device-hosts/{host['id']}/uninstall-stream",
+                json={"password": "ssh-password"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        events = [json.loads(line) for line in response.text.splitlines() if line]
+        progress = [event for event in events if event["type"] == "progress"]
+        self.assertEqual(progress[0]["progress"], 1)
+        self.assertTrue(any(event["progress"] == 60 for event in progress))
+        self.assertEqual(progress[-1], {
+            "type": "progress",
+            "progress": 100,
+            "message": "Isolated robot stack uninstalled",
+        })
+        self.assertEqual(events[-1]["type"], "done")
+        self.assertEqual(events[-1]["result"]["summary"], "Isolated robot stack uninstalled")
+        self.assertEqual(self.client.get("/device-hosts").json()["devices"], [])
 
     def test_device_can_be_renamed_without_repairing_or_exposing_tokens(self):
         hardware = _HardwareService()
@@ -1940,6 +2723,74 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(inspect.call_args.kwargs["hardware_ports"], [8767])
         self.assertNotIn("ssh-password", response.text)
 
+    def test_managed_update_check_describes_runtime_only_dirty_checkout(self):
+        runtime = _HardwareService("runtime-token")
+        host = server._device_registry.pair_host(
+            name="Second Runtime",
+            runtime_url="http://192.168.1.87:8768",
+            runtime_token=runtime.token,
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "alex-desktop-instance-2",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.1.87",
+                "ssh_port": 22,
+                "ssh_username": "robot",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "instance-2",
+                "runtime_port": 8768,
+                "service_name": "blacknode-runtime-instance-2.service",
+                "runtime_dir": "~/blacknode-runtimes/instance-2",
+            },
+        )
+        checked = {
+            "ok": False,
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "components": [{
+                "kind": "runtime",
+                "service_name": "blacknode-runtime-instance-2.service",
+                "port": 8768,
+                "installed": {"version": "0.3.8", "commit": "111111111111"},
+                "latest": {"version": "0.3.9", "commit": "222222222222"},
+                "update_available": True,
+                "can_update": False,
+                "dirty": True,
+                "state": "active",
+                "error": (
+                    "Local source changes must be committed, stashed, or "
+                    "removed before update."
+                ),
+            }],
+        }
+        with (
+            patch.object(
+                server._device_registry,
+                "host_client",
+                return_value=SimpleNamespace(manifest=lambda: {
+                    "runtime_version": "0.3.8",
+                }),
+            ),
+            patch.object(
+                server,
+                "inspect_managed_service_updates",
+                return_value=checked,
+            ) as inspect,
+        ):
+            result = server._check_device_host_updates_payload(
+                host["id"],
+                server.UpdateManagedDeviceReq(password="ssh-password"),
+            )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(
+            result["summary"],
+            "Checked 1 service; 1 needs attention before Runtime can be updated.",
+        )
+        inspect.assert_called_once()
+        self.assertEqual(inspect.call_args.kwargs["hardware_ports"], [])
+
     def test_managed_robot_service_can_be_restarted_by_exact_hardware_port(self):
         hardware = _HardwareService()
         host = server._device_registry.pair_host(
@@ -2072,15 +2923,81 @@ class EditorDeviceApiTests(unittest.TestCase):
             "name": "Leader live",
             "state": "running",
         })
+        self.assertFalse(payload["connected"])
+        self.assertEqual(payload["connection_state"], "disconnected")
+        self.assertFalse(payload["connection_reported"])
         self.assertNotIn("error", payload)
         self.assertIn("Leader live", payload["notice"])
-        self.assertIn("Device checks are paused", payload["notice"])
+        self.assertIn("treats the robot as disconnected", payload["notice"])
+        self.assertIn("Stop the deployment", payload["notice"])
         rpc_methods = [
             body["method"]
             for method, path, _auth, body in hardware.requests
             if method == "POST" and path == "/rpc"
         ]
         self.assertNotIn("resume", rpc_methods)
+
+    def test_device_status_uses_active_deployment_connection_telemetry(self):
+        hardware = _HardwareService(status_overrides={
+            "connected": False,
+            "leased_to_deployment": True,
+            "error": "serial hardware is leased to a Blacknode deployment",
+        })
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            hardware.runtime_deployments["leader-live"] = {
+                "id": "leader-live",
+                "name": "Leader live",
+                "state": "running",
+                "target_device_id": paired["id"],
+            }
+            hardware.runtime_telemetry["leader-live"] = {
+                "available": True,
+                "stale": False,
+                "payload": {"connected": True},
+            }
+            response = self.client.get(f"/devices/{paired['id']}/status")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["connected"])
+        self.assertEqual(payload["connection_state"], "connected")
+        self.assertTrue(payload["connection_reported"])
+        self.assertEqual(payload["deployment_lease"]["state"], "running")
+
+    def test_device_status_uses_noninvasive_serial_presence_during_deployment(self):
+        hardware = _HardwareService(status_overrides={
+            "connected": True,
+            "connection_present": True,
+            "connection_reported": True,
+            "connection_source": "device_path",
+            "leased_to_deployment": True,
+            "error": "serial hardware is leased to a Blacknode deployment",
+        })
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Follower arm",
+                "base_url": "http://192.168.1.87:8767",
+                "token": hardware.token,
+            }).json()["device"]
+            hardware.runtime_deployments["follower-live"] = {
+                "id": "follower-live",
+                "name": "Follower live",
+                "state": "running",
+                "target_device_id": paired["id"],
+            }
+            response = self.client.get(f"/devices/{paired['id']}/status")
+
+        payload = response.json()
+        self.assertTrue(payload["connected"])
+        self.assertEqual(payload["connection_state"], "connected")
+        self.assertTrue(payload["connection_reported"])
+        self.assertEqual(payload["connection_source"], "device_path")
+        self.assertIn("serial device path is present", payload["notice"])
 
     def test_device_status_reports_running_monitor_without_motion_lease(self):
         hardware = _HardwareService(status_overrides={
@@ -2206,7 +3123,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(payload["source"], "hardware")
         self.assertEqual(payload["payload"]["joints"][0]["position"], 5.0)
 
-    def test_device_status_reports_stopped_deployment_stored_on_runtime(self):
+    def test_device_status_reports_stopped_deployment_as_inactive(self):
         hardware = _HardwareService(status_overrides={
             "connected": True,
             "leased_to_deployment": False,
@@ -2229,13 +3146,19 @@ class EditorDeviceApiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()
+        self.assertEqual(payload["connection_state"], "connected")
+        self.assertEqual(payload["inactive_deployment"], {
+            "id": "leader-stored",
+            "name": "Leader workflow",
+            "state": "stopped",
+        })
         self.assertEqual(payload["stored_deployment"], {
             "id": "leader-stored",
             "name": "Leader workflow",
             "state": "stopped",
         })
-        self.assertIn("stored on the Runtime", payload["notice"])
-        self.assertIn("can be restarted", payload["notice"])
+        self.assertIn("stopped on the Runtime", payload["notice"])
+        self.assertIn("can be restarted", payload["notice"].lower())
         self.assertNotIn("running_deployment", payload)
 
     def test_repairing_same_url_replaces_token_without_duplicating_device(self):
@@ -3168,7 +4091,8 @@ class EditorDeviceApiTests(unittest.TestCase):
         )
         self.assertEqual(hardware_check["status"], "fail")
         self.assertIn("Leader live", hardware_check["message"])
-        self.assertIn("Device checks are paused", hardware_check["message"])
+        self.assertIn("treats the robot as disconnected", hardware_check["message"])
+        self.assertIn("Stop the deployment", hardware_check["message"])
 
     def test_staging_rejects_graph_changed_after_validation(self):
         hardware = _HardwareService()

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -288,7 +288,7 @@ class EditorRuntimeTests(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"selected": r"E:\RobotData", "cancelled": False})
-        picker.assert_called_once_with(r"C:\Users\robot")
+        picker.assert_called_once_with(r"C:\Users\robot", "")
 
     def test_dataset_frame_endpoint_returns_synchronized_robot_values(self):
         frame = {

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -89,6 +89,7 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["ROS2TopicPublisher"]["package"] == "blacknode-ros2"
     assert "ROS2DemoPublisher" not in payload["nodes"]
     assert payload["nodes"]["RobotDiscovery"]["package"] == "blacknode-robot"
+    assert payload["nodes"]["RobotMonitor"]["package"] == "blacknode-robot"
     assert payload["nodes"]["EpisodeRecorder"] == {
         "package": "blacknode-dataset",
         "git_url": "https://github.com/temiroff/blacknode-dataset.git",


### PR DESCRIPTION
## What changed
- unify local and remote device layouts and connection-state reporting
- split Runtime and Hardware into independently managed package cards
- add run, stop, restart, update, reinstall, and delete lifecycle actions
- add local-stack installation and removal plus remote SSH setup
- add an on-canvas robot monitor node and normalized deployment status
- improve reconnect detection and Windows background service handling

## Why
The editor mixed computer connection, software package, hardware connection, and deployment states. Local and remote devices also used different layouts, making disconnected and unknown states hard to understand.

## Impact
Every computer now uses the same device summary, package controls, and explicit connected or disconnected states. Local computers can host isolated robot stacks, while monitoring opens as a live canvas node.

## Validation
- python -m unittest discover -s tests: 455 passed, 8 skipped
- npm run build in editor: passed
- package integration suites and workflow validation: passed