### PR TITLE
Fix remote installation manifest

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -1040,7 +1040,7 @@ manifest_path.write_text(json.dumps({
     "packages_dir": str(Path(sys.argv[3]) / "packages"),
     "hardware_dir": sys.argv[4] if sys.argv[6] == "isolated_stack" else "",
     "runtime_service": sys.argv[5],
-}, indent=2) + "\n", encoding="utf-8")
+}, indent=2) + "\\n", encoding="utf-8")
 PY
 install_complete=true
 progress 96 "Verifying the runtime service"

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -4,6 +4,7 @@ import base64
 import io
 import json
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -495,6 +496,25 @@ class EditorDeviceApiTests(unittest.TestCase):
             'legacy_side_root = home / "blacknode-runtimes"',
             device_installer._INSPECTION_SCRIPT,
         )
+
+    def test_remote_install_embedded_python_blocks_compile(self):
+        script = next(
+            value
+            for value in device_installer.install_runtime.__code__.co_consts
+            if (
+                isinstance(value, str)
+                and value.startswith("#!/usr/bin/env bash")
+                and "__BLACKNODE_INSTALL_PROGRESS__" in value
+            )
+        )
+        python_blocks = re.findall(
+            r"(?ms)^[^\n]*<<'PY'(?:\s*&)?\n(.*?)^PY$",
+            script,
+        )
+
+        self.assertEqual(len(python_blocks), 3)
+        for index, python_block in enumerate(python_blocks, start=1):
+            compile(python_block, f"<remote-install-python-{index}>", "exec")
 
     def test_reinstall_of_incomplete_instance_uses_next_available_port(self):
         class RemoteFile(io.StringIO):


### PR DESCRIPTION
## What changed

- Escaped the newline written by the generated remote installation manifest block.
- Added a regression test that extracts and compiles every embedded Python heredoc in the remote installer.

## Root cause

The installer Bash script is generated from a Python string. The manifest block used `"\n"`, which the outer string converted into a literal line break inside the generated Python quoted string. Runtime setup completed, but manifest creation then failed with an unterminated string literal and invoked incomplete-install cleanup.

## Impact

Remote Runtime installation can now finish and record its organized `~/Blacknode/devices/<instance>/install.json` manifest.

## Validation

- Project virtual environment: 464 tests passed, 8 skipped
- Device API suite: 95 tests passed
- Exact generated installer validated with `bash -n`
- All generated installer Python heredocs compile
- `git diff --check`