### PR TITLE
Clarify managed installation deletion

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -2436,7 +2436,7 @@ if [[ "$runtime_dir" == "$organized_runtime_dir" ]]; then
   rmdir -- "$stack_root/secrets" "$stack_root" "$HOME/Blacknode/devices" \
     "$HOME/Blacknode" >/dev/null 2>&1 || true
 fi
-progress 94 "Finalizing uninstall"
+progress 94 "Finalizing deletion"
 """
     try:
         report(10, "Inspecting the managed stack")
@@ -2447,7 +2447,7 @@ progress 94 "Finalizing uninstall"
             if discovered_port and discovered_port != selected_port:
                 raise DeviceInstallError(
                     "The runtime port changed since this device was installed. "
-                    "Inspect and pair it again before uninstalling."
+                    "Inspect and pair it again before deleting it."
                 )
         sftp = connection.client.open_sftp()
         try:

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -4725,18 +4725,17 @@ def _uninstall_device_host_payload(
         raise HTTPException(400, str(exc)) from exc
     except DeviceRegistryError as exc:
         raise HTTPException(409, str(exc)) from exc
-    summary = (
-        (
-            "Local robot stack uninstalled"
-            if managed.get("hardware_dir")
-            else "Local Runtime uninstalled"
-        )
-        if str(managed.get("management_mode") or "") == "local"
-        else
-        "Isolated robot stack uninstalled"
-        if str(managed.get("stack_mode") or "runtime_only") == "isolated"
-        else "Runtime uninstalled"
-    )
+    if str(managed.get("management_mode") or "") == "local":
+        if result.get("source_preserved"):
+            summary = "Local services uninstalled; source checkout preserved"
+        elif managed.get("hardware_dir"):
+            summary = "Local robot stack deleted"
+        else:
+            summary = "Local Runtime installation deleted"
+    elif str(managed.get("stack_mode") or "runtime_only") == "isolated":
+        summary = "Isolated robot stack deleted"
+    else:
+        summary = "Runtime installation deleted"
     report(100, summary)
     return {
         "ok": True,

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -1348,19 +1348,19 @@ export default function DevicesPanel() {
   const uninstallDevice = async (device: ComputeDevice) => {
     const managedLocally = device.managed_runtime?.management_mode === 'local'
     if (!managedLocally && !uninstallPassword) {
-      setError('Enter the SSH password to uninstall this managed runtime.')
+      setError('Enter the SSH password to delete this managed installation.')
       return
     }
     if (!window.confirm(
       managedLocally
         ? device.managed_runtime?.hardware_dir
           ? device.managed_runtime?.owned_install && device.managed_runtime?.hardware_owned_install
-            ? `Uninstall "${device.name}" from this computer? This stops Runtime and Robot Hardware, removes both editor-created installation folders and attached robot registrations, and removes this device card.`
+            ? `Delete and uninstall "${device.name}" from this computer? This stops Runtime and Robot Hardware, permanently deletes both editor-created installation folders and attached robot registrations, and removes this device card.`
             : `Uninstall "${device.name}" from this computer? This stops Runtime and Robot Hardware, removes their editor-managed configuration and attached robot registrations, preserves existing source checkouts, and removes this device card.`
           : device.managed_runtime?.owned_install
-            ? `Uninstall "${device.name}" from this computer? This stops its Runtime, removes the editor-created installation folder and attached robot registrations, and removes this device card.`
+            ? `Delete and uninstall "${device.name}" from this computer? This stops its Runtime, permanently deletes the editor-created installation folder and attached robot registrations, and removes this device card.`
             : `Uninstall "${device.name}" from this computer? This stops its Runtime, removes its editor-managed configuration and attached robot registrations, preserves the existing source checkout, and removes this device card.`
-        : `Uninstall "${device.name}" from the remote computer? This stops its runtime, removes its service, files, token, firewall rule, attached robot registrations, and this device card.`,
+        : `Delete and uninstall "${device.name}" from the remote computer? This stops its Runtime and permanently deletes its service, Runtime files, workflow packages, token, firewall rule, attached robot registrations, and this device card.`,
     )) return
     setBusy(true)
     setError(null)
@@ -1368,7 +1368,7 @@ export default function DevicesPanel() {
       ...previous,
       [device.id]: {
         progress: 1,
-        message: 'Starting managed device uninstall',
+        message: 'Starting managed installation deletion',
       },
     }))
     try {
@@ -1392,7 +1392,7 @@ export default function DevicesPanel() {
       const message = reason instanceof Error ? reason.message : String(reason)
       setActionProgress(previous => ({
         ...previous,
-        [device.id]: { progress: 0, message: `Uninstall failed: ${message}` },
+        [device.id]: { progress: 0, message: `Delete failed: ${message}` },
       }))
       setError(message)
     } finally {
@@ -2926,7 +2926,12 @@ export default function DevicesPanel() {
                         disabled={busy}
                         className="bn-device-action-button is-danger"
                       >
-                        {selectedDeviceManagedLocally ? 'Uninstall local stack' : 'Uninstall runtime'}
+                        {selectedDeviceManagedLocally
+                          && !selectedDevice.managed_runtime?.owned_install
+                          ? 'Uninstall local services'
+                          : selectedStackIsIsolated
+                            ? 'Delete robot stack'
+                            : 'Delete Runtime installation'}
                       </button>
                     </>
                   )}
@@ -4183,7 +4188,13 @@ export default function DevicesPanel() {
             >
               <div>
                 <strong>
-                  Uninstall this managed {
+                  {
+                    selectedDeviceManagedLocally
+                      && !selectedDevice.managed_runtime?.owned_install
+                      ? 'Uninstall this managed '
+                      : 'Delete and uninstall this managed '
+                  }
+                  {
                     selectedDeviceManagedLocally || selectedStackIsIsolated
                       ? 'robot stack'
                       : 'runtime'
@@ -4239,7 +4250,12 @@ export default function DevicesPanel() {
                   Cancel
                 </button>
                 <button type="submit" disabled={busy} style={dangerButton}>
-                  {busy ? 'Uninstalling…' : 'Uninstall and remove device'}
+                  {busy
+                    ? 'Deleting…'
+                    : selectedDeviceManagedLocally
+                      && !selectedDevice.managed_runtime?.owned_install
+                      ? 'Uninstall services and forget device'
+                      : 'Delete files, uninstall, and forget device'}
                 </button>
               </div>
             </form>

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -1613,7 +1613,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         ]
         self.assertEqual(
             uninstall_events[-1]["result"]["summary"],
-            "Local Runtime uninstalled",
+            "Local Runtime installation deleted",
         )
         self.assertTrue(uninstall.called)
         self.assertEqual(self.client.get("/device-hosts").json()["devices"], [])
@@ -2119,10 +2119,10 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(progress[-1], {
             "type": "progress",
             "progress": 100,
-            "message": "Isolated robot stack uninstalled",
+            "message": "Isolated robot stack deleted",
         })
         self.assertEqual(events[-1]["type"], "done")
-        self.assertEqual(events[-1]["result"]["summary"], "Isolated robot stack uninstalled")
+        self.assertEqual(events[-1]["result"]["summary"], "Isolated robot stack deleted")
         self.assertEqual(self.client.get("/device-hosts").json()["devices"], [])
 
     def test_device_can_be_renamed_without_repairing_or_exposing_tokens(self):


### PR DESCRIPTION
## What changed
- label destructive managed actions as **Delete Runtime installation** or **Delete robot stack** when files are removed
- retain **Uninstall local services** when user-owned source checkouts are preserved
- make confirmations enumerate Runtime files, workflow packages, secrets, services, registrations, and firewall rules
- report deletion and preservation outcomes accurately

## Why
The former **Uninstall Runtime** label did not clearly communicate that a managed remote installation and its package files are permanently deleted.

## Validation
- `python -m unittest discover -s tests` (463 passed, 8 skipped)
- focused device tests (94 passed)
- editor production build
- uninstall Bash syntax check