### PR TITLE
Fix robot deployment replacement safety

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -561,6 +561,7 @@ def _stop_active_cook() -> None:
 
 _RUNTIME_MODULES = {
     "ros2": "blacknode.pkg.blacknode_ros2.ros2_runtime",
+    "ros2_live": "blacknode.pkg.blacknode_skills.follow.leader_follower_runtime",
     "joint_control": "blacknode.pkg.blacknode_controllers.joint_control.adapters.ros2.joint_motion",
     "vision": "blacknode.pkg.blacknode_perception.cv2_runtime",
     "cuda": "blacknode.pkg.blacknode_cuda.cuda_stream_runtime",
@@ -580,6 +581,11 @@ _RUNTIME_REGISTRY_ANCHORS = {
     "joint_control": "ROS2ManualMove",
 }
 
+_RUNTIME_CALLABLE_ALIASES = {
+    ("ros2_live", "runtime_status"): "leader_follower_runtime_status",
+    ("ros2_live", "stop_runtime_services"): "stop_leader_follower_services",
+}
+
 
 def _runtime_module(module_name: str):
     module = sys.modules.get(module_name)
@@ -592,13 +598,22 @@ def _runtime_module(module_name: str):
 
 
 def _runtime_callable(label: str, module_name: str, name: str):
+    callable_name = _RUNTIME_CALLABLE_ALIASES.get((label, name), name)
     anchor_name = _RUNTIME_REGISTRY_ANCHORS.get(label)
     anchor = _NODE_REGISTRY.get(anchor_name) if anchor_name else None
-    candidate = getattr(anchor, "__globals__", {}).get(name) if anchor is not None else None
+    candidate = (
+        getattr(anchor, "__globals__", {}).get(callable_name)
+        if anchor is not None
+        else None
+    )
     if callable(candidate):
         return candidate
     runtime = _runtime_module(module_name)
-    candidate = getattr(runtime, name, None) if runtime is not None else None
+    candidate = (
+        getattr(runtime, callable_name, None)
+        if runtime is not None
+        else None
+    )
     return candidate if callable(candidate) else None
 
 
@@ -614,7 +629,18 @@ def _runtime_module_status(label: str, module_name: str) -> dict[str, Any]:
             "report": f"{label} runtime is not loaded",
         }
     try:
-        return dict(status_fn())
+        status = status_fn()
+        if isinstance(status, list):
+            return {
+                "ok": True,
+                "active": bool(status),
+                "streams": [],
+                "managed_runs": [
+                    item for item in status if isinstance(item, dict)
+                ],
+                "detached_count": 0,
+            }
+        return dict(status)
     except Exception as exc:
         return {"ok": False, "active": False, "error": f"{type(exc).__name__}: {exc}"}
 
@@ -664,7 +690,11 @@ def _stop_runtime_module(label: str, module_name: str) -> dict[str, Any]:
             "report": f"{label} runtime is not loaded",
         }
     try:
