### PR TITLE
Fix noninteractive managed updates

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -2081,12 +2081,12 @@ def control_runtime(
             connection,
             (
                 "sudo -S -p '' -v"
-                f" && sudo systemctl {systemd_action} {service_name}"
-                f' && state="$(sudo systemctl is-active {service_name} || true)"'
+                f" && sudo -S -p '' systemctl {systemd_action} {service_name}"
+                f' && state="$(sudo -S -p \'\' systemctl is-active {service_name} || true)"'
                 ' && printf "%s\\n" "$state"'
                 f' && [ "$state" = "{"inactive" if clean_action == "pause" else "active"}" ]'
             ),
-            stdin_text=password + "\n",
+            stdin_text=_sudo_input(password),
             timeout=60.0,
         )
         state = output.strip().splitlines()[-1] if output.strip() else ""

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -2882,6 +2882,21 @@ export default function DevicesPanel() {
                   >
                     {busy ? 'Checking…' : 'Check updates'}
                   </button>
+                  {!selectedDeviceManagedLocally && (
+                    <button
+                      type="button"
+                      className="bn-device-action-button is-primary"
+                      disabled={busy || !updatePassword}
+                      title="Update Runtime, all installed workflow packages, and Hardware"
+                      onClick={() => void updateDevice(
+                        selectedDevice,
+                        'all',
+                        'update',
+                      )}
+                    >
+                      Update all
+                    </button>
+                  )}
                 </div>
               </div>
               {!selectedDeviceManagedLocally && (
@@ -3675,27 +3690,6 @@ export default function DevicesPanel() {
                   {updateCheckReport.warnings.map(warning => (
                     <span key={warning}>{warning}</span>
                   ))}
-                </div>
-              )}
-              {!selectedDeviceManagedLocally
-                && checkedRuntimeComponents.length > 0
-                && checkedHardwareComponents.length > 0 && (
-                <div className="bn-device-update-report-actions">
-                  <button
-                    type="button"
-                    className="bn-device-action-button"
-                    disabled={
-                      busy
-                      || !updatePassword
-                      || checkedSoftwareComponents.some(
-                        component => component.dirty || Boolean(component.error),
-                      )
-                    }
-                    title="Update Runtime, installed workflow packages, and Hardware together"
-                    onClick={() => void updateDevice(selectedDevice, 'all')}
-                  >
-                    Update all
-                  </button>
                 </div>
               )}
             </section>

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -383,6 +383,40 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "line-one\nline-two",
             )
 
+    def test_runtime_control_uses_password_stdin_for_every_sudo(self):
+        commands = []
+        stdin_values = []
+        connection = SimpleNamespace(close=lambda: None)
+
+        def fake_run(_connection, command, **kwargs):
+            commands.append(command)
+            stdin_values.append(kwargs.get("stdin_text"))
+            return "inactive\n"
+
+        with (
+            patch.object(device_installer, "_connect", return_value=connection),
+            patch.object(device_installer, "_run", side_effect=fake_run),
+        ):
+            result = device_installer.control_runtime(
+                host="192.168.1.87",
+                port=22,
+                username="alex",
+                password="ssh-password",
+                host_fingerprint="SHA256:trusted-device-key",
+                instance_id="default",
+                action="pause",
+            )
+
+        self.assertEqual(result["state"], "inactive")
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(commands[0].count("sudo -S -p ''"), 3)
+        self.assertNotIn(" && sudo systemctl", commands[0])
+        self.assertNotIn("$(sudo systemctl", commands[0])
+        self.assertEqual(
+            stdin_values,
+            [device_installer._sudo_input("ssh-password")],
+        )
+
     def test_ssh_authentication_failure_is_clear_and_non_mutating(self):
         class AuthenticationException(Exception):
             pass


### PR DESCRIPTION
## What changed

- run every remote Runtime service-control `sudo` command in non-interactive stdin mode
- provide reusable password input for all `sudo` reads in the composed SSH command
- keep **Update all** visible beside **Check updates** for remote devices, even when an update check failed
- add regression coverage for the multi-sudo Runtime lifecycle command

## Root cause

The updater authenticated the first `sudo` invocation with `-S`, but the following `systemctl` and status commands invoked `sudo` without `-S`. Remote SSH execution has no terminal, so those commands could not read the password and exited with code 1.

## User impact

After entering the SSH password, users can press **Update all** immediately. Runtime, installed workflow packages, and Hardware can complete their managed update without requiring an interactive SSH terminal.

## Validation

- `python -m pytest -q tests/test_editor_devices.py` (94 passed)
- `python -m unittest discover -s tests` (463 passed, 8 skipped)
- `npm run build` in `editor/`