### PR TITLE
Update workflow packages with Runtime

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -66,6 +66,13 @@ Update clean package checkouts with:
 blacknode packages update --all
 ```
 
+For a managed remote device, **Devices → Software packages → Update Runtime**
+and **Update all** also refresh every extension package already installed in
+that Runtime. Blacknode stops active deployments, disarms attached robots,
+updates the service and clean package checkouts, reloads Runtime, and verifies
+the resulting package manifest. Deployments remain stopped and disarmed until
+the operator explicitly starts and arms them.
+
 The update command is intentionally conservative: it fetches and fast-forwards
 only packages with no local edits and no local commits ahead of upstream. Dirty,
 ahead, diverged, non-git, and non-folder packages are reported and skipped so a

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -4080,6 +4080,13 @@ def _update_device_host_payload(
 
     report(92, "Verifying reported runtime and hardware versions")
     runtime_manifest: dict[str, Any] | None = None
+    extension_update: dict[str, Any] = {
+        "ok": True,
+        "installed": [],
+        "already_present": [],
+        "activated": [],
+        "messages": [],
+    }
     runtime_error = ""
     for _attempt in range(40):
         try:
@@ -4097,6 +4104,72 @@ def _update_device_host_payload(
         raise DeviceRegistryError(
             f"The runtime service updated but did not pass verification: {runtime_error}"
         )
+
+    if include_runtime:
+        extension_specs, extension_warnings = _runtime_extension_update_specs(
+            runtime_manifest
+        )
+        warnings.extend(extension_warnings)
+        if extension_specs:
+            if "package_refresh_v1" not in set(
+                runtime_manifest.get("features") or []
+            ):
+                raise DeviceRegistryError(
+                    "Runtime updated but does not support refreshing installed "
+                    "workflow packages. Install Runtime 0.3.15 or newer."
+                )
+            report(
+                93,
+                f"Updating {len(extension_specs)} installed workflow package"
+                f"{'s' if len(extension_specs) != 1 else ''}",
+            )
+            extension_update = _device_registry.host_client(
+                host_id
+            ).sync_packages(extension_specs)
+            if extension_update.get("ok") is not True:
+                raise DeviceRegistryError(
+                    "The Runtime updated, but its workflow packages did not."
+                )
+            # Package modules are imported into Runtime and deployment
+            # processes. Reload Runtime after refreshing the checkouts so every
+            # later deployment start sees one coherent package set.
+            report(95, "Reloading Runtime with updated workflow packages")
+            control_runtime(
+                host=str(managed.get("ssh_host") or ""),
+                port=int(managed.get("ssh_port") or 22),
+                username=str(managed.get("ssh_username") or ""),
+                password=req.password,
+                host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                instance_id=str(managed.get("instance_id") or "default"),
+                action="pause",
+            )
+            control_runtime(
+                host=str(managed.get("ssh_host") or ""),
+                port=int(managed.get("ssh_port") or 22),
+                username=str(managed.get("ssh_username") or ""),
+                password=req.password,
+                host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                instance_id=str(managed.get("instance_id") or "default"),
+                action="resume",
+            )
+            runtime_manifest = None
+            for _attempt in range(40):
+                try:
+                    candidate = _device_registry.host_client(host_id).manifest()
+                    if (
+                        candidate.get("service") == "blacknode-runtime"
+                        and candidate.get("protocol_version") == 1
+                    ):
+                        runtime_manifest = candidate
+                        break
+                except (DeviceRegistryError, KeyError) as exc:
+                    runtime_error = str(exc)
+                    time.sleep(0.25)
+            if runtime_manifest is None:
+                raise DeviceRegistryError(
+                    "Workflow packages updated, but Runtime did not return after "
+                    f"its package reload: {runtime_error}"
+                )
 
     verified_robots: list[dict[str, Any]] = []
     for robot in robots:
@@ -4189,6 +4262,14 @@ def _update_device_host_payload(
     summary += (
         "The runtime and robot monitoring are online, and Blacknode motion remains disarmed."
     )
+    refreshed_extensions = len(extension_update.get("already_present") or []) + len(
+        extension_update.get("installed") or []
+    )
+    if refreshed_extensions:
+        summary += (
+            f" Refreshed {refreshed_extensions} installed workflow package"
+            f"{'s' if refreshed_extensions != 1 else ''}."
+        )
     if warnings:
         summary += (
             f" Completed with {len(warnings)} warning"
@@ -4201,6 +4282,7 @@ def _update_device_host_payload(
         "device": device,
         "update": update,
         "runtime": runtime_manifest,
+        "extension_packages": extension_update,
         "robots": verified_robots,
         "stopped_deployments": stopped_deployments,
         "controlled_robots": controlled_robots,
@@ -5430,6 +5512,50 @@ def _package_git_source(path: str) -> str:
     if match:
         return f"https://{match.group(1)}/{match.group(2)}"
     return source
+
+
+def _runtime_extension_update_specs(
+    runtime_manifest: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Build latest-revision sync requests for installed extension packages."""
+    remote_package_names = {
+        str(item.get("name") or "")
+        for item in (runtime_manifest.get("packages") or [])
+        if (
+            isinstance(item, dict)
+            and str(item.get("name") or "").startswith("blacknode-")
+            and str(item.get("name") or "")
+            not in {"blacknode-runtime", "blacknode-hardware"}
+        )
+    }
+    local_packages = {
+        info.name: info
+        for info in installed_packages()
+    }
+    indexed_packages = package_index_payload().get("packages") or {}
+    specs: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for name in sorted(remote_package_names):
+        local = local_packages.get(name)
+        indexed = indexed_packages.get(name)
+        git_url = (
+            _package_git_source(str(local.path or ""))
+            if local is not None
+            else ""
+        )
+        if not git_url and isinstance(indexed, dict):
+            git_url = str(indexed.get("git_url") or "").strip()
+        if not git_url:
+            warnings.append(
+                f"{name} is installed on the Runtime but has no trusted update source."
+            )
+            continue
+        specs.append({
+            "name": name,
+            "git_url": git_url,
+            "update": True,
+        })
+    return specs, warnings
 
 
 def _workflow_target_package_specs(

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -228,6 +228,11 @@ export interface DeviceRuntimeStatus {
     protocol_version?: number
     runtime_version?: string
     device_id?: string
+    packages?: Array<{
+      name: string
+      version: string
+      source?: string
+    }>
     [key: string]: unknown
   }
   hardware?: {
@@ -406,6 +411,17 @@ export interface ManagedServiceUpdateResult {
   runtime: {
     runtime_version?: string
     [key: string]: unknown
+  }
+  extension_packages?: {
+    ok: boolean
+    installed: Array<{ name: string; version: string }>
+    already_present: Array<{ name: string; version: string }>
+    activated: Array<{
+      package: string
+      component: string
+      adapter: string
+    }>
+    messages: string[]
   }
   robots: Array<{
     id: string

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -459,6 +459,12 @@ export default function DevicesPanel() {
   )
     ? `v${selectedRuntimeVersionValue}`
     : 'version not reported'
+  const selectedWorkflowPackages = (
+    selectedDeviceState?.runtime?.manifest?.packages ?? []
+  ).filter(item => (
+    item.name.startsWith('blacknode-')
+    && !['blacknode-runtime', 'blacknode-hardware'].includes(item.name)
+  ))
   const selectedHardwareVersion = (
     selectedDeviceState?.runtime?.hardware?.status?.software_version
     || selectedDeviceState?.runtime?.hardware?.installed_version
@@ -1347,9 +1353,9 @@ export default function DevicesPanel() {
           ? 'Runtime package'
           : 'Hardware package'
       : scope === 'all'
-        ? 'Runtime + Robot Hardware'
+        ? 'Runtime + workflow packages + Robot Hardware'
         : scope === 'runtime'
-          ? 'Runtime'
+          ? 'Runtime + installed workflow packages'
           : `${device.managed_runtime?.stack_mode === 'isolated' ? 'isolated' : 'shared'} Robot Hardware installation used by ${hardwareServiceCount} robot service${
             hardwareServiceCount === 1 ? '' : 's'
           }`
@@ -1366,12 +1372,12 @@ export default function DevicesPanel() {
         message: managedLocally
           ? `Preparing ${targetLabel}`
           : scope === 'runtime'
-            ? 'Preparing Runtime update'
+            ? 'Preparing Runtime + workflow package update'
             : scope === 'hardware'
               ? `Preparing shared Robot Hardware update for ${hardwareServiceCount} robot service${
                 hardwareServiceCount === 1 ? '' : 's'
               }`
-              : 'Preparing Runtime + Robot Hardware update',
+              : 'Preparing Runtime + workflow packages + Robot Hardware update',
       },
     }))
     try {
@@ -2850,7 +2856,9 @@ export default function DevicesPanel() {
                 <div>
                   <strong>Software packages</strong>
                   <span>
-                    Runtime and Hardware use the same package controls on every device.
+                    {selectedDeviceManagedLocally
+                      ? 'Runtime and Hardware use independent package controls.'
+                      : 'Updating Runtime also refreshes every installed workflow package.'}
                   </span>
                 </div>
                 <div className="bn-local-package-summary-actions">
@@ -2885,8 +2893,15 @@ export default function DevicesPanel() {
               )}
               <div className="bn-local-package-summary">
                 <SoftwarePackageSummaryCard
-                  label="Runtime package"
+                  label={selectedDeviceManagedLocally
+                    ? 'Runtime package'
+                    : 'Runtime + workflow packages'}
                   path={selectedDevice.managed_runtime?.runtime_dir || selectedDevice.runtime_url}
+                  detail={selectedDeviceManagedLocally
+                    ? undefined
+                    : `${selectedWorkflowPackages.length} installed workflow package${
+                        selectedWorkflowPackages.length === 1 ? '' : 's'
+                      } update with Runtime`}
                   state={selectedRuntimePackageState}
                   currentVersion={runtimeCurrentVersion}
                   latestVersion={runtimeLatestVersion}
@@ -3676,12 +3691,10 @@ export default function DevicesPanel() {
                         component => component.dirty || Boolean(component.error),
                       )
                     }
-                    title="Update or reinstall the Runtime and Hardware packages together"
+                    title="Update Runtime, installed workflow packages, and Hardware together"
                     onClick={() => void updateDevice(selectedDevice, 'all')}
                   >
-                    {checkedSoftwareComponents.some(component => component.update_available)
-                      ? 'Update all'
-                      : 'Reinstall all'}
+                    Update all
                   </button>
                 </div>
               )}

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -81,6 +81,7 @@ class _HardwareService:
             "process_supervision_v1",
             "rollback_v1",
             "package_sync_v1",
+            "package_refresh_v1",
             "component_sync_v1",
             "deployment_ownership_v1",
             "deployment_workflow_v1",
@@ -143,6 +144,7 @@ class _HardwareService:
             })
         if path == "/packages/sync":
             installed = []
+            already_present = []
             package_index = server.package_index_payload()["packages"]
             for spec in body.get("packages", []):
                 name = spec["name"]
@@ -160,6 +162,8 @@ class _HardwareService:
                     installed.append(item)
                 elif spec.get("version"):
                     existing["version"] = spec["version"]
+                if existing is not None:
+                    already_present.append(dict(existing))
                 indexed = package_index.get(name) or {}
                 self.runtime_node_types = sorted(set(
                     self.runtime_node_types + list(indexed.get("node_types") or [])
@@ -167,7 +171,7 @@ class _HardwareService:
             return _JsonResponse({
                 "ok": True,
                 "installed": installed,
-                "already_present": [],
+                "already_present": already_present,
                 "messages": [],
             })
         if path == "/diagnostics/ros2":
@@ -2528,6 +2532,11 @@ class EditorDeviceApiTests(unittest.TestCase):
             "torque_enabled": False,
         })
         runtime = _HardwareService("runtime-token")
+        runtime.runtime_packages.append({
+            "name": "blacknode-skills",
+            "version": "0.2.2",
+            "source": "workspace",
+        })
         runtime.runtime_deployments["live"] = {
             "id": "live",
             "name": "Live workflow",
@@ -2589,6 +2598,28 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "update_managed_services",
                 return_value=update_result,
             ) as update,
+            patch.object(
+                server,
+                "_runtime_extension_update_specs",
+                return_value=([
+                    {
+                        "name": "blacknode-skills",
+                        "git_url": (
+                            "https://github.com/temiroff/blacknode-skills.git"
+                        ),
+                        "update": True,
+                    },
+                ], []),
+            ),
+            patch.object(
+                server,
+                "control_runtime",
+                return_value={
+                    "ok": True,
+                    "state": "active",
+                    "service_name": "blacknode-runtime.service",
+                },
+            ) as control,
         ):
             response = self.client.post(
                 f"/device-hosts/{host['id']}/update-stream",
@@ -2608,6 +2639,18 @@ class EditorDeviceApiTests(unittest.TestCase):
         update.assert_called_once()
         self.assertEqual(update.call_args.kwargs["hardware_ports"], [])
         self.assertTrue(update.call_args.kwargs["include_runtime"])
+        sync_request = next(
+            item
+            for item in runtime.requests
+            if item[0] == "POST" and item[1] == "/packages/sync"
+        )
+        self.assertEqual(sync_request[3]["packages"][0]["update"], True)
+        self.assertEqual(control.call_count, 2)
+        self.assertEqual(
+            result["extension_packages"]["already_present"][0]["name"],
+            "blacknode-skills",
+        )
+        self.assertIn("workflow package", result["summary"])
         self.assertNotIn("ssh-password", response.text)
 
     def test_managed_runtime_update_falls_back_to_verified_ssh_when_api_times_out(self):
@@ -2702,6 +2745,41 @@ class EditorDeviceApiTests(unittest.TestCase):
         update.assert_called_once()
         self.assertEqual(result["runtime"]["runtime_version"], "0.3.9")
         self.assertEqual(progress[-1]["progress"], 100)
+
+    def test_runtime_extension_update_specs_refresh_installed_packages(self):
+        package = SimpleNamespace(
+            name="blacknode-skills",
+            path=Path("packages/blacknode-skills"),
+        )
+        with (
+            patch.object(server, "installed_packages", return_value=[package]),
+            patch.object(
+                server,
+                "_package_git_source",
+                return_value="https://github.com/temiroff/blacknode-skills.git",
+            ),
+        ):
+            specs, warnings = server._runtime_extension_update_specs({
+                "packages": [
+                    {
+                        "name": "blacknode-runtime",
+                        "version": "0.3.15",
+                        "source": "runtime",
+                    },
+                    {
+                        "name": "blacknode-skills",
+                        "version": "0.2.3",
+                        "source": "workspace",
+                    },
+                ],
+            })
+
+        self.assertEqual(warnings, [])
+        self.assertEqual(specs, [{
+            "name": "blacknode-skills",
+            "git_url": "https://github.com/temiroff/blacknode-skills.git",
+            "update": True,
+        }])
 
     def test_managed_update_check_reports_installed_latest_and_live_versions(self):
         hardware = _HardwareService(status_overrides={


### PR DESCRIPTION
## What changed
- Extend managed remote Runtime updates to refresh all installed workflow packages.
- Reload Runtime after package refresh and verify the resulting manifest.
- Require the `package_refresh_v1` capability instead of silently skipping package updates.
- Clarify the update scope in Devices UI and always expose an `Update all` action.

## Why
The previous Runtime/Hardware update UI did not include extension packages, leaving old ROS drivers and controllers active after users reasonably expected an all-inclusive update.

## Safety
Deployments are stopped and robots are disarmed before updates. Deployments remain stopped/disarmed afterward and require explicit start/arm actions.

## Validation
- `python -m unittest discover -s tests` (462 passed, 8 skipped)
- `pytest -q tests/test_editor_devices.py` (93 passed)
- `npm run build`