### PR TITLE
Organize managed device installations

### DIFF
--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -75,6 +75,25 @@ runtime service, configures runtime port `8766` in UFW when UFW is active, and
 pairs the runtime with the editor. The SSH password remains in memory for that
 setup request and is not saved.
 
+Managed Linux installations use one visible root per stable Runtime instance:
+
+```text
+~/Blacknode/devices/<instance-id>/
+  install.json
+  runtime/
+    packages/
+  hardware/
+  secrets/
+```
+
+The Runtime, its synchronized workflow packages, and an isolated Robot Hardware
+checkout therefore have one ownership boundary that the Devices panel can show
+and uninstall precisely. Multiple robots attached to the same Runtime share its
+`runtime/packages/` store. A separate complete stack receives another stable
+instance directory. Device display-name changes do not rename these paths.
+Legacy `~/blacknode-runtime`, `~/blacknode-runtimes`, and Hardware checkout
+locations remain discoverable and manageable.
+
 When another robot needs complete separation on the same Linux computer,
 choose **Install a complete isolated robot stack** during the SSH review. The
 new stack receives separate Runtime and Robot Hardware repositories,

--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -207,8 +207,11 @@ def host_environment():
     }
 
 ids = {"default"}
-side_root = home / "blacknode-runtimes"
-if side_root.is_dir():
+organized_root = home / "Blacknode" / "devices"
+legacy_side_root = home / "blacknode-runtimes"
+for side_root in (organized_root, legacy_side_root):
+    if not side_root.is_dir():
+        continue
     ids.update(
         path.name
         for path in side_root.iterdir()
@@ -222,16 +225,22 @@ for unit_path in glob.glob("/etc/systemd/system/blacknode-runtime-*.service"):
 
 instances = []
 for instance in sorted(ids, key=lambda value: (value != "default", value)):
+    organized_stack = organized_root / instance
+    organized_repo = organized_stack / "runtime"
+    organized_token = organized_stack / "secrets" / "runtime.auth.token"
     if instance == "default":
-        repo = home / "blacknode-runtime"
+        legacy_repo = home / "blacknode-runtime"
         unit = "blacknode-runtime.service"
         fallback_port = 8766
-        fallback_token = home / ".blacknode" / "runtime.auth.token"
+        legacy_token = home / ".blacknode" / "runtime.auth.token"
     else:
-        repo = side_root / instance
+        legacy_repo = legacy_side_root / instance
         unit = f"blacknode-runtime-{instance}.service"
         fallback_port = 0
-        fallback_token = home / ".blacknode" / "runtimes" / f"{instance}.auth.token"
+        legacy_token = home / ".blacknode" / "runtimes" / f"{instance}.auth.token"
+    organized_present = organized_repo.exists() or organized_token.exists()
+    repo = organized_repo if organized_present else legacy_repo
+    fallback_token = organized_token if organized_present else legacy_token
     config_path = repo / ".blacknode-runtime" / "runtime.json"
     config = {}
     if config_path.is_file():
@@ -275,7 +284,9 @@ for instance in sorted(ids, key=lambda value: (value != "default", value)):
         error = "The runtime is not running."
     instances.append({
         "instance_id": instance,
+        "install_root": str(organized_stack) if organized_present else "",
         "runtime_dir": str(repo),
+        "packages_dir": str(repo / "packages"),
         "service_name": unit,
         "port": port,
         "repository": (repo / ".git").is_dir(),
@@ -741,7 +752,9 @@ def install_runtime(
                     "instance_id": selected_instance,
                     "runtime_port": runtime_port,
                     "service_name": str(existing.get("service_name") or ""),
+                    "install_root": str(existing.get("install_root") or ""),
                     "runtime_dir": str(existing.get("runtime_dir") or ""),
+                    "packages_dir": str(existing.get("packages_dir") or ""),
                     "stack_mode": "runtime_only",
                     "hardware_dir": "",
                 }
@@ -780,22 +793,24 @@ instance="$2"
 runtime_port="$3"
 token_source="$4"
 remove_old_port="$5"
+[[ "$instance" == "default" || "$instance" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || {
+  echo "Invalid Blacknode runtime instance."
+  exit 2
+}
+stack_root="$HOME/Blacknode/devices/$instance"
+runtime_dir="$stack_root/runtime"
+token_file="$stack_root/secrets/runtime.auth.token"
+hardware_dir="$stack_root/hardware"
 if [[ "$instance" == "default" ]]; then
-  runtime_dir="$HOME/blacknode-runtime"
-  token_file="$HOME/.blacknode/runtime.auth.token"
   service_name="blacknode-runtime.service"
   service_instance=""
-  hardware_dir="$HOME/blacknode-hardware"
+  legacy_runtime_dir="$HOME/blacknode-runtime"
+  legacy_token_file="$HOME/.blacknode/runtime.auth.token"
 else
-  [[ "$instance" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || {
-    echo "Invalid Blacknode runtime instance."
-    exit 2
-  }
-  runtime_dir="$HOME/blacknode-runtimes/$instance"
-  token_file="$HOME/.blacknode/runtimes/$instance.auth.token"
   service_name="blacknode-runtime-$instance.service"
   service_instance="$instance"
-  hardware_dir="$HOME/blacknode-hardware-instances/$instance"
+  legacy_runtime_dir="$HOME/blacknode-runtimes/$instance"
+  legacy_token_file="$HOME/.blacknode/runtimes/$instance.auth.token"
 fi
 active_sibling_services=()
 if [[ "$action" == "side_by_side" || "$action" == "isolated_stack" ]] \
@@ -834,12 +849,16 @@ cleanup_failed_install() {
 }
 trap cleanup_failed_install EXIT
 case "$runtime_dir" in
-  "$HOME/blacknode-runtime"|"$HOME/blacknode-runtimes/"*) ;;
+  "$HOME/Blacknode/devices/"*/runtime) ;;
   *) echo "Unsafe runtime directory."; exit 2 ;;
 esac
 case "$hardware_dir" in
-  "$HOME/blacknode-hardware"|"$HOME/blacknode-hardware-instances/"*) ;;
+  "$HOME/Blacknode/devices/"*/hardware) ;;
   *) echo "Unsafe Hardware directory."; exit 2 ;;
+esac
+case "$legacy_runtime_dir" in
+  "$HOME/blacknode-runtime"|"$HOME/blacknode-runtimes/"*) ;;
+  *) echo "Unsafe legacy Runtime directory."; exit 2 ;;
 esac
 token_dir="$(dirname -- "$token_file")"
 progress 14 "Preparing the selected runtime"
