### PR TITLE
Attach installed robots securely

### DIFF
--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -119,8 +119,12 @@ device identity as the existing pairing, and then enables device lifecycle and
 robot-service restart actions. The SSH password is used for that request and is
 not saved.
 
-Open the new square device card and choose **Add robot** for each hardware
-service connected to that computer. Enter the robot URL and token printed by
+Open the device card and choose **Attach robot**. On an SSH-managed device,
+**Find and attach robots** discovers installed Robot Hardware services and
+reads their private pairing credentials through the verified SSH connection.
+The token is paired server-side and is never displayed in the browser; the SSH
+password is used for that request and is not saved. Manual pairing remains
+available by entering the robot URL and token printed by
 `blacknode-hardware/pair.sh`. One device may contain several robots; each robot
 remains a distinct deployment target and uses its parent device's shared
 runtime. Pairing and discovery keep physical motion disarmed.

--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -10,6 +10,7 @@ import secrets
 import socket
 import time
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Any, Callable
 
 
@@ -19,6 +20,7 @@ class DeviceInstallError(RuntimeError):
 
 _INSTANCE_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 _INSPECTION_MARKER = "__BLACKNODE_RUNTIME_INSPECTION__="
+_HARDWARE_PAIRING_INSPECTION_MARKER = "__BLACKNODE_HARDWARE_PAIRINGS__="
 _UPDATE_REPORT_MARKER = "__BLACKNODE_UPDATE_REPORT__="
 _INSPECTION_SCRIPT = r"""python3 - <<'PY'
 import glob
@@ -629,6 +631,258 @@ def _read_remote_token(connection: _Connection, instance: dict[str, Any]) -> str
     if len(clean) < 24 or any(character.isspace() for character in clean):
         raise DeviceInstallError("The existing runtime pairing token is invalid.")
     return clean
+
+
+def discover_hardware_pairings(
+    *,
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    host_fingerprint: str,
+    expected_hardware_dir: str = "",
+) -> dict[str, Any]:
+    """Read installed Hardware service credentials over the verified SSH channel."""
+
+    expected = str(host_fingerprint or "").strip()
+    if not expected:
+        raise DeviceInstallError(
+            "Check the SSH connection and confirm its host fingerprint first."
+        )
+    expected_directory_payload = base64.urlsafe_b64encode(
+        json.dumps(str(expected_hardware_dir or "")).encode("utf-8")
+    ).decode("ascii")
+    connection = _connect(
+        host,
+        port,
+        username,
+        password,
+        expected_fingerprint=expected,
+        timeout=15.0,
+    )
+    inspection_command = r"""python3 - __BLACKNODE_EXPECTED_HARDWARE_DIR__ <<'PY'
+import base64
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+
+expected_directory = json.loads(
+    base64.urlsafe_b64decode(sys.argv[1]).decode("utf-8")
+)
+expected_directory = (
+    os.path.abspath(os.path.expanduser(expected_directory))
+    if expected_directory
+    else ""
+)
+
+def command(args):
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=124,
+            stdout="",
+            stderr=str(exc),
+        )
+
+def argument(argv, name):
+    for index, value in enumerate(argv):
+        if value == name and index + 1 < len(argv):
+            return argv[index + 1]
+        if value.startswith(name + "="):
+            return value.split("=", 1)[1]
+    return ""
+
+units = set()
+for args in (
+    ["systemctl", "list-unit-files", "blacknode-hardware*.service", "--no-legend"],
+    [
+        "systemctl", "list-units", "--all", "--type=service",
+        "blacknode-hardware*.service", "--no-legend",
+    ],
+):
+    result = command(args)
+    for line in result.stdout.splitlines():
+        unit = line.split(None, 1)[0] if line.split() else ""
+        if re.fullmatch(
+            r"blacknode-hardware(?:[-.@][A-Za-z0-9_.@-]+)?\.service",
+            unit,
+        ):
+            units.add(unit)
+
+services = []
+for unit in sorted(units):
+    result = command(["systemctl", "cat", unit])
+    if result.returncode != 0:
+        continue
+    working_directory = ""
+    exec_start = ""
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if line.startswith("WorkingDirectory="):
+            working_directory = line.split("=", 1)[1].strip().strip('"')
+        elif line.startswith("ExecStart="):
+            exec_start = line.split("=", 1)[1].strip()
+    if not working_directory or not exec_start:
+        continue
+    working_directory = os.path.abspath(os.path.expanduser(working_directory))
+    if expected_directory and working_directory != expected_directory:
+        continue
+    try:
+        argv = shlex.split(exec_start)
+    except ValueError:
+        continue
+    service_port = argument(argv, "--port")
+    config_path = argument(argv, "--config")
+    token_path = argument(argv, "--auth-token-file")
+    if not service_port.isdigit() or not config_path or not token_path:
+        continue
+    services.append({
+        "service_name": unit,
+        "working_directory": working_directory,
+        "port": int(service_port),
+        "config_path": os.path.abspath(os.path.expanduser(config_path)),
+        "token_path": os.path.abspath(os.path.expanduser(token_path)),
+        "active": command(["systemctl", "is-active", "--quiet", unit]).returncode == 0,
+    })
+
+print("__BLACKNODE_HARDWARE_PAIRINGS__=" + json.dumps(
+    {"services": services},
+    separators=(",", ":"),
+))
+PY"""
+    inspection_command = inspection_command.replace(
+        "__BLACKNODE_EXPECTED_HARDWARE_DIR__",
+        expected_directory_payload,
+        1,
+    )
+    try:
+        output = _run(connection, inspection_command, timeout=45.0)
+        marker_line = next(
+            (
+                line[len(_HARDWARE_PAIRING_INSPECTION_MARKER):]
+                for line in output.splitlines()
+                if line.startswith(_HARDWARE_PAIRING_INSPECTION_MARKER)
+            ),
+            "",
+        )
+        if not marker_line:
+            raise DeviceInstallError(
+                "The device did not return its installed Robot Hardware services."
+            )
+        try:
+            inspection = json.loads(marker_line)
+        except json.JSONDecodeError as exc:
+            raise DeviceInstallError(
+                "The device returned invalid Robot Hardware service information."
+            ) from exc
+        services = [
+            item
+            for item in inspection.get("services", [])
+            if isinstance(item, dict)
+        ]
+        pairings: list[dict[str, Any]] = []
+        errors: list[str] = []
+        sftp = connection.client.open_sftp()
+        try:
+            def read_remote_text(path: PurePosixPath, limit: int) -> str:
+                with sftp.file(str(path), "r") as remote_file:
+                    value = remote_file.read(limit + 1)
+                if isinstance(value, bytes):
+                    value = value.decode("utf-8", errors="strict")
+                text = str(value)
+                if len(text.encode("utf-8")) > limit:
+                    raise ValueError("file is larger than the allowed limit")
+                return text
+
+            for service in services:
+                unit = str(service.get("service_name") or "Robot Hardware service")
+                try:
+                    service_port = int(service.get("port") or 0)
+                    working_directory = PurePosixPath(
+                        str(service.get("working_directory") or "")
+                    )
+                    config_path = PurePosixPath(
+                        str(service.get("config_path") or "")
+                    )
+                    token_path = PurePosixPath(
+                        str(service.get("token_path") or "")
+                    )
+                    if (
+                        not working_directory.is_absolute()
+                        or not config_path.is_absolute()
+                        or not token_path.is_absolute()
+                        or not 1 <= service_port <= 65535
+                    ):
+                        raise ValueError("service paths or port are invalid")
+                    private_directory = working_directory / ".blacknode-hardware"
+                    config_path.relative_to(private_directory)
+                    token_path.relative_to(private_directory)
+                    if token_path.name != "auth.token":
+                        raise ValueError("pairing token path is not an auth.token file")
+                    manifest = read_remote_text(
+                        working_directory / "pyproject.toml",
+                        256 * 1024,
+                    )
+                    if not re.search(
+                        r'(?m)^\s*name\s*=\s*["\']blacknode-hardware["\']\s*$',
+                        manifest,
+                    ):
+                        raise ValueError(
+                            "service directory is not a Blacknode Hardware checkout"
+                        )
+                    config = json.loads(read_remote_text(config_path, 256 * 1024))
+                    if not isinstance(config, dict):
+                        raise ValueError("robot configuration is not an object")
+                    token = read_remote_text(token_path, 4096).strip()
+                    if len(token) < 32 or any(
+                        character.isspace() for character in token
+                    ):
+                        raise ValueError("pairing token is invalid")
+                    pairings.append({
+                        "service_name": unit,
+                        "port": service_port,
+                        "name": str(
+                            config.get("name")
+                            or config.get("device_id")
+                            or unit
+                        ).strip(),
+                        "device_id": str(config.get("device_id") or "").strip(),
+                        "token": token,
+                        "active": bool(service.get("active")),
+                    })
+                except (
+                    OSError,
+                    UnicodeDecodeError,
+                    ValueError,
+                    json.JSONDecodeError,
+                ) as exc:
+                    errors.append(f"{unit}: {exc}")
+        finally:
+            sftp.close()
+        return {
+            "pairings": pairings,
+            "errors": errors,
+            "discovered": len(services),
+        }
+    except DeviceInstallError:
+        raise
+    except Exception as exc:
+        raise DeviceInstallError(
+            "Could not read installed Robot Hardware pairing credentials."
+        ) from exc
+    finally:
+        connection.close()
 
 
 def inspect_runtime(

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -56,6 +56,7 @@ from blacknode.workflow import validate_workflow as validate_bn_workflow
 from device_installer import (
     control_runtime,
     DeviceInstallError,
+    discover_hardware_pairings,
     inspect_managed_service_updates,
     inspect_runtime,
     install_runtime,
@@ -459,6 +460,9 @@ class ConfigureDeviceHostManagementReq(InspectDeviceHostReq):
     pass
 
 class UninstallDeviceHostReq(BaseModel):
+    password: str
+
+class DiscoverHostRobotsReq(BaseModel):
     password: str
 
 class RuntimeLifecycleReq(BaseModel):
@@ -4788,6 +4792,125 @@ def pair_host_robot(host_id: str, req: PairHostRobotReq):
         "robot": device,
         "status": status,
         "runtime": _device_host_runtime_status(host_id),
+    }
+
+
+@app.post("/device-hosts/{host_id}/robots/discover")
+def discover_and_pair_host_robots(host_id: str, req: DiscoverHostRobotsReq):
+    try:
+        host = _device_registry.get_host_public(host_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    if host is None:
+        raise HTTPException(404, "Device not found")
+    managed = host.get("managed_runtime")
+    if not isinstance(managed, dict):
+        raise HTTPException(
+            409,
+            "Enable verified SSH controls before finding installed robots.",
+        )
+    if str(managed.get("management_mode") or "") == "local":
+        raise HTTPException(
+            409,
+            "Use the local Hardware package controls for this computer.",
+        )
+    if not str(req.password or ""):
+        raise HTTPException(
+            400,
+            "Enter the device SSH password to find installed robots.",
+        )
+    try:
+        discovered = discover_hardware_pairings(
+            host=str(managed.get("ssh_host") or ""),
+            port=int(managed.get("ssh_port") or 22),
+            username=str(managed.get("ssh_username") or ""),
+            password=req.password,
+            host_fingerprint=str(managed.get("host_fingerprint") or ""),
+            expected_hardware_dir=str(managed.get("hardware_dir") or ""),
+        )
+    except DeviceInstallError as exc:
+        raise HTTPException(400, str(exc)) from exc
+
+    runtime_url = urllib.parse.urlsplit(str(host.get("runtime_url") or ""))
+    runtime_hostname = str(runtime_url.hostname or "")
+    if not runtime_hostname:
+        raise HTTPException(409, "The paired Runtime URL has no hostname.")
+    service_host = (
+        f"[{runtime_hostname}]" if ":" in runtime_hostname else runtime_hostname
+    )
+    scheme = runtime_url.scheme or "http"
+    attached: list[dict[str, Any]] = []
+    statuses: dict[str, dict[str, Any]] = {}
+    errors = [
+        str(value)
+        for value in discovered.get("errors", [])
+        if str(value).strip()
+    ]
+    for pairing in discovered.get("pairings", []):
+        if not isinstance(pairing, dict):
+            continue
+        service_name = str(
+            pairing.get("service_name") or "Robot Hardware service"
+        )
+        if not pairing.get("active"):
+            errors.append(
+                f"{service_name}: service is installed but not running."
+            )
+            continue
+        try:
+            service_port = int(pairing.get("port") or 0)
+            client = HardwareDeviceClient(
+                f"{scheme}://{service_host}:{service_port}",
+                str(pairing.get("token") or ""),
+            )
+            status = client.validate_pairing()
+            configured_device_id = str(pairing.get("device_id") or "")
+            actual_device_id = str(status.get("device_id") or "")
+            if configured_device_id and actual_device_id != configured_device_id:
+                raise DeviceRegistryError(
+                    f"returned robot '{actual_device_id}', expected "
+                    f"'{configured_device_id}' from its saved configuration"
+                )
+            robot = _device_registry.pair(
+                name=str(pairing.get("name") or ""),
+                base_url=client.base_url,
+                token=str(pairing.get("token") or ""),
+                host_id=host_id,
+                status=status,
+            )
+            attached.append(robot)
+            statuses[str(robot["id"])] = status
+        except (DeviceRegistryError, ValueError) as exc:
+            errors.append(f"{service_name}: {exc}")
+
+    if not attached:
+        if int(discovered.get("discovered") or 0) == 0:
+            detail = (
+                "No installed Robot Hardware services were found in this device "
+                "stack. Connect and configure the robot, install its Hardware "
+                "service, then press Find and attach robots again."
+            )
+        else:
+            detail = (
+                "Installed Robot Hardware services were found, but none could be "
+                "paired. " + " ".join(errors)
+            )
+        raise HTTPException(409, detail)
+    summary = (
+        f"Attached {len(attached)} installed robot"
+        f"{'s' if len(attached) != 1 else ''} securely over verified SSH."
+    )
+    if errors:
+        summary += (
+            f" {len(errors)} service"
+            f"{'s' if len(errors) != 1 else ''} need attention."
+        )
+    return {
+        "ok": True,
+        "robots": attached,
+        "statuses": statuses,
+        "errors": errors,
+        "summary": summary,
     }
 
 

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1314,6 +1314,19 @@ export const api = {
       { name, base_url: baseUrl, token },
       10000,
     ),
+  discoverAndPairRobots: (hostId: string, password: string) =>
+    req<{
+      ok: boolean
+      robots: HardwareDevice[]
+      statuses: Record<string, HardwareDeviceStatus>
+      errors: string[]
+      summary: string
+    }>(
+      'POST',
+      `/device-hosts/${encodeURIComponent(hostId)}/robots/discover`,
+      { password },
+      60000,
+    ),
   renameComputeDevice: (id: string, name: string) =>
     req<{ device: ComputeDevice }>(
       'PATCH',

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -522,6 +522,7 @@ export default function DevicesPanel() {
   const [robotName, setRobotName] = useState('')
   const [robotUrl, setRobotUrl] = useState('')
   const [robotToken, setRobotToken] = useState('')
+  const [robotDiscoveryPassword, setRobotDiscoveryPassword] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [linkedProjectName, setLinkedProjectName] = useState('')
@@ -1251,8 +1252,95 @@ export default function DevicesPanel() {
     setRobotName('')
     setRobotUrl(suggestedHardwareUrl(device))
     setRobotToken('')
+    setRobotDiscoveryPassword('')
     setError(null)
     setShowRobotForm(true)
+  }
+
+  const discoverAndAttachRobots = async () => {
+    if (!selectedDevice) return
+    if (!robotDiscoveryPassword) {
+      setError('Enter the device SSH password to find installed robots.')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    setActionProgress(previous => ({
+      ...previous,
+      [selectedDevice.id]: {
+        progress: 10,
+        message: 'Finding installed Robot Hardware services over verified SSH',
+      },
+    }))
+    try {
+      const result = await api.discoverAndPairRobots(
+        selectedDevice.id,
+        robotDiscoveryPassword,
+      )
+      setRobotDiscoveryPassword('')
+      setShowRobotForm(false)
+      setRobotToken('')
+      setRobotStates(previous => {
+        const next = { ...previous }
+        result.robots.forEach(robot => {
+          next[robot.id] = {
+            status: result.statuses[robot.id],
+            loading: false,
+            checkedAt: Date.now(),
+          }
+        })
+        return next
+      })
+      setActionProgress(previous => ({
+        ...previous,
+        [selectedDevice.id]: {
+          progress: 100,
+          message: result.errors.length
+            ? `${result.summary} ${result.errors.join(' ')}`
+            : result.summary,
+        },
+      }))
+      await refresh()
+      if (activeProject) {
+        const discoveredIds = result.robots.map(robot => robot.id)
+        const nextDeviceIds = Array.from(new Set([
+          ...activeProject.deviceIds,
+          ...discoveredIds,
+        ]))
+        if (nextDeviceIds.length !== activeProject.deviceIds.length) {
+          try {
+            const project = await api.updateProject(activeProject.id, {
+              device_ids: nextDeviceIds,
+            })
+            setActiveProject({
+              id: project.id,
+              name: project.name,
+              workflowSlugs: project.workflow_slugs,
+              deviceIds: project.device_ids,
+            })
+            setLinkedProjectName(project.name)
+          } catch (projectError) {
+            setError(
+              `The robots were attached, but they could not be linked to “${activeProject.name}”: ${
+                projectError instanceof Error ? projectError.message : String(projectError)
+              }`,
+            )
+          }
+        }
+      }
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [selectedDevice.id]: {
+          progress: 0,
+          message: `Robot discovery failed: ${message}`,
+        },
+      }))
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
   }
 
   const addRobot = async (event: FormEvent) => {
@@ -4357,6 +4445,41 @@ export default function DevicesPanel() {
               <div className="bn-device-form-title">
                 Attach existing robot to {selectedDevice.name}
               </div>
+              {selectedDevice.managed_runtime && !selectedDeviceManagedLocally && (
+                <div className="bn-device-local-note" role="note">
+                  <strong>Find installed robots automatically</strong>
+                  <span>
+                    Blacknode reads each installed Hardware service URL and pairing
+                    token through this device’s verified SSH connection. Tokens remain
+                    hidden and the SSH password is never saved.
+                  </span>
+                  <label>
+                    <span>Device SSH password</span>
+                    <input
+                      type="password"
+                      value={robotDiscoveryPassword}
+                      onChange={event => setRobotDiscoveryPassword(event.target.value)}
+                      placeholder={`Password for ${
+                        selectedDevice.managed_runtime.ssh_username || 'SSH user'
+                      }`}
+                      autoComplete="current-password"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    className="bn-device-action-button is-primary"
+                    disabled={busy || !robotDiscoveryPassword}
+                    onClick={() => void discoverAndAttachRobots()}
+                  >
+                    {busy ? 'Finding robots…' : 'Find and attach robots'}
+                  </button>
+                </div>
+              )}
+              {selectedDevice.managed_runtime && !selectedDeviceManagedLocally && (
+                <div className="bn-device-help">
+                  Or enter one Hardware service manually below.
+                </div>
+              )}
               <label>
                 <span>Robot name</span>
                 <input
@@ -4403,6 +4526,7 @@ export default function DevicesPanel() {
                   onClick={() => {
                     setShowRobotForm(false)
                     setRobotToken('')
+                    setRobotDiscoveryPassword('')
                   }}
                   style={miniButton}
                 >

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -516,6 +516,93 @@ class EditorDeviceApiTests(unittest.TestCase):
         for index, python_block in enumerate(python_blocks, start=1):
             compile(python_block, f"<remote-install-python-{index}>", "exec")
 
+    def test_hardware_pairing_discovery_reads_only_verified_service_files(self):
+        token = "hardware-pairing-token-1234567890"
+        files = {
+            "/home/alex/Blacknode/devices/default/hardware/pyproject.toml": (
+                '[project]\nname = "blacknode-hardware"\nversion = "0.1.2"\n'
+            ),
+            (
+                "/home/alex/Blacknode/devices/default/hardware/"
+                ".blacknode-hardware/devices/follower/device.json"
+            ): json.dumps({
+                "name": "Follower arm",
+                "device_id": "follower-device",
+            }),
+            (
+                "/home/alex/Blacknode/devices/default/hardware/"
+                ".blacknode-hardware/devices/follower/auth.token"
+            ): token,
+        }
+
+        class Sftp:
+            def file(self, path, _mode):
+                return io.StringIO(files[path])
+
+            def close(self):
+                return None
+
+        connection = SimpleNamespace(
+            client=SimpleNamespace(open_sftp=lambda: Sftp()),
+            fingerprint="SHA256:trusted-device-key",
+            close=lambda: None,
+        )
+        commands = []
+
+        def fake_run(_connection, command, **_kwargs):
+            commands.append(command)
+            return (
+                "__BLACKNODE_HARDWARE_PAIRINGS__="
+                + json.dumps({
+                    "services": [{
+                        "service_name": "blacknode-hardware-follower.service",
+                        "working_directory": (
+                            "/home/alex/Blacknode/devices/default/hardware"
+                        ),
+                        "port": 8765,
+                        "config_path": (
+                            "/home/alex/Blacknode/devices/default/hardware/"
+                            ".blacknode-hardware/devices/follower/device.json"
+                        ),
+                        "token_path": (
+                            "/home/alex/Blacknode/devices/default/hardware/"
+                            ".blacknode-hardware/devices/follower/auth.token"
+                        ),
+                        "active": True,
+                    }],
+                })
+            )
+
+        with (
+            patch.object(device_installer, "_connect", return_value=connection),
+            patch.object(device_installer, "_run", side_effect=fake_run),
+        ):
+            result = device_installer.discover_hardware_pairings(
+                host="192.168.1.87",
+                port=22,
+                username="alex",
+                password="ssh-password",
+                host_fingerprint="SHA256:trusted-device-key",
+                expected_hardware_dir=(
+                    "~/Blacknode/devices/default/hardware"
+                ),
+            )
+
+        self.assertEqual(result["discovered"], 1)
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(result["pairings"], [{
+            "service_name": "blacknode-hardware-follower.service",
+            "port": 8765,
+            "name": "Follower arm",
+            "device_id": "follower-device",
+            "token": token,
+            "active": True,
+        }])
+        self.assertNotIn(token, commands[0])
+        self.assertIn("systemctl\", \"cat\"", commands[0])
+        remote_python = commands[0].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+        compile(remote_python, "<hardware-pairing-discovery>", "exec")
+
     def test_reinstall_of_incomplete_instance_uses_next_available_port(self):
         class RemoteFile(io.StringIO):
             def __enter__(self):
@@ -942,6 +1029,88 @@ class EditorDeviceApiTests(unittest.TestCase):
         )
         self.assertIsNone(hardware.requests[0][2])
         self.assertEqual(hardware.requests[1][2], f"Bearer {hardware.token}")
+
+    def test_managed_device_can_discover_and_pair_hardware_without_exposing_token(self):
+        runtime_token = "runtime-pairing-token-1234567890"
+        hardware_token = "hardware-pairing-token-1234567890"
+        host = server._device_registry.pair_host(
+            name="alex-desktop",
+            runtime_url="http://192.168.1.87:8766",
+            runtime_token=runtime_token,
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "alex-desktop",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.1.87",
+                "ssh_port": 22,
+                "ssh_username": "alex",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "default",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime.service",
+                "install_root": "~/Blacknode/devices/default",
+                "runtime_dir": "~/Blacknode/devices/default/runtime",
+                "packages_dir": "~/Blacknode/devices/default/runtime/packages",
+                "stack_mode": "isolated",
+                "hardware_dir": "~/Blacknode/devices/default/hardware",
+            },
+        )
+        hardware = _HardwareService(
+            hardware_token,
+            status_overrides={"device_id": "follower-device"},
+        )
+        discovery = {
+            "discovered": 1,
+            "errors": [],
+            "pairings": [{
+                "service_name": "blacknode-hardware-follower.service",
+                "port": 8765,
+                "name": "Follower arm",
+                "device_id": "follower-device",
+                "token": hardware_token,
+                "active": True,
+            }],
+        }
+
+        with (
+            patch.object(
+                server,
+                "discover_hardware_pairings",
+                return_value=discovery,
+            ) as discover,
+            patch(
+                "device_registry.urllib.request.urlopen",
+                side_effect=hardware,
+            ),
+        ):
+            response = self.client.post(
+                f"/device-hosts/{host['id']}/robots/discover",
+                json={"password": "ssh-password"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["robots"][0]["name"], "Follower arm")
+        self.assertEqual(
+            response.json()["robots"][0]["base_url"],
+            "http://192.168.1.87:8765",
+        )
+        self.assertNotIn(hardware_token, response.text)
+        self.assertNotIn("ssh-password", response.text)
+        discover.assert_called_once_with(
+            host="192.168.1.87",
+            port=22,
+            username="alex",
+            password="ssh-password",
+            host_fingerprint="SHA256:trusted-device-key",
+            expected_hardware_dir="~/Blacknode/devices/default/hardware",
+        )
+        saved = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            saved["devices"]["follower-device"]["token"],
+            hardware_token,
+        )
 
     def test_pairing_stores_and_checks_a_separate_runtime_token(self):
         hardware = _HardwareService("hardware-token")


### PR DESCRIPTION
## What changed

- Added **Attach robot → Find and attach robots** for SSH-managed devices.
- Discovers installed `blacknode-hardware` systemd services and their authoritative ports/configuration paths.
- Reads each private pairing token through the already verified SSH/SFTP channel and pairs server-side.
- Validates the live Hardware service and stable robot identity before saving the pairing.
- Keeps the SSH password ephemeral and never returns pairing tokens to the browser or command output.
- Retains manual URL/token pairing as a fallback.
- Links automatically discovered robots to the active Project.

## Why

Attaching a managed robot previously required opening a terminal, running `pair.sh`, and manually copying a token even though Blacknode already had a verified SSH relationship with the device.

## Safety

Discovery reads only `auth.token` and device configuration files located under the private directory of a recognized Blacknode Hardware checkout referenced by an installed Hardware systemd unit. Robot motion remains disarmed.

## Validation

- Project virtual environment: 466 tests passed, 8 skipped
- Device API suite: 97 tests passed
- Editor production build passed
- Generated remote discovery Python compiles
- API tests verify Hardware tokens and SSH passwords are absent from responses
- `git diff --check`