### PR TITLE
Install managed Hardware by default

### DIFF
--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -71,9 +71,10 @@ disarmed.
 For remote SSH setup, choose **Add device → Remote SSH** and enter the
 computer's IP address, username, and password. Blacknode first displays the
 SSH host-key fingerprint for confirmation. After confirmation it installs the
-runtime service, configures runtime port `8766` in UFW when UFW is active, and
-pairs the runtime with the editor. The SSH password remains in memory for that
-setup request and is not saved.
+Runtime and Robot Hardware packages, configures runtime port `8766` in UFW when
+UFW is active, and pairs the Runtime with the editor. The Hardware environment
+is ready for connected-robot configuration and starts with motion disarmed. The
+SSH password remains in memory for that setup request and is not saved.
 
 Managed Linux installations use one visible root per stable Runtime instance:
 
@@ -93,6 +94,10 @@ and uninstall precisely. Multiple robots attached to the same Runtime share its
 instance directory. Device display-name changes do not rename these paths.
 Legacy `~/blacknode-runtime`, `~/blacknode-runtimes`, and Hardware checkout
 locations remain discoverable and manageable.
+
+A Runtime-only managed device created by an older editor can add the organized
+Hardware checkout in place from **Attach robot → Install Hardware package**.
+This preserves the Runtime pairing and does not require deleting the device.
 
 **Delete device** stops the selected Runtime and its deployments, removes its
 Runtime checkout, synchronized workflow packages, secret, systemd service, and

--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -861,6 +861,12 @@ PY"""
                         "token": token,
                         "active": bool(service.get("active")),
                     })
+                except FileNotFoundError:
+                    errors.append(
+                        f"{unit}: its saved Hardware package, configuration, or "
+                        "pairing token is missing. Reinstall the Hardware package "
+                        "and configure this robot again."
+                    )
                 except (
                     OSError,
                     UnicodeDecodeError,
@@ -882,6 +888,179 @@ PY"""
             "Could not read installed Robot Hardware pairing credentials."
         ) from exc
     finally:
