### PR TITLE
Delete complete managed devices

### DIFF
--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -94,6 +94,14 @@ instance directory. Device display-name changes do not rename these paths.
 Legacy `~/blacknode-runtime`, `~/blacknode-runtimes`, and Hardware checkout
 locations remain discoverable and manageable.
 
+**Delete device** stops the selected Runtime and its deployments, removes its
+Runtime checkout, synchronized workflow packages, secret, systemd service, and
+firewall rule, then removes the exact Robot Hardware services registered under
+that device. A Hardware checkout is deleted only when no remaining Hardware
+service uses it. The saved robot registrations and device card are removed
+last. Other Blacknode stacks, system ROS 2, Docker, and operating-system
+packages remain available.
+
 When another robot needs complete separation on the same Linux computer,
 choose **Install a complete isolated robot stack** during the SSH review. The
 new stack receives separate Runtime and Robot Hardware repositories,

--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -2312,6 +2312,7 @@ def uninstall_runtime(
     instance_id: str,
     runtime_port: int,
     stack_mode: str = "runtime_only",
+    hardware_ports: list[int] | None = None,
     progress: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     def report(percent: int, message: str) -> None:
@@ -2331,6 +2332,15 @@ def uninstall_runtime(
     selected_port = int(runtime_port)
     if selected_port < 1 or selected_port > 65535:
         raise DeviceInstallError("The managed runtime port is invalid.")
+    selected_hardware_ports = sorted({
+        int(value)
+        for value in (hardware_ports or [])
+    })
+    if any(value < 1 or value > 65535 for value in selected_hardware_ports):
+        raise DeviceInstallError("A Robot Hardware port is invalid.")
+    hardware_ports_payload = base64.urlsafe_b64encode(
+        json.dumps(selected_hardware_ports, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
     connection = _connect(
         host,
         port,
@@ -2348,6 +2358,17 @@ progress() {
 instance="$1"
 runtime_port="$2"
 stack_mode="$3"
+hardware_ports_payload="$4"
+mapfile -t selected_hardware_ports < <(
+  python3 - "$hardware_ports_payload" <<'PY'
+import base64
+import json
+import sys
+
+for value in json.loads(base64.urlsafe_b64decode(sys.argv[1]).decode("utf-8")):
+    print(int(value))
+PY
+)
 stack_root="$HOME/Blacknode/devices/$instance"
 organized_runtime_dir="$stack_root/runtime"
 organized_token_file="$stack_root/secrets/runtime.auth.token"
@@ -2378,52 +2399,128 @@ case "$runtime_dir" in
   "$HOME/blacknode-runtimes/"*) ;;
   *) echo "Unsafe runtime directory."; exit 2 ;;
 esac
+list_hardware_units() {
+  {
+    systemctl list-unit-files 'blacknode-hardware*.service' --no-legend 2>/dev/null
+    systemctl list-units --all --type=service 'blacknode-hardware*.service' \\
+      --no-legend 2>/dev/null
+    find /etc/systemd/system /run/systemd/system -maxdepth 1 \\
+      -name 'blacknode-hardware*.service' -printf '%f\\n' 2>/dev/null
+  } | awk '{print $1}' | sort -u
+}
+hardware_unit_directory() {
+  local unit="$1"
+  local directory
+  directory="$(
+    systemctl show "$unit" --property=WorkingDirectory --value 2>/dev/null || true
+  )"
+  if [[ -z "$directory" ]]; then
+    directory="$(
+      systemctl cat "$unit" 2>/dev/null \\
+        | sed -nE 's/^WorkingDirectory=(.*)$/\\1/p' \\
+        | tail -n 1
+    )"
+  fi
+  printf '%s' "$directory"
+}
+hardware_unit_port() {
+  local unit="$1"
+  {
+    systemctl show "$unit" --property=ExecStart --value 2>/dev/null || true
+    systemctl cat "$unit" 2>/dev/null || true
+  } | sed -nE 's/.*--port[= ]"?([0-9]+).*/\\1/p' | tail -n 1
+}
+validate_hardware_directory() {
+  case "$1" in
+    "$HOME/Blacknode/devices/"*/hardware|\\
+    "$HOME/blacknode-hardware"|\\
+    "$HOME/blacknode-hardware-instances/"*) return 0 ;;
+    *) echo "Refusing to delete an unrecognized Robot Hardware directory: $1" >&2; return 1 ;;
+  esac
+}
+mapfile -t candidate_hardware_units < <(list_hardware_units)
+hardware_units=()
+declare -A hardware_directories=()
+if [[ "$stack_mode" == "isolated" ]]; then
+  validate_hardware_directory "$hardware_dir"
+  hardware_directories["$hardware_dir"]=1
+  for unit in "${candidate_hardware_units[@]}"; do
+    [[ "$unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\\.service$ ]] \\
+      || continue
+    directory="$(hardware_unit_directory "$unit")"
+    [[ "$directory" == "$hardware_dir" ]] || continue
+    hardware_units+=("$unit")
+  done
+else
+  if [[ "${#selected_hardware_ports[@]}" -gt 0 && -d "$hardware_dir" ]]; then
+    validate_hardware_directory "$hardware_dir"
+    hardware_directories["$hardware_dir"]=1
+  fi
+  for selected_hardware_port in "${selected_hardware_ports[@]}"; do
+    matches=()
+    for unit in "${candidate_hardware_units[@]}"; do
+      [[ "$unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\\.service$ ]] \\
+        || continue
+      [[ "$(hardware_unit_port "$unit")" == "$selected_hardware_port" ]] || continue
+      matches+=("$unit")
+    done
+    if [[ "${#matches[@]}" -gt 1 ]]; then
+      echo "Multiple Robot Hardware services match port $selected_hardware_port." >&2
+      exit 6
+    fi
+    [[ "${#matches[@]}" -eq 1 ]] || continue
+    unit="${matches[0]}"
+    directory="$(hardware_unit_directory "$unit")"
+    [[ -n "$directory" ]] || {
+      echo "$unit does not report its installation directory." >&2
+      exit 6
+    }
+    validate_hardware_directory "$directory"
+    hardware_units+=("$unit")
+    hardware_directories["$directory"]=1
+  done
+fi
 progress 20 "Stopping Runtime service"
 sudo systemctl stop "$service_name" >/dev/null 2>&1 || true
 sudo systemctl disable "$service_name" >/dev/null 2>&1 || true
 progress 35 "Removing Runtime service"
 sudo rm -f -- "/etc/systemd/system/$service_name"
 sudo systemctl daemon-reload
-if [[ "$stack_mode" == "isolated" ]]; then
-  case "$hardware_dir" in
-    "$HOME/Blacknode/devices/"*/hardware|\
-    "$HOME/blacknode-hardware-instances/"*) ;;
-    *) echo "Unsafe Hardware directory."; exit 2 ;;
-  esac
-  progress 48 "Finding isolated Robot Hardware services"
-  mapfile -t hardware_units < <(
-    {
-      systemctl list-unit-files 'blacknode-hardware*.service' --no-legend 2>/dev/null
-      systemctl list-units --all --type=service 'blacknode-hardware*.service' \
-        --no-legend 2>/dev/null
-    } | awk '{print $1}' | sort -u
-  )
+if [[ "${#hardware_units[@]}" -gt 0 ]]; then
+  progress 48 "Deleting Robot Hardware services"
   for hardware_unit in "${hardware_units[@]}"; do
-    [[ "$hardware_unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\\.service$ ]] \
-      || continue
-    working_directory="$(
-      systemctl show "$hardware_unit" --property=WorkingDirectory --value 2>/dev/null || true
-    )"
-    [[ "$working_directory" == "$hardware_dir" ]] || continue
-    progress 60 "Stopping isolated Robot Hardware services"
     hardware_port="$(
-      systemctl cat "$hardware_unit" 2>/dev/null \
-        | sed -nE 's/.*--port[= ]"?([0-9]+).*/\\1/p' \
-        | tail -n 1
+      hardware_unit_port "$hardware_unit"
     )"
     sudo systemctl stop "$hardware_unit" >/dev/null 2>&1 || true
     sudo systemctl disable "$hardware_unit" >/dev/null 2>&1 || true
-    sudo rm -f -- "/etc/systemd/system/$hardware_unit"
-    if [[ "$hardware_port" =~ ^[0-9]+$ ]] \
-      && command -v ufw >/dev/null 2>&1 \
+    sudo rm -f -- \\
+      "/etc/systemd/system/$hardware_unit" \\
+      "/run/systemd/system/$hardware_unit"
+    if [[ "$hardware_port" =~ ^[0-9]+$ ]] \\
+      && command -v ufw >/dev/null 2>&1 \\
       && sudo ufw status 2>/dev/null | grep -qi '^Status: active'; then
       sudo ufw --force delete allow "$hardware_port/tcp" >/dev/null 2>&1 || true
     fi
   done
-  progress 74 "Removing isolated Robot Hardware files"
   sudo systemctl daemon-reload
-  rm -rf -- "$hardware_dir"
 fi
+progress 70 "Deleting unused Robot Hardware files"
+mapfile -t remaining_hardware_units < <(list_hardware_units)
+for directory in "${!hardware_directories[@]}"; do
+  directory_in_use=false
+  for unit in "${remaining_hardware_units[@]}"; do
+    [[ "$unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\\.service$ ]] \\
+      || continue
+    if [[ "$(hardware_unit_directory "$unit")" == "$directory" ]]; then
+      directory_in_use=true
+      break
+    fi
+  done
+  if [[ "$directory_in_use" == false ]]; then
+    rm -rf -- "$directory"
+  fi
+done
 progress 84 "Removing Runtime files and firewall rule"
 if command -v ufw >/dev/null 2>&1 \
   && sudo ufw status 2>/dev/null | grep -qi '^Status: active'; then
@@ -2469,7 +2566,8 @@ progress 94 "Finalizing deletion"
             connection,
             (
                 f"sudo -S -p '' -v && bash {remote_script_path} "
-                f"{selected_instance} {selected_port} {selected_stack_mode}"
+                f"{selected_instance} {selected_port} {selected_stack_mode} "
+                f"{hardware_ports_payload}"
             ),
             stdin_text=password + "\n",
             timeout=120.0,
@@ -2482,6 +2580,7 @@ progress 94 "Finalizing deletion"
             "runtime_port": selected_port,
             "already_absent": not bool(existing),
             "stack_mode": selected_stack_mode,
+            "hardware_ports": selected_hardware_ports,
         }
     finally:
         try:

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -4708,6 +4708,18 @@ def _uninstall_device_host_payload(
         if str(managed.get("management_mode") or "") == "local":
             result = uninstall_local_runtime(managed, progress=progress)
         else:
+            hardware_ports: set[int] = set()
+            for robot in host.get("robots", []):
+                if not isinstance(robot, dict):
+                    continue
+                try:
+                    hardware_port = urllib.parse.urlsplit(
+                        str(robot.get("base_url") or "")
+                    ).port
+                except ValueError:
+                    continue
+                if hardware_port is not None:
+                    hardware_ports.add(int(hardware_port))
             result = uninstall_runtime(
                 host=str(managed.get("ssh_host") or ""),
                 port=int(managed.get("ssh_port") or 22),
@@ -4717,6 +4729,7 @@ def _uninstall_device_host_payload(
                 instance_id=str(managed.get("instance_id") or "default"),
                 runtime_port=int(managed.get("runtime_port") or 0),
                 stack_mode=str(managed.get("stack_mode") or "runtime_only"),
+                hardware_ports=sorted(hardware_ports),
                 progress=progress,
             )
         report(97, "Removing the saved device registration")
@@ -4732,10 +4745,8 @@ def _uninstall_device_host_payload(
             summary = "Local robot stack deleted"
         else:
             summary = "Local Runtime installation deleted"
-    elif str(managed.get("stack_mode") or "runtime_only") == "isolated":
-        summary = "Isolated robot stack deleted"
     else:
-        summary = "Runtime installation deleted"
+        summary = "Device deleted"
     report(100, summary)
     return {
         "ok": True,

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -1360,7 +1360,7 @@ export default function DevicesPanel() {
           : device.managed_runtime?.owned_install
             ? `Delete and uninstall "${device.name}" from this computer? This stops its Runtime, permanently deletes the editor-created installation folder and attached robot registrations, and removes this device card.`
             : `Uninstall "${device.name}" from this computer? This stops its Runtime, removes its editor-managed configuration and attached robot registrations, preserves the existing source checkout, and removes this device card.`
-        : `Delete and uninstall "${device.name}" from the remote computer? This stops its Runtime and permanently deletes its service, Runtime files, workflow packages, token, firewall rule, attached robot registrations, and this device card.`,
+        : `Delete device "${device.name}" from the remote computer? This stops its Runtime and deployments, then permanently deletes its Runtime files, workflow packages, token, service, firewall rule, attached Robot Hardware services and unused Hardware files, robot registrations, and this device card. System ROS 2, Docker, and other device stacks are preserved.`,
     )) return
     setBusy(true)
     setError(null)
@@ -2929,9 +2929,7 @@ export default function DevicesPanel() {
                         {selectedDeviceManagedLocally
                           && !selectedDevice.managed_runtime?.owned_install
                           ? 'Uninstall local services'
-                          : selectedStackIsIsolated
-                            ? 'Delete robot stack'
-                            : 'Delete Runtime installation'}
+                          : 'Delete device'}
                       </button>
                     </>
                   )}
@@ -4192,12 +4190,12 @@ export default function DevicesPanel() {
                     selectedDeviceManagedLocally
                       && !selectedDevice.managed_runtime?.owned_install
                       ? 'Uninstall this managed '
-                      : 'Delete and uninstall this managed '
+                      : 'Delete this '
                   }
                   {
-                    selectedDeviceManagedLocally || selectedStackIsIsolated
+                    selectedDeviceManagedLocally
                       ? 'robot stack'
-                      : 'runtime'
+                      : 'device'
                   }
                 </strong>
                 <span>
@@ -4205,10 +4203,7 @@ export default function DevicesPanel() {
                     ? selectedDevice.managed_runtime.hardware_dir
                       ? `Stops the local Runtime on port ${selectedDevice.managed_runtime.runtime_port} and Robot Hardware on port ${selectedDevice.managed_runtime.hardware_port}.`
                       : `Stops the local Runtime on port ${selectedDevice.managed_runtime.runtime_port}.`
-                    : `Stops ${selectedDevice.managed_runtime.service_name}, removes ${selectedDevice.managed_runtime.runtime_dir}, its packages, token and port ${selectedDevice.managed_runtime.runtime_port} firewall rule.${selectedDevice.managed_runtime.install_root ? ` The empty ${selectedDevice.managed_runtime.install_root} stack folder is also removed.` : ''}`}
-                  {selectedStackIsIsolated
-                    ? ` Its instance-scoped Robot Hardware services and ${selectedDevice.managed_runtime.hardware_dir} are also removed.`
-                    : ''}
+                    : `Stops ${selectedDevice.managed_runtime.service_name} and its deployments; deletes ${selectedDevice.managed_runtime.runtime_dir}, its workflow packages, token, service and port ${selectedDevice.managed_runtime.runtime_port} firewall rule; and deletes this device's ${selectedDevice.robots.length} Robot Hardware service${selectedDevice.robots.length === 1 ? '' : 's'} plus Hardware files when no other device uses them.${selectedDevice.managed_runtime.install_root ? ` The empty ${selectedDevice.managed_runtime.install_root} stack folder is also removed.` : ''}`}
                   {selectedDeviceManagedLocally
                     ? selectedDevice.managed_runtime.hardware_dir
                       ? selectedDevice.managed_runtime.owned_install
@@ -4218,7 +4213,7 @@ export default function DevicesPanel() {
                       : selectedDevice.managed_runtime.owned_install
                         ? ' The editor-created installation folder is removed.'
                         : ' The existing source checkout is preserved.'
-                    : ' Other stacks on this computer stay untouched.'}
+                    : ' System ROS 2, Docker, and other device stacks on this computer stay untouched.'}
                 </span>
               </div>
               {!selectedDeviceManagedLocally && (
@@ -4255,7 +4250,7 @@ export default function DevicesPanel() {
                     : selectedDeviceManagedLocally
                       && !selectedDevice.managed_runtime?.owned_install
                       ? 'Uninstall services and forget device'
-                      : 'Delete files, uninstall, and forget device'}
+                      : 'Delete device'}
                 </button>
               </div>
             </form>

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -613,19 +613,16 @@ class EditorDeviceApiTests(unittest.TestCase):
                 instance_id="instance-2",
                 runtime_port=8768,
                 stack_mode="isolated",
+                hardware_ports=[8765, 8767],
                 progress=progress.append,
             )
 
         self.assertEqual(result["stack_mode"], "isolated")
         self.assertTrue(any(item["progress"] == 60 for item in progress))
-        self.assertIn(
-            'progress 48 "Finding isolated Robot Hardware services"',
-            uploaded[0],
-        )
-        self.assertIn(
-            'progress 74 "Removing isolated Robot Hardware files"',
-            uploaded[0],
-        )
+        self.assertEqual(result["hardware_ports"], [8765, 8767])
+        self.assertIn('progress 48 "Deleting Robot Hardware services"', uploaded[0])
+        self.assertIn('progress 70 "Deleting unused Robot Hardware files"', uploaded[0])
+        self.assertIn('Refusing to delete an unrecognized Robot Hardware directory', uploaded[0])
         self.assertNotIn("ssh-password", uploaded[0])
 
     def test_robot_service_restart_resolves_exact_systemd_unit_by_port(self):
@@ -2042,6 +2039,17 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "instance_id": "instance-2",
             })
         host_id = installed.json()["device"]["id"]
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            attached = self.client.post(
+                f"/device-hosts/{host_id}/robots",
+                json={
+                    "name": "Follower",
+                    "base_url": "http://192.168.1.87:8765",
+                    "token": hardware.token,
+                },
+            )
+        self.assertEqual(attached.status_code, 200)
         with patch.object(server, "uninstall_runtime", return_value={
             "ok": True,
             "instance_id": "instance-2",
@@ -2065,6 +2073,7 @@ class EditorDeviceApiTests(unittest.TestCase):
             instance_id="instance-2",
             runtime_port=8767,
             stack_mode="runtime_only",
+            hardware_ports=[8765],
             progress=None,
         )
 
@@ -2119,10 +2128,10 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(progress[-1], {
             "type": "progress",
             "progress": 100,
-            "message": "Isolated robot stack deleted",
+            "message": "Device deleted",
         })
         self.assertEqual(events[-1]["type"], "done")
-        self.assertEqual(events[-1]["result"]["summary"], "Isolated robot stack deleted")
+        self.assertEqual(events[-1]["result"]["summary"], "Device deleted")
         self.assertEqual(self.client.get("/device-hosts").json()["devices"], [])
 
     def test_device_can_be_renamed_without_repairing_or_exposing_tokens(self):


### PR DESCRIPTION
## What changed

- Added a single **Delete device** action for remotely managed devices.
- Deletes the selected Runtime service, deployment processes, checkout, installed workflow packages, secret, and firewall rule.
- Deletes the exact attached Robot Hardware services and their firewall rules.
- Removes Hardware files only when no remaining Hardware service uses that checkout.
- Removes robot registrations and the device card after remote cleanup succeeds.
- Preserves system ROS 2, Docker, operating-system packages, and other Blacknode device stacks.

## Why

The previous uninstall action removed Runtime but could leave attached Hardware services and files behind, so deleting a device did not match the user's expectation of removing the complete managed installation.

## Validation

- `python -m unittest discover -s tests` — 463 passed, 8 skipped
- `npm run build` in `editor/`
- Generated remote uninstall script validated with `bash -n`
- `git diff --check`