@@ -861,6 +880,8 @@ if [[ "$action" == "replace" ]]; then
   fi
   rm -rf -- "$runtime_dir"
   rm -f -- "$token_file"
+  rm -rf -- "$legacy_runtime_dir"
+  rm -f -- "$legacy_token_file"
 elif [[ -e "$runtime_dir" ]]; then
   echo "The selected runtime directory already exists. Inspect the device again."
   exit 3
@@ -1004,6 +1025,23 @@ if command -v ufw >/dev/null 2>&1 \
     sudo ufw allow "$default_port/tcp" comment "Blacknode runtime" >/dev/null
   fi
 fi
+python3 - "$stack_root/install.json" "$instance" "$runtime_dir" "$hardware_dir" \
+  "$service_name" "$action" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+manifest_path.parent.mkdir(parents=True, exist_ok=True)
+manifest_path.write_text(json.dumps({
+    "layout_version": 1,
+    "instance_id": sys.argv[2],
+    "runtime_dir": sys.argv[3],
+    "packages_dir": str(Path(sys.argv[3]) / "packages"),
+    "hardware_dir": sys.argv[4] if sys.argv[6] == "isolated_stack" else "",
+    "runtime_service": sys.argv[5],
+}, indent=2) + "\n", encoding="utf-8")
+PY
 install_complete=true
 progress 96 "Verifying the runtime service"
 """
@@ -1061,18 +1099,16 @@ progress 96 "Verifying the runtime service"
             "instance_id": selected_instance,
             "runtime_port": runtime_port,
             "service_name": service_name,
-            "runtime_dir": (
-                "~/blacknode-runtime"
-                if selected_instance == "default"
-                else f"~/blacknode-runtimes/{selected_instance}"
-            ),
+            "install_root": f"~/Blacknode/devices/{selected_instance}",
+            "runtime_dir": f"~/Blacknode/devices/{selected_instance}/runtime",
+            "packages_dir": f"~/Blacknode/devices/{selected_instance}/runtime/packages",
             "stack_mode": (
                 "isolated"
                 if clean_action == "isolated_stack"
                 else "runtime_only"
             ),
             "hardware_dir": (
-                f"~/blacknode-hardware-instances/{selected_instance}"
+                f"~/Blacknode/devices/{selected_instance}/hardware"
                 if clean_action == "isolated_stack"
                 else ""
             ),
@@ -1176,22 +1212,26 @@ for target in targets:
     print(f"{int(target['port'])}\t{str(target.get('device_id') or '')}")
 PY
 )
+organized_stack="$HOME/Blacknode/devices/$instance"
+organized_runtime_dir="$organized_stack/runtime"
+organized_hardware_dir="$organized_stack/hardware"
 if [[ "$instance" == "default" ]]; then
-  runtime_dir="$HOME/blacknode-runtime"
+  legacy_runtime_dir="$HOME/blacknode-runtime"
+  legacy_hardware_dir="$HOME/blacknode-hardware"
   runtime_service="blacknode-runtime.service"
 else
   [[ "$instance" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || {
     echo "Invalid Blacknode runtime instance."
     exit 2
   }
-  runtime_dir="$HOME/blacknode-runtimes/$instance"
+  legacy_runtime_dir="$HOME/blacknode-runtimes/$instance"
+  legacy_hardware_dir="$HOME/blacknode-hardware-instances/$instance"
   runtime_service="blacknode-runtime-$instance.service"
 fi
-if [[ "$stack_mode" == "isolated" ]]; then
-  hardware_repo="$HOME/blacknode-hardware-instances/$instance"
-else
-  hardware_repo="$HOME/blacknode-hardware"
-fi
+runtime_dir="$legacy_runtime_dir"
+[[ ! -d "$organized_runtime_dir" ]] || runtime_dir="$organized_runtime_dir"
+hardware_repo="$legacy_hardware_dir"
+[[ ! -d "$organized_hardware_dir" ]] || hardware_repo="$organized_hardware_dir"
 
 package_version() {
   python3 - "$1" <<'PY'
@@ -1729,12 +1769,14 @@ MARKER = "__BLACKNODE_UPDATE_CHECK__="
 request = json.loads(base64.urlsafe_b64decode(sys.argv[1]).decode("utf-8"))
 home = Path.home()
 instance = request["instance_id"]
+organized_runtime = home / "Blacknode" / "devices" / instance / "runtime"
 if instance == "default":
-    runtime_dir = home / "blacknode-runtime"
+    legacy_runtime = home / "blacknode-runtime"
     runtime_service = "blacknode-runtime.service"
 else:
-    runtime_dir = home / "blacknode-runtimes" / instance
+    legacy_runtime = home / "blacknode-runtimes" / instance
     runtime_service = f"blacknode-runtime-{{instance}}.service"
+runtime_dir = organized_runtime if organized_runtime.is_dir() else legacy_runtime
 
 def command(args, timeout=30):
     try:
@@ -2306,19 +2348,34 @@ progress() {
 instance="$1"
 runtime_port="$2"
 stack_mode="$3"
+stack_root="$HOME/Blacknode/devices/$instance"
+organized_runtime_dir="$stack_root/runtime"
+organized_token_file="$stack_root/secrets/runtime.auth.token"
+organized_hardware_dir="$stack_root/hardware"
 if [[ "$instance" == "default" ]]; then
-  runtime_dir="$HOME/blacknode-runtime"
-  token_file="$HOME/.blacknode/runtime.auth.token"
+  legacy_runtime_dir="$HOME/blacknode-runtime"
+  legacy_token_file="$HOME/.blacknode/runtime.auth.token"
+  legacy_hardware_dir="$HOME/blacknode-hardware"
   service_name="blacknode-runtime.service"
 else
   [[ "$instance" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || exit 2
-  runtime_dir="$HOME/blacknode-runtimes/$instance"
-  token_file="$HOME/.blacknode/runtimes/$instance.auth.token"
+  legacy_runtime_dir="$HOME/blacknode-runtimes/$instance"
+  legacy_token_file="$HOME/.blacknode/runtimes/$instance.auth.token"
+  legacy_hardware_dir="$HOME/blacknode-hardware-instances/$instance"
   service_name="blacknode-runtime-$instance.service"
 fi
-hardware_dir="$HOME/blacknode-hardware-instances/$instance"
+runtime_dir="$legacy_runtime_dir"
+token_file="$legacy_token_file"
+if [[ -d "$organized_runtime_dir" || -f "$organized_token_file" ]]; then
+  runtime_dir="$organized_runtime_dir"
+  token_file="$organized_token_file"
+fi
+hardware_dir="$legacy_hardware_dir"
+[[ ! -d "$organized_hardware_dir" ]] || hardware_dir="$organized_hardware_dir"
 case "$runtime_dir" in
-  "$HOME/blacknode-runtime"|"$HOME/blacknode-runtimes/"*) ;;
+  "$HOME/Blacknode/devices/"*/runtime|\
+  "$HOME/blacknode-runtime"|\
+  "$HOME/blacknode-runtimes/"*) ;;
   *) echo "Unsafe runtime directory."; exit 2 ;;
 esac
 progress 20 "Stopping Runtime service"
@@ -2329,6 +2386,7 @@ sudo rm -f -- "/etc/systemd/system/$service_name"
 sudo systemctl daemon-reload
 if [[ "$stack_mode" == "isolated" ]]; then
   case "$hardware_dir" in
+    "$HOME/Blacknode/devices/"*/hardware|\
     "$HOME/blacknode-hardware-instances/"*) ;;
     *) echo "Unsafe Hardware directory."; exit 2 ;;
   esac
@@ -2373,6 +2431,11 @@ if command -v ufw >/dev/null 2>&1 \
 fi
 rm -rf -- "$runtime_dir"
 rm -f -- "$token_file"
+if [[ "$runtime_dir" == "$organized_runtime_dir" ]]; then
+  rm -f -- "$stack_root/install.json"
+  rmdir -- "$stack_root/secrets" "$stack_root" "$HOME/Blacknode/devices" \
+    "$HOME/Blacknode" >/dev/null 2>&1 || true
+fi
 progress 94 "Finalizing uninstall"
 """
     try:

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -473,7 +473,9 @@ class DeviceRegistry:
                         "instance_id",
                         "runtime_port",
                         "service_name",