+        connection.close()
+
+
+def install_hardware_environment(
+    *,
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    host_fingerprint: str,
+    instance_id: str,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Install the managed Hardware package beside an existing Runtime."""
+
+    def report(percent: int, message: str) -> None:
+        if progress is not None:
+            progress({
+                "progress": max(0, min(100, int(percent))),
+                "message": str(message),
+            })
+
+    selected_instance = _clean_instance_id(instance_id or "default")
+    expected = str(host_fingerprint or "").strip()
+    if not expected:
+        raise DeviceInstallError(
+            "Check the SSH connection and confirm its host fingerprint first."
+        )
+    report(5, "Connecting to the verified device")
+    connection = _connect(
+        host,
+        port,
+        username,
+        password,
+        expected_fingerprint=expected,
+        timeout=15.0,
+    )
+    script = r"""#!/usr/bin/env bash
+set -euo pipefail
+progress() {
+  echo "__BLACKNODE_HARDWARE_INSTALL_PROGRESS__=$1|$2"
+}
+sudo() {
+  command sudo -S -p '' "$@"
+}
+export -f sudo
+instance="$1"
+[[ "$instance" == "default" || "$instance" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || {
+  echo "Invalid Blacknode runtime instance."
+  exit 2
+}
+stack_root="$HOME/Blacknode/devices/$instance"
+runtime_dir="$stack_root/runtime"
+hardware_dir="$stack_root/hardware"
+service_instance=""
+[[ "$instance" == "default" ]] || service_instance="$instance"
+case "$hardware_dir" in
+  "$HOME/Blacknode/devices/"*/hardware) ;;
+  *) echo "Unsafe Hardware directory."; exit 2 ;;
+esac
+[[ -d "$runtime_dir/.git" && -f "$runtime_dir/pyproject.toml" ]] || {
+  echo "The organized Runtime installation is missing: $runtime_dir"
+  exit 3
+}
+created=false
+cleanup_failed_install() {
+  exit_code=$?
+  if [[ "$exit_code" -ne 0 && "$created" == true ]]; then
+    progress 0 "Cleaning the incomplete Hardware package"
+    rm -rf -- "$hardware_dir"
+  fi
+  exit "$exit_code"
+}
+trap cleanup_failed_install EXIT
+if [[ -e "$hardware_dir" ]]; then
+  [[ -d "$hardware_dir/.git" && -f "$hardware_dir/pyproject.toml" ]] || {
+    echo "The existing Hardware directory is not a valid package checkout:"
+    echo "  $hardware_dir"
+    exit 4
+  }
+  origin="$(git -C "$hardware_dir" remote get-url origin 2>/dev/null || true)"
+  [[ "$origin" =~ (github\.com[:/])temiroff/blacknode-hardware(\.git)?$ ]] || {
+    echo "The existing Hardware checkout has an unrecognized Git origin."
+    exit 4
+  }
+  progress 25 "Using the existing Robot Hardware package"
+else
+  progress 20 "Downloading the Robot Hardware package"
+  mkdir -p "$(dirname -- "$hardware_dir")"
+  git clone https://github.com/temiroff/blacknode-hardware.git "$hardware_dir"
+  created=true
+fi
+if ! grep -q 'BLACKNODE_HARDWARE_INSTANCE' "$hardware_dir/install-service.sh" \
+  || ! grep -q 'previous_working_directory' "$hardware_dir/install-service.sh"; then
+  echo "The downloaded Blacknode Hardware release does not support managed stacks yet."
+  exit 4
+fi
+progress 50 "Setting up the Robot Hardware environment"
+(
+  cd "$hardware_dir"
+  BLACKNODE_HARDWARE_INSTANCE="$service_instance" ./setup_ubuntu.sh
+)
+progress 88 "Recording the complete device stack"
+python3 - "$stack_root/install.json" "$instance" "$runtime_dir" "$hardware_dir" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+try:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+except (OSError, ValueError):
+    payload = {
+        "layout_version": 1,
+        "instance_id": sys.argv[2],
+        "runtime_dir": sys.argv[3],
+        "packages_dir": str(Path(sys.argv[3]) / "packages"),
+    }
+payload["hardware_dir"] = sys.argv[4]
+manifest_path.parent.mkdir(parents=True, exist_ok=True)
+manifest_path.write_text(
+    json.dumps(payload, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+created=false
+progress 100 "Robot Hardware package installed"
+"""
+    remote_script_path = (
+        f"/tmp/blacknode-hardware-install-{secrets.token_hex(8)}.sh"
+    )
+    try:
+        sftp = connection.client.open_sftp()
+        try:
+            with sftp.file(remote_script_path, "w") as remote_script:
+                remote_script.write(script)
+            sftp.chmod(remote_script_path, 0o700)
+        finally:
+            sftp.close()
+        _run(
+            connection,
+            f"bash {remote_script_path} {selected_instance}",
+            stdin_text=_sudo_input(password, attempts=8),
+            timeout=900.0,
+            on_output=lambda line: (
+                report(int(match.group(1)), match.group(2).strip())
+                if (
+                    match := re.match(
+                        r"^__BLACKNODE_HARDWARE_INSTALL_PROGRESS__="
+                        r"(\d{1,3})\|(.*)$",
+                        line.strip(),
+                    )
+                )
+                else None
+            ),
+        )
+        return {
+            "ok": True,
+            "instance_id": selected_instance,
+            "hardware_dir": (
+                f"~/Blacknode/devices/{selected_instance}/hardware"
+            ),
+            "stack_mode": "isolated",
+        }
+    finally:
+        try:
+            _run(
+                connection,
+                f"rm -f -- {remote_script_path}",
+                timeout=10.0,
+            )
+        except DeviceInstallError:
+            pass
         connection.close()
 
 
@@ -1055,6 +1234,11 @@ stack_root="$HOME/Blacknode/devices/$instance"
 runtime_dir="$stack_root/runtime"
 token_file="$stack_root/secrets/runtime.auth.token"
 hardware_dir="$stack_root/hardware"
+complete_stack=false
+if [[ "$action" == "install" || "$action" == "replace" \
+  || "$action" == "isolated_stack" ]]; then
+  complete_stack=true
+fi
 if [[ "$instance" == "default" ]]; then
   service_name="blacknode-runtime.service"
   service_instance=""
@@ -1116,7 +1300,8 @@ case "$legacy_runtime_dir" in
 esac
 token_dir="$(dirname -- "$token_file")"
 progress 14 "Preparing the selected runtime"
-if [[ "$action" == "isolated_stack" && -e "$hardware_dir" ]]; then
+if [[ "$complete_stack" == true && "$action" != "replace" \
+  && -e "$hardware_dir" ]]; then
   echo "The isolated Hardware directory already exists. Preserve or remove it before retrying:"
   echo "  $hardware_dir"
   exit 3
@@ -1234,8 +1419,8 @@ if [[ -n "$service_instance" ]]; then
   BLACKNODE_RUNTIME_INSTANCE="$service_instance" ./configure.sh \
     --device-id "$(hostname)-$service_instance"
 fi
-if [[ "$action" == "isolated_stack" ]]; then
-  progress 72 "Creating the isolated Robot Hardware environment"
+if [[ "$complete_stack" == true && ! -d "$hardware_dir" ]]; then
+  progress 72 "Installing the Robot Hardware package"
   mkdir -p "$(dirname -- "$hardware_dir")"
   cleanup_hardware=true
   git clone https://github.com/temiroff/blacknode-hardware.git "$hardware_dir"
@@ -1248,6 +1433,12 @@ if [[ "$action" == "isolated_stack" ]]; then
     cd "$hardware_dir"
     BLACKNODE_HARDWARE_INSTANCE="$service_instance" ./setup_ubuntu.sh
   )
+elif [[ "$complete_stack" == true ]]; then
+  [[ -d "$hardware_dir/.git" && -f "$hardware_dir/pyproject.toml" ]] || {
+    echo "The existing Hardware directory is not a valid package checkout:"
+    echo "  $hardware_dir"
+    exit 4
+  }
 fi
 progress 88 "Installing the runtime service"
 kill "$port_guard" >/dev/null 2>&1 || true
@@ -1292,7 +1483,11 @@ manifest_path.write_text(json.dumps({
     "instance_id": sys.argv[2],
     "runtime_dir": sys.argv[3],
     "packages_dir": str(Path(sys.argv[3]) / "packages"),
-    "hardware_dir": sys.argv[4] if sys.argv[6] == "isolated_stack" else "",
+    "hardware_dir": (
+        sys.argv[4]
+        if sys.argv[6] in {"install", "replace", "isolated_stack"}
+        else ""
+    ),
     "runtime_service": sys.argv[5],
 }, indent=2) + "\\n", encoding="utf-8")
 PY
@@ -1358,12 +1553,12 @@ progress 96 "Verifying the runtime service"
             "packages_dir": f"~/Blacknode/devices/{selected_instance}/runtime/packages",
             "stack_mode": (
                 "isolated"
-                if clean_action == "isolated_stack"
+                if clean_action in {"install", "replace", "isolated_stack"}
                 else "runtime_only"
             ),
             "hardware_dir": (
                 f"~/Blacknode/devices/{selected_instance}/hardware"
-                if clean_action == "isolated_stack"
+                if clean_action in {"install", "replace", "isolated_stack"}
                 else ""
             ),
         }

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -59,6 +59,7 @@ from device_installer import (
     discover_hardware_pairings,
     inspect_managed_service_updates,
     inspect_runtime,
+    install_hardware_environment,
     install_runtime,
     probe_device,
     restart_hardware_service,
@@ -4912,6 +4913,81 @@ def discover_and_pair_host_robots(host_id: str, req: DiscoverHostRobotsReq):
         "errors": errors,
         "summary": summary,
     }
+
+
+def _install_device_host_hardware_payload(
+    host_id: str,
+    req: DiscoverHostRobotsReq,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    try:
+        host = _device_registry.get_host_public(host_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    if host is None:
+        raise HTTPException(404, "Device not found")
+    managed = host.get("managed_runtime")
+    if not isinstance(managed, dict):
+        raise HTTPException(
+            409,
+            "Enable verified SSH controls before installing Robot Hardware.",
+        )
+    if str(managed.get("management_mode") or "") == "local":
+        raise HTTPException(
+            409,
+            "Use the local Hardware package controls for this computer.",
+        )
+    if not str(req.password or ""):
+        raise HTTPException(
+            400,
+            "Enter the device SSH password to install Robot Hardware.",
+        )
+    try:
+        installed = install_hardware_environment(
+            host=str(managed.get("ssh_host") or ""),
+            port=int(managed.get("ssh_port") or 22),
+            username=str(managed.get("ssh_username") or ""),
+            password=req.password,
+            host_fingerprint=str(managed.get("host_fingerprint") or ""),
+            instance_id=str(managed.get("instance_id") or "default"),
+            progress=progress,
+        )
+        updated_management = {
+            **managed,
+            "hardware_dir": str(installed["hardware_dir"]),
+            "stack_mode": "isolated",
+        }
+        device = _device_registry.set_host_management(
+            host_id,
+            updated_management,
+        )
+    except DeviceInstallError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    except DeviceRegistryError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    return {
+        "ok": True,
+        "device": device,
+        "install": installed,
+        "summary": (
+            "Robot Hardware package installed. Connect and configure a robot, "
+            "then use Find and attach robots."
+        ),
+    }
+
+
+@app.post("/device-hosts/{host_id}/hardware-package/install-stream")
+def install_device_host_hardware_stream(
+    host_id: str,
+    req: DiscoverHostRobotsReq,
+):
+    return _lifecycle_stream(
+        lambda progress: _install_device_host_hardware_payload(
+            host_id,
+            req,
+            progress,
+        )
+    )
 
 
 @app.patch("/device-hosts/{host_id}")

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1327,6 +1327,25 @@ export const api = {
       { password },
       60000,
     ),
+  installComputeDeviceHardware: (
+    hostId: string,
+    password: string,
+    onProgress: (progress: DeviceActionProgress) => void,
+  ) =>
+    streamDeviceAction<{
+      ok: boolean
+      device: ComputeDevice
+      install: {
+        instance_id: string
+        hardware_dir: string
+        stack_mode: 'isolated'
+      }
+      summary: string
+    }>(
+      `/device-hosts/${encodeURIComponent(hostId)}/hardware-package/install-stream`,
+      { password },
+      onProgress,
+    ),
   renameComputeDevice: (id: string, name: string) =>
     req<{ device: ComputeDevice }>(
       'PATCH',

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -1343,6 +1343,54 @@ export default function DevicesPanel() {
     }
   }
 
+  const installDeviceHardware = async () => {
+    if (!selectedDevice) return
+    if (!robotDiscoveryPassword) {
+      setError('Enter the device SSH password to install Robot Hardware.')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    setActionProgress(previous => ({
+      ...previous,
+      [selectedDevice.id]: {
+        progress: 5,
+        message: 'Preparing the managed Robot Hardware package',
+      },
+    }))
+    try {
+      const result = await api.installComputeDeviceHardware(
+        selectedDevice.id,
+        robotDiscoveryPassword,
+        progress => setActionProgress(previous => ({
+          ...previous,
+          [selectedDevice.id]: progress,
+        })),
+      )
+      setRobotDiscoveryPassword('')
+      setActionProgress(previous => ({
+        ...previous,
+        [selectedDevice.id]: {
+          progress: 100,
+          message: result.summary,
+        },
+      }))
+      await refresh()
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setActionProgress(previous => ({
+        ...previous,
+        [selectedDevice.id]: {
+          progress: 0,
+          message: `Robot Hardware installation failed: ${message}`,
+        },
+      }))
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const addRobot = async (event: FormEvent) => {
     event.preventDefault()
     if (!selectedDevice) return
@@ -2657,8 +2705,11 @@ export default function DevicesPanel() {
                           }}
                         />
                         <span>
-                          <strong>Install Blacknode Runtime</strong>
-                          <small>Creates the default isolated service on port {sshInspection.suggested_port}.</small>
+                          <strong>Install complete robot device</strong>
+                          <small>
+                            Installs Runtime and Robot Hardware in the default managed
+                            stack on port {sshInspection.suggested_port}.
+                          </small>
                         </span>
                       </label>
                     )}
@@ -2682,25 +2733,27 @@ export default function DevicesPanel() {
                         </span>
                       </label>
                     )}
-                    <label className={installAction === 'isolated_stack' ? 'is-selected' : ''}>
-                      <input
-                        type="radio"
-                        name="runtime-install-action"
-                        checked={installAction === 'isolated_stack'}
-                        onChange={() => {
-                          setInstallAction('isolated_stack')
-                          setInstallInstanceId(sshInspection.suggested_instance_id)
-                        }}
-                      />
-                      <span>
-                        <strong>Install a complete isolated robot stack</strong>
-                        <small>
-                          Creates {sshInspection.suggested_instance_id} with separate Runtime
-                          and Robot Hardware directories, environments, tokens, state, services,
-                          and ports. Existing stacks remain untouched.
-                        </small>
-                      </span>
-                    </label>
+                    {sshInspection.instances.length > 0 && (
+                      <label className={installAction === 'isolated_stack' ? 'is-selected' : ''}>
+                        <input
+                          type="radio"
+                          name="runtime-install-action"
+                          checked={installAction === 'isolated_stack'}
+                          onChange={() => {
+                            setInstallAction('isolated_stack')
+                            setInstallInstanceId(sshInspection.suggested_instance_id)
+                          }}
+                        />
+                        <span>
+                          <strong>Install a complete isolated robot stack</strong>
+                          <small>
+                            Creates {sshInspection.suggested_instance_id} with separate Runtime
+                            and Robot Hardware directories, environments, tokens, state, services,
+                            and ports. Existing stacks remain untouched.
+                          </small>
+                        </span>
+                      </label>
+                    )}
                   </div>
                 </div>
               )}
@@ -2832,7 +2885,9 @@ export default function DevicesPanel() {
                           ? 'Reinstall runtime'
                           : installAction === 'isolated_stack'
                             ? 'Install isolated stack'
-                            : 'Install runtime'
+                            : installAction === 'install'
+                              ? 'Install robot device'
+                              : 'Install runtime'
                       : 'Confirm and inspect'
                     : setupMode === 'local' ? 'Add local computer' : 'Pair runtime'}
               </button>
@@ -4447,11 +4502,15 @@ export default function DevicesPanel() {
               </div>
               {selectedDevice.managed_runtime && !selectedDeviceManagedLocally && (
                 <div className="bn-device-local-note" role="note">
-                  <strong>Find installed robots automatically</strong>
+                  <strong>
+                    {selectedDevice.managed_runtime.hardware_dir
+                      ? 'Find installed robots automatically'
+                      : 'Install the Robot Hardware package'}
+                  </strong>
                   <span>
-                    Blacknode reads each installed Hardware service URL and pairing
-                    token through this device’s verified SSH connection. Tokens remain
-                    hidden and the SSH password is never saved.
+                    {selectedDevice.managed_runtime.hardware_dir
+                      ? 'Blacknode reads each installed Hardware service URL and pairing token through this device’s verified SSH connection. Tokens remain hidden and the SSH password is never saved.'
+                      : 'This Runtime-only device is missing its managed Hardware package. Install it beside Runtime before configuring and attaching a physical robot.'}
                   </span>
                   <label>
                     <span>Device SSH password</span>
@@ -4469,9 +4528,19 @@ export default function DevicesPanel() {
                     type="button"
                     className="bn-device-action-button is-primary"
                     disabled={busy || !robotDiscoveryPassword}
-                    onClick={() => void discoverAndAttachRobots()}
+                    onClick={() => (
+                      selectedDevice.managed_runtime?.hardware_dir
+                        ? void discoverAndAttachRobots()
+                        : void installDeviceHardware()
+                    )}
                   >
-                    {busy ? 'Finding robots…' : 'Find and attach robots'}
+                    {busy
+                      ? selectedDevice.managed_runtime.hardware_dir
+                        ? 'Finding robots…'
+                        : 'Installing Hardware…'
+                      : selectedDevice.managed_runtime.hardware_dir
+                        ? 'Find and attach robots'
+                        : 'Install Hardware package'}
                   </button>
                 </div>
               )}

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -479,7 +479,13 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn('stack_root="$HOME/Blacknode/devices/$instance"', script)
         self.assertIn('runtime_dir="$stack_root/runtime"', script)
         self.assertIn('hardware_dir="$stack_root/hardware"', script)
+        self.assertIn('"$action" == "install" || "$action" == "replace"', script)
+        self.assertIn('if [[ "$complete_stack" == true && ! -d "$hardware_dir" ]]', script)
         self.assertIn('"packages_dir": str(Path(sys.argv[3]) / "packages")', script)
+        self.assertIn(
+            'if sys.argv[6] in {"install", "replace", "isolated_stack"}',
+            script,
+        )
         self.assertIn('BLACKNODE_HARDWARE_INSTANCE="$service_instance"', script)
         self.assertIn("does not support isolated stacks yet", script)
         self.assertNotIn("keep_sudo_alive", script)
@@ -602,6 +608,81 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn("systemctl\", \"cat\"", commands[0])
         remote_python = commands[0].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
         compile(remote_python, "<hardware-pairing-discovery>", "exec")
+
+    def test_hardware_environment_can_be_added_to_runtime_only_device(self):
+        uploaded = []
+
+        class RemoteFile(io.StringIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                uploaded.append(self.getvalue())
+                self.close()
+                return False
+
+        class Sftp:
+            def file(self, _path, _mode):
+                return RemoteFile()
+
+            def chmod(self, _path, _mode):
+                return None
+
+            def close(self):
+                return None
+
+        connection = SimpleNamespace(
+            client=SimpleNamespace(open_sftp=lambda: Sftp()),
+            fingerprint="SHA256:trusted-device-key",
+            close=lambda: None,
+        )
+        commands = []
+        stdin_values = []
+        progress = []
+
+        def fake_run(_connection, command, **kwargs):
+            commands.append(command)
+            stdin_values.append(kwargs.get("stdin_text"))
+            if "on_output" in kwargs:
+                kwargs["on_output"](
+                    "__BLACKNODE_HARDWARE_INSTALL_PROGRESS__=50|"
+                    "Setting up the Robot Hardware environment"
+                )
+            return ""
+
+        with (
+            patch.object(device_installer, "_connect", return_value=connection),
+            patch.object(device_installer, "_run", side_effect=fake_run),
+        ):
+            result = device_installer.install_hardware_environment(
+                host="192.168.1.87",
+                port=22,
+                username="alex",
+                password="ssh-password",
+                host_fingerprint="SHA256:trusted-device-key",
+                instance_id="default",
+                progress=progress.append,
+            )
+
+        self.assertEqual(
+            result["hardware_dir"],
+            "~/Blacknode/devices/default/hardware",
+        )
+        self.assertEqual(result["stack_mode"], "isolated")
+        self.assertTrue(any(item["progress"] == 50 for item in progress))
+        self.assertIn("bash /tmp/blacknode-hardware-install-", commands[0])
+        self.assertEqual(stdin_values[0], "ssh-password\n" * 8)
+        self.assertNotIn("ssh-password", uploaded[0])
+        self.assertIn(
+            'hardware_dir="$stack_root/hardware"',
+            uploaded[0],
+        )
+        self.assertIn(
+            'BLACKNODE_HARDWARE_INSTANCE="$service_instance" ./setup_ubuntu.sh',
+            uploaded[0],
+        )
+        remote_python = uploaded[0].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+        compile(remote_python, "<hardware-environment-install>", "exec")
 
     def test_reinstall_of_incomplete_instance_uses_next_available_port(self):
         class RemoteFile(io.StringIO):
@@ -1110,6 +1191,84 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(
             saved["devices"]["follower-device"]["token"],
             hardware_token,
+        )
+
+    def test_runtime_only_device_can_install_managed_hardware_package(self):
+        managed = {
+            "ssh_host": "192.168.1.87",
+            "ssh_port": 22,
+            "ssh_username": "alex",
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "instance_id": "default",
+            "runtime_port": 8766,
+            "service_name": "blacknode-runtime.service",
+            "install_root": "~/Blacknode/devices/default",
+            "runtime_dir": "~/Blacknode/devices/default/runtime",
+            "packages_dir": "~/Blacknode/devices/default/runtime/packages",
+            "stack_mode": "runtime_only",
+            "hardware_dir": "",
+        }
+        host = {
+            "id": "alex-computer",
+            "name": "alex-desktop",
+            "runtime_url": "http://192.168.1.87:8766",
+            "managed_runtime": managed,
+            "robots": [],
+        }
+        installed = {
+            "ok": True,
+            "instance_id": "default",
+            "hardware_dir": "~/Blacknode/devices/default/hardware",
+            "stack_mode": "isolated",
+        }
+        updated_host = {
+            **host,
+            "managed_runtime": {
+                **managed,
+                "hardware_dir": installed["hardware_dir"],
+                "stack_mode": "isolated",
+            },
+        }
+
+        with (
+            patch.object(
+                server._device_registry,
+                "get_host_public",
+                return_value=host,
+            ),
+            patch.object(
+                server,
+                "install_hardware_environment",
+                return_value=installed,
+            ) as install,
+            patch.object(
+                server._device_registry,
+                "set_host_management",
+                return_value=updated_host,
+            ) as save,
+        ):
+            result = server._install_device_host_hardware_payload(
+                host["id"],
+                server.DiscoverHostRobotsReq(password="ssh-password"),
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(
+            result["device"]["managed_runtime"]["hardware_dir"],
+            "~/Blacknode/devices/default/hardware",
+        )
+        install.assert_called_once_with(
+            host="192.168.1.87",
+            port=22,
+            username="alex",
+            password="ssh-password",
+            host_fingerprint="SHA256:trusted-device-key",
+            instance_id="default",
+            progress=None,
+        )
+        self.assertEqual(
+            save.call_args.args[1]["stack_mode"],
+            "isolated",
         )
 
     def test_pairing_stores_and_checks_a_separate_runtime_token(self):


### PR DESCRIPTION
## What changed

- Fresh automatic device setup now installs both Runtime and Robot Hardware in `~/Blacknode/devices/<instance>/`.
- Reinstalling a managed Runtime adds the organized Hardware checkout when it is missing while preserving an existing valid checkout.
- Runtime-only devices created by older editors now show **Attach robot → Install Hardware package** and can upgrade in place.
- Added a streamed verified-SSH Hardware installation endpoint with progress and incomplete-install cleanup.
- The clean-device setup UI now presents one **Install complete robot device** choice instead of separate overlapping Runtime/isolated choices.
- Missing legacy service files now produce an actionable Hardware reinstall/configuration message instead of raw `Errno 2` output.

## Root cause

The prior clean-install default installed only Runtime. Hardware was installed only when the user explicitly selected the isolated-stack option, so a newly created managed device could discover stale legacy Hardware units but had no current Hardware checkout or pairing files.

## Safety

The recovery installs only into the selected managed stack path, validates existing checkout identity, preserves a valid Hardware checkout and robot data, removes only a newly created incomplete checkout on failure, and does not arm motion.

## Validation

- Project virtual environment: 468 tests passed, 8 skipped
- Device API suite: 99 tests passed
- Editor production build passed
- Exact generated Runtime and Hardware installer scripts pass `bash -n`
- Embedded remote Python blocks compile
- `git diff --check`