-        return dict(stop_fn())
+        result = dict(stop_fn())
+        stopped = result.get("stopped")
+        if isinstance(stopped, (int, float)):
+            result["stopped"] = {"managed_runs": int(stopped)}
+        return result
     except Exception as exc:
         return {
             "ok": False,
@@ -4485,12 +4515,29 @@ def _control_robot_lifecycle_payload(
         }
 
     if action == "pause":
-        report(20, "Checking for an active deployment")
+        report(20, "Stopping every deployment targeting this robot")
+        stopped_deployments: list[str] = []
         try:
             status = _deployment_aware_device_status(device_id)
             lease = status.get("deployment_lease")
+            runtime_client = _runtime_client_or_404(device_id)
+            deployment_ids = {
+                str(item.get("id") or "")
+                for item in (
+                    runtime_client.list_deployments().get("deployments") or []
+                )
+                if (
+                    isinstance(item, dict)
+                    and str(item.get("state") or "") == "running"
+                    and str(item.get("target_device_id") or "") == device_id
+                    and str(item.get("id") or "")
+                )
+            }
             if isinstance(lease, dict) and lease.get("id"):
-                _runtime_client_or_404(device_id).stop_deployment(str(lease["id"]))
+                deployment_ids.add(str(lease["id"]))
+            for deployment_id in sorted(deployment_ids):
+                runtime_client.stop_deployment(deployment_id)
+                stopped_deployments.append(deployment_id)
         except (DeviceRegistryError, HTTPException, KeyError) as exc:
             detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
             warnings.append(
@@ -4531,6 +4578,9 @@ def _control_robot_lifecycle_payload(
         "ok": True,
         "action": action,
         "status": status,
+        "stopped_deployments": (
+            stopped_deployments if action == "pause" else []
+        ),
         "warnings": warnings,
         "summary": summary,
     }
@@ -6074,6 +6124,14 @@ def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
     if active:
         owner = active[0]
         result = dict(status)
+        conflicting_deployments = [
+            {
+                "id": str(item.get("id") or ""),
+                "name": str(item.get("name") or item.get("id") or "Deployment"),
+                "state": "running",
+            }
+            for item in active
+        ]
         deployment = {
             "id": str(owner.get("id") or ""),
             "name": str(owner.get("name") or owner.get("id") or "Deployment"),
@@ -6141,6 +6199,13 @@ def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
             result["notice"] = (
                 f"Deployment '{owner.get('name') or owner.get('id')}' is running, "
                 "but the hardware service does not report that it owns motion control."
+            )
+        if len(conflicting_deployments) > 1:
+            result["conflicting_deployments"] = conflicting_deployments
+            result["notice"] = (
+                f"Safety conflict: {len(conflicting_deployments)} deployments are "
+                f"running for this robot. Pause the robot to stop all of them. "
+                + str(result.get("notice") or "")
             )
         return result
 
@@ -6451,6 +6516,70 @@ def _remote_deployment_owner(
     }
 
 
+def _target_deployment_records(
+    runtime_client,
+    device_id: str,
+    *,
+    exclude_id: str = "",
+) -> list[dict[str, Any]]:
+    return [
+        item
+        for item in (
+            runtime_client.list_deployments().get("deployments") or []
+        )
+        if (
+            isinstance(item, dict)
+            and str(item.get("target_device_id") or "") == device_id
+            and str(item.get("id") or "")
+            and str(item.get("id") or "") != exclude_id
+        )
+    ]
+
+
+def _start_replacing_device_deployment(
+    device_id: str,
+    runtime_client,
+    deployment_id: str,
+) -> tuple[dict[str, Any], list[str], list[str]]:
+    superseded = _target_deployment_records(
+        runtime_client,
+        device_id,
+        exclude_id=deployment_id,
+    )
+    for item in superseded:
+        if str(item.get("state") or "") == "running":
+            runtime_client.stop_deployment(str(item["id"]))
+
+    _require_device_safe_to_start(device_id)
+    _set_device_deployment_lease(device_id, leased=True)
+    try:
+        deployment = runtime_client.start_deployment(deployment_id)
+    except Exception:
+        _set_device_deployment_lease(device_id, leased=False)
+        raise
+
+    superseded_ids = {
+        str(item.get("id") or "")
+        for item in superseded
+        if str(item.get("id") or "")
+    }
+    superseded_ids.update(
+        str(item)
+        for item in (deployment.get("superseded_deployment_ids") or [])
+        if str(item)
+    )
+    cleanup_warnings: list[str] = []
+    for old_id in sorted(superseded_ids):
+        try:
+            runtime_client.delete_deployment(old_id)
+        except DeviceRegistryError as exc:
+            cleanup_warnings.append(
+                f"Replacement started, but superseded deployment "
+                f"'{old_id}' could not be removed: {exc}"
+            )
+    return deployment, sorted(superseded_ids), cleanup_warnings
+
+
 @app.post("/devices/{device_id}/deployments")
 def stage_device_deployment(device_id: str, req: RemoteDeployReq):
     deployment_owner = _remote_deployment_owner(device_id, req)
@@ -6563,20 +6692,26 @@ def stage_device_deployment(device_id: str, req: RemoteDeployReq):
                     "Target package synchronization did not provide " + "; ".join(details),
                 )
         deployment = client.stage_deployment(payload)
+        superseded_deployments: list[str] = []
+        cleanup_warnings: list[str] = []
         if req.start:
-            _require_device_safe_to_start(device_id)
-            _set_device_deployment_lease(device_id, leased=True)
-            try:
-                deployment = client.start_deployment(str(deployment["id"]))
-            except Exception:
-                _set_device_deployment_lease(device_id, leased=False)
-                raise
+            (
+                deployment,
+                superseded_deployments,
+                cleanup_warnings,
+            ) = _start_replacing_device_deployment(
+                device_id,
+                client,
+                str(deployment["id"]),
+            )
     except DeviceRegistryError as exc:
         raise HTTPException(502, str(exc)) from exc
     return {
         "deployment": deployment,
         "workflow_hash": current_hash,
         "started": bool(req.start),
+        "superseded_deployments": superseded_deployments,
+        "cleanup_warnings": cleanup_warnings,
     }
 
 
@@ -6588,25 +6723,41 @@ def get_device_deployment(device_id: str, deployment_id: str):
 @app.post("/devices/{device_id}/deployments/{deployment_id}/start")
 def start_device_deployment(device_id: str, deployment_id: str):
     _require_targeted_deployment(device_id, deployment_id)
-    _require_device_safe_to_start(device_id)
-    _set_device_deployment_lease(device_id, leased=True)
     try:
-        return _runtime_client_or_404(device_id).start_deployment(deployment_id)
-    except Exception as exc:
-        _set_device_deployment_lease(device_id, leased=False)
-        if isinstance(exc, DeviceRegistryError):
-            raise HTTPException(502, str(exc)) from exc
-        raise
+        deployment, superseded, cleanup_warnings = (
+            _start_replacing_device_deployment(
+                device_id,
+                _runtime_client_or_404(device_id),
+                deployment_id,
+            )
+        )
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+    return {
+        **deployment,
+        "superseded_deployments": superseded,
+        "cleanup_warnings": cleanup_warnings,
+    }
 
 
 @app.post("/devices/{device_id}/deployments/{deployment_id}/stop")
 def stop_device_deployment(device_id: str, deployment_id: str):
     _require_targeted_deployment(device_id, deployment_id)
     try:
-        deployment = _runtime_client_or_404(device_id).stop_deployment(deployment_id)
+        runtime_client = _runtime_client_or_404(device_id)
+        deployment = runtime_client.stop_deployment(deployment_id)
     except DeviceRegistryError as exc:
         raise HTTPException(502, str(exc)) from exc
-    _set_device_deployment_lease(device_id, leased=False)
+    remaining = _target_deployment_records(
+        runtime_client,
+        device_id,
+        exclude_id=deployment_id,
+    )
+    if not any(
+        str(item.get("state") or "") == "running"
+        for item in remaining
+    ):
+        _set_device_deployment_lease(device_id, leased=False)
     return deployment
 
 
@@ -6617,23 +6768,38 @@ def rollback_device_deployment(
     req: RemoteRollbackReq,
 ):
     _require_targeted_deployment(device_id, deployment_id)
-    if req.start:
-        _require_device_safe_to_start(device_id)
-        _set_device_deployment_lease(device_id, leased=True)
     try:
-        deployment = _runtime_client_or_404(device_id).rollback_deployment(
+        runtime_client = _runtime_client_or_404(device_id)
+        deployment = runtime_client.rollback_deployment(
             deployment_id,
-            start=req.start,
+            start=False,
         )
-    except Exception as exc:
         if req.start:
+            deployment, superseded, cleanup_warnings = (
+                _start_replacing_device_deployment(
+                    device_id,
+                    runtime_client,
+                    deployment_id,
+                )
+            )
+            return {
+                **deployment,
+                "superseded_deployments": superseded,
+                "cleanup_warnings": cleanup_warnings,
+            }
+        remaining = _target_deployment_records(
+            runtime_client,
+            device_id,
+            exclude_id=deployment_id,
+        )
+        if not any(
+            str(item.get("state") or "") == "running"
+            for item in remaining
+        ):
             _set_device_deployment_lease(device_id, leased=False)
-        if isinstance(exc, DeviceRegistryError):
-            raise HTTPException(502, str(exc)) from exc
-        raise
-    if not req.start:
-        _set_device_deployment_lease(device_id, leased=False)
-    return deployment
+        return deployment
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
 
 
 @app.get("/devices/{device_id}/deployments/{deployment_id}/logs")

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1434,7 +1434,13 @@ export const api = {
     projectId?: string,
     workflowSlug?: string,
   ) =>
-    req<{ deployment: RemoteDeployment; workflow_hash: string; started: boolean }>(
+    req<{
+      deployment: RemoteDeployment
+      workflow_hash: string
+      started: boolean
+      superseded_deployments: string[]
+      cleanup_warnings: string[]
+    }>(
       'POST',
       `/devices/${encodeURIComponent(deviceId)}/deployments`,
       {

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -556,6 +556,23 @@ export default function DeploymentsPanel({
       || preflight.workflow.name
       || DEFAULT_DEPLOYMENT_NAME
     )
+    const replacements = remoteDeployments.filter(deployment => (
+      deployment.id !== existing?.id
+      && deployment.target_device_id === selectedDeviceId
+    ))
+    if (
+      start
+      && replacements.length > 0
+      && !window.confirm(
+        `Replace ${replacements.length} existing deployment${
+          replacements.length === 1 ? '' : 's'
+        } for "${selectedRobot?.name || selectedDeviceId}"? Blacknode will stop ${
+          replacements.some(deployment => deployment.state === 'running')
+            ? 'the running workflow'
+            : 'any running workflow'
+        }, start "${name}", then remove the superseded deployment records.`,
+      )
+    ) return
     setBusy(true)
     setRemoteAction(start ? 'send-run' : 'send')
     setRemoteNotice(null)
@@ -574,7 +591,17 @@ export default function DeploymentsPanel({
       await refreshRemote()
       setRemoteNotice(
         start
-          ? `"${name}" was sent to ${selectedComputeDevice?.name || 'the compute device'} and started for ${selectedRobot?.name || 'the selected robot'}.`
+          ? `"${name}" was sent to ${selectedComputeDevice?.name || 'the compute device'} and started for ${selectedRobot?.name || 'the selected robot'}.${
+            (result.superseded_deployments?.length ?? 0) > 0
+              ? ` Replaced ${result.superseded_deployments.length} previous deployment${
+                result.superseded_deployments.length === 1 ? '' : 's'
+              }.`
+              : ''
+          }${
+            (result.cleanup_warnings?.length ?? 0) > 0
+              ? ` ${result.cleanup_warnings.join(' ')}`
+              : ''
+          }`
           : `"${name}" was sent to ${selectedComputeDevice?.name || 'the compute device'} for ${selectedRobot?.name || 'the selected robot'} and is ready to start.`,
       )
     } catch (err) {
@@ -590,6 +617,26 @@ export default function DeploymentsPanel({
     if (!window.confirm(`Delete remote deployment "${deployment.name}"?`)) return
     await actRemote(() => api.deleteRemoteDeployment(selectedDeviceId, deployment.id))
     setRemoteOpenId(current => current === deployment.id ? null : current)
+  }
+
+  const startRemote = async (deployment: RemoteDeployment) => {
+    if (!selectedDeviceId) return
+    const replacements = remoteDeployments.filter(item => (
+      item.id !== deployment.id
+      && item.target_device_id === selectedDeviceId
+    ))
+    if (
+      replacements.length > 0
+      && !window.confirm(
+        `Run "${deployment.name}" and replace ${replacements.length} other deployment${
+          replacements.length === 1 ? '' : 's'
+        } for this robot? Superseded deployment records will be removed after the replacement starts.`,
+      )
+    ) return
+    await actRemote(() => api.startRemoteDeployment(
+      selectedDeviceId,
+      deployment.id,
+    ))
   }
 
   const remoteRunning = remoteDeployments.filter(d => d.state === 'running').length
@@ -1059,7 +1106,13 @@ export default function DeploymentsPanel({
                       {remoteAction === 'send' ? 'Sending…' : 'Send to robot'}
                     </button>
                     <button onClick={() => stageRemote(true)} disabled={busy} style={primaryButton}>
-                      {remoteAction === 'send-run' ? 'Sending & starting…' : 'Send & run on robot'}
+                      {remoteAction === 'send-run'
+                        ? 'Sending & starting…'
+                        : remoteDeployments.some(deployment => (
+                          deployment.target_device_id === selectedDeviceId
+                        ))
+                          ? 'Send & replace on robot'
+                          : 'Send & run on robot'}
                     </button>
                   </>
                 )}
@@ -1115,9 +1168,7 @@ export default function DeploymentsPanel({
               current === deployment.id ? null : deployment.id
             ))}
             onStage={() => stageRemote(false, deployment)}
-            onStart={() => actRemote(() => (
-              api.startRemoteDeployment(selectedDeviceId, deployment.id)
-            ))}
+            onStart={() => startRemote(deployment)}
             onStop={() => actRemote(() => (
               api.stopRemoteDeployment(selectedDeviceId, deployment.id)
             ))}

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -2351,6 +2351,40 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertTrue(status.json()["paused"])
         self.assertFalse(resumed.json()["status"]["paused"])
 
+    def test_robot_pause_stops_every_running_deployment_for_that_robot(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            robot = self.client.post("/devices", json={
+                "name": "Follower",
+                "base_url": "http://192.168.1.87:8767",
+                "token": hardware.token,
+            }).json()["device"]
+            for deployment_id in ("follower-old", "follower-new"):
+                hardware.runtime_deployments[deployment_id] = {
+                    "id": deployment_id,
+                    "name": deployment_id,
+                    "state": "running",
+                    "target_device_id": robot["id"],
+                }
+
+            paused = self.client.post(
+                f"/devices/{robot['id']}/lifecycle",
+                json={"action": "pause"},
+            )
+
+        self.assertEqual(paused.status_code, 200)
+        self.assertEqual(
+            set(paused.json()["stopped_deployments"]),
+            {"follower-old", "follower-new"},
+        )
+        self.assertEqual(
+            {
+                item["state"]
+                for item in hardware.runtime_deployments.values()
+            },
+            {"stopped"},
+        )
+
     def test_robot_pause_still_disarms_when_deployment_runtime_is_unreachable(self):
         hardware = _HardwareService(status_overrides={
             "deployment_lease": {
@@ -3907,6 +3941,60 @@ class EditorDeviceApiTests(unittest.TestCase):
             device_id,
         )
         self.assertFalse(stage_request[3]["manifest"]["telemetry_required"])
+
+    def test_send_and_run_replaces_and_removes_older_target_deployments(self):
+        hardware = _HardwareService()
+        workflow = _workflow([])
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Follower",
+                "base_url": "http://192.168.1.87:8767",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            hardware.runtime_deployments["follower-old"] = {
+                "id": "follower-old",
+                "name": "Follower old",
+                "state": "running",
+                "target_device_id": device_id,
+            }
+            with patch.object(server, "_workflow_payload", return_value=workflow):
+                preflight = self.client.post(
+                    f"/devices/{device_id}/deployment-preflight",
+                    json={},
+                ).json()
+                response = self.client.post(
+                    f"/devices/{device_id}/deployments",
+                    json={
+                        "name": "Follower replacement",
+                        "workflow_hash": preflight["workflow"]["hash"],
+                        "start": True,
+                    },
+                )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["superseded_deployments"], ["follower-old"])
+        self.assertEqual(payload["cleanup_warnings"], [])
+        self.assertNotIn("follower-old", hardware.runtime_deployments)
+        self.assertEqual(payload["deployment"]["state"], "running")
+        replacement_id = payload["deployment"]["id"]
+        self.assertEqual(
+            set(hardware.runtime_deployments),
+            {replacement_id},
+        )
+        deployment_requests = [
+            (method, path)
+            for method, path, _auth, _body in hardware.requests
+            if path.startswith("/deployments/")
+        ]
+        self.assertIn(
+            ("POST", "/deployments/follower-old/stop"),
+            deployment_requests,
+        )
+        self.assertIn(
+            ("DELETE", "/deployments/follower-old"),
+            deployment_requests,
+        )
 
     def test_robot_deployment_manifest_requires_fresh_telemetry(self):
         workflow = _workflow(["joint_group", "position_feedback"])

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -24,6 +24,33 @@ class EditorRuntimeTests(unittest.TestCase):
         self.assertEqual(server._RUNTIME_MODULES["isaac"], "blacknode.pkg.blacknode_isaac.runtime")
         self.assertEqual(server._RUNTIME_REGISTRY_ANCHORS["isaac"], "IsaacPolicyBridge")
 
+    def test_leader_follower_runtime_is_managed_and_normalized(self):
+        self.assertEqual(
+            server._RUNTIME_MODULES["ros2_live"],
+            "blacknode.pkg.blacknode_skills.follow.leader_follower_runtime",
+        )
+        with patch.object(
+            server,
+            "_runtime_callable",
+            side_effect=[
+                lambda: [{"run_id": "leader_follower", "armed": False}],
+                lambda: {
+                    "ok": True,
+                    "stopped": 1,
+                    "report": "stopped 1 leader-follower controller(s)",
+                },
+            ],
+        ):
+            status = server._runtime_module_status("ros2_live", "unused")
+            stopped = server._stop_runtime_module("ros2_live", "unused")
+
+        self.assertTrue(status["active"])
+        self.assertEqual(
+            status["managed_runs"][0]["run_id"],
+            "leader_follower",
+        )
+        self.assertEqual(stopped["stopped"]["managed_runs"], 1)
+
     def test_robot_runtime_helpers_follow_registered_launcher_state(self):
         status_fn = lambda: {"ok": True, "active": True, "managed_runs": [{"run_id": "robot"}]}
         stop_fn = lambda: {"ok": True, "stopped": {"managed_runs": 1}}


### PR DESCRIPTION
## Summary
- pause every running deployment that owns the selected robot target
- replace and clean up superseded target deployments before starting a new revision
- surface conflicting deployments and replacement cleanup in the editor
- restore ROS 2 live runtime status and stop-service mappings
- add regression coverage for pause-all, replacement cleanup, and runtime normalization

## Verification
- editor device/runtime tests: `106 passed`
- editor production build passed
- full core suite: `458 tests`, with one pre-existing unrelated typography assertion (`index.css` uses `9px`)
- `git diff --check` passed