+                        "install_root",
                         "runtime_dir",
+                        "packages_dir",
                         "stack_mode",
                         "hardware_dir",
                         "hardware_port",
@@ -593,7 +595,9 @@ class DeviceRegistry:
             "instance_id",
             "runtime_port",
             "service_name",
+            "install_root",
             "runtime_dir",
+            "packages_dir",
             "stack_mode",
             "hardware_dir",
             "hardware_port",
@@ -617,6 +621,8 @@ class DeviceRegistry:
         }
         required_keys = allowed_keys - {
             "stack_mode",
+            "install_root",
+            "packages_dir",
             "hardware_dir",
             "hardware_port",
             "hardware_service_name",

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -3115,7 +3115,9 @@ def _install_local_device_host_payload(
                 "instance_id",
                 "runtime_port",
                 "service_name",
+                "install_root",
                 "runtime_dir",
+                "packages_dir",
                 "stack_mode",
                 "hardware_dir",
                 "hardware_port",
@@ -3131,6 +3133,7 @@ def _install_local_device_host_payload(
                 "log_path",
                 "owned_install",
             )
+            if key in installed
         },
     )
     if progress is not None:
@@ -3244,7 +3247,9 @@ def _install_device_host_payload(
             "instance_id": installed["instance_id"],
             "runtime_port": runtime_port,
             "service_name": installed["service_name"],
+            "install_root": installed.get("install_root", ""),
             "runtime_dir": installed["runtime_dir"],
+            "packages_dir": installed.get("packages_dir", ""),
             "stack_mode": installed.get("stack_mode", "runtime_only"),
             "hardware_dir": installed.get("hardware_dir", ""),
         },
@@ -3405,7 +3410,9 @@ def configure_device_host_management(
         "instance_id": str(instance.get("instance_id") or ""),
         "runtime_port": runtime_port,
         "service_name": str(instance.get("service_name") or ""),
+        "install_root": str(instance.get("install_root") or ""),
         "runtime_dir": str(instance.get("runtime_dir") or ""),
+        "packages_dir": str(instance.get("packages_dir") or ""),
     }
     if not all(
         management.get(key)

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -126,7 +126,9 @@ export interface ComputeDevice {
     instance_id: string
     runtime_port: number
     service_name: string
+    install_root?: string
     runtime_dir: string
+    packages_dir?: string
     stack_mode?: 'runtime_only' | 'isolated'
     hardware_dir?: string
     hardware_port?: number
@@ -154,7 +156,9 @@ export interface SshDeviceProbe {
 
 export interface SshRuntimeInstance {
   instance_id: string
+  install_root?: string
   runtime_dir: string
+  packages_dir?: string
   service_name: string
   port: number
   repository: boolean
@@ -487,7 +491,9 @@ export interface InstallComputeDeviceResult {
     instance_id: string
     runtime_port: number
     service_name: string
+    install_root?: string
     runtime_dir: string
+    packages_dir?: string
     stack_mode?: 'runtime_only' | 'isolated'
     hardware_dir?: string
     management_mode?: 'ssh' | 'local'

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -3264,9 +3264,14 @@ export default function DevicesPanel() {
                   path={selectedDevice.managed_runtime?.runtime_dir || selectedDevice.runtime_url}
                   detail={selectedDeviceManagedLocally
                     ? undefined
-                    : `${selectedWorkflowPackages.length} installed workflow package${
-                        selectedWorkflowPackages.length === 1 ? '' : 's'
-                      } update with Runtime`}
+                    : `Packages: ${
+                        selectedDevice.managed_runtime?.packages_dir
+                        || `${selectedDevice.managed_runtime?.runtime_dir}/packages`
+                      } · ${selectedWorkflowPackages.length
+                        ? selectedWorkflowPackages
+                          .map(item => `${item.name} v${item.version}`)
+                          .join(', ')
+                        : 'no workflow packages installed'}`}
                   state={selectedRuntimePackageState}
                   currentVersion={runtimeCurrentVersion}
                   latestVersion={runtimeLatestVersion}
@@ -4189,7 +4194,7 @@ export default function DevicesPanel() {
                     ? selectedDevice.managed_runtime.hardware_dir
                       ? `Stops the local Runtime on port ${selectedDevice.managed_runtime.runtime_port} and Robot Hardware on port ${selectedDevice.managed_runtime.hardware_port}.`
                       : `Stops the local Runtime on port ${selectedDevice.managed_runtime.runtime_port}.`
-                    : `Stops ${selectedDevice.managed_runtime.service_name}, removes only ${selectedDevice.managed_runtime.runtime_dir}, its token and port ${selectedDevice.managed_runtime.runtime_port} firewall rule.`}
+                    : `Stops ${selectedDevice.managed_runtime.service_name}, removes ${selectedDevice.managed_runtime.runtime_dir}, its packages, token and port ${selectedDevice.managed_runtime.runtime_port} firewall rule.${selectedDevice.managed_runtime.install_root ? ` The empty ${selectedDevice.managed_runtime.install_root} stack folder is also removed.` : ''}`}
                   {selectedStackIsIsolated
                     ? ` Its instance-scoped Robot Hardware services and ${selectedDevice.managed_runtime.hardware_dir} are also removed.`
                     : ''}

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -3819,7 +3819,7 @@ button.bn-compute-device-card:active:not(:disabled) {
   margin: -1px 0 5px;
   color: var(--tx3);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: 11px;
 }
 
 .bn-joint-monitor-range span:nth-child(2) {

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -475,13 +475,24 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn("sock.bind((\"0.0.0.0\", candidate))", script)
         self.assertIn("'blacknode-runtime*.service' 'blacknode-hardware*.service'", script)
         self.assertIn('sudo systemctl start "$sibling_service"', script)
-        self.assertIn('hardware_dir="$HOME/blacknode-hardware-instances/$instance"', script)
+        self.assertIn('stack_root="$HOME/Blacknode/devices/$instance"', script)
+        self.assertIn('runtime_dir="$stack_root/runtime"', script)
+        self.assertIn('hardware_dir="$stack_root/hardware"', script)
+        self.assertIn('"packages_dir": str(Path(sys.argv[3]) / "packages")', script)
         self.assertIn('BLACKNODE_HARDWARE_INSTANCE="$service_instance"', script)
         self.assertIn("does not support isolated stacks yet", script)
         self.assertNotIn("keep_sudo_alive", script)
 
         self.assertIn(
             "fallback_port = 0",
+            device_installer._INSPECTION_SCRIPT,
+        )
+        self.assertIn(
+            'organized_root = home / "Blacknode" / "devices"',
+            device_installer._INSPECTION_SCRIPT,
+        )
+        self.assertIn(
+            'legacy_side_root = home / "blacknode-runtimes"',
             device_installer._INSPECTION_SCRIPT,
         )
 
@@ -1472,7 +1483,9 @@ class EditorDeviceApiTests(unittest.TestCase):
             "instance_id": "default",
             "runtime_port": 8766,
             "service_name": "blacknode-runtime.service",
-            "runtime_dir": "~/blacknode-runtime",
+            "install_root": "~/Blacknode/devices/default",
+            "runtime_dir": "~/Blacknode/devices/default/runtime",
+            "packages_dir": "~/Blacknode/devices/default/runtime/packages",
         }
         host = {
             "id": "robot-computer",
@@ -1634,7 +1647,9 @@ class EditorDeviceApiTests(unittest.TestCase):
             "instance_id": "default",
             "runtime_port": 8766,
             "service_name": "blacknode-runtime.service",
-            "runtime_dir": "~/blacknode-runtime",
+            "install_root": "~/Blacknode/devices/default",
+            "runtime_dir": "~/Blacknode/devices/default/runtime",
+            "packages_dir": "~/Blacknode/devices/default/runtime/packages",
         }
         with (
             patch.object(server, "install_runtime", return_value=install_result),
@@ -1661,6 +1676,14 @@ class EditorDeviceApiTests(unittest.TestCase):
         managed = response.json()["device"]["managed_runtime"]
         self.assertEqual(managed["instance_id"], "default")
         self.assertEqual(managed["runtime_port"], 8766)
+        self.assertEqual(
+            managed["install_root"],
+            "~/Blacknode/devices/default",
+        )
+        self.assertEqual(
+            managed["packages_dir"],
+            "~/Blacknode/devices/default/runtime/packages",
+        )
 
     def test_automatic_install_stream_reports_progress_and_finishes_pairing(self):
         runtime = _HardwareService("generated-runtime-token")


### PR DESCRIPTION
## What changed
- install each managed Linux Runtime instance under `~/Blacknode/devices/<instance-id>/`
- keep Runtime, synchronized workflow packages, optional isolated Hardware, secrets, and a non-secret install manifest under one ownership boundary
- continue discovering, updating, and uninstalling legacy installation paths
- show the exact package directory plus installed package names and versions in Devices
- remove an organized stack directory when uninstall leaves it empty
- restore the joint-limit label to the editor's 11 px accessibility minimum

## Why
Runtime instances, Hardware checkouts, tokens, and package stores were spread across several home-directory paths. The organized layout makes multiple stacks on one computer easy to inspect and delete precisely while robots sharing one Runtime continue sharing packages.

## Safety
Existing running installations are not moved automatically. Migration occurs only through an explicit reinstall, which already stops the selected Runtime and disarms motion.

## Validation
- `python -m unittest discover -s tests` (463 passed, 8 skipped)
- focused device and typography tests (96 passed)
- editor production build
- Bash syntax checks for install, update, and uninstall scripts