### PR TITLE
Allow default complete robot stack

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -2776,8 +2776,6 @@ def uninstall_runtime(
     selected_stack_mode = str(stack_mode or "runtime_only").strip().lower()
     if selected_stack_mode not in {"runtime_only", "isolated"}:
         raise DeviceInstallError("The managed stack mode is invalid.")
-    if selected_stack_mode == "isolated" and selected_instance == "default":
-        raise DeviceInstallError("The default Runtime cannot own an isolated stack.")
     selected_port = int(runtime_port)
     if selected_port < 1 or selected_port > 65535:
         raise DeviceInstallError("The managed runtime port is invalid.")

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -743,7 +743,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(result["runtime_port"], 8769)
         self.assertIn("replace instance-2 8768", commands[0])
 
-    def test_isolated_stack_uninstall_streams_remote_cleanup_progress(self):
+    def test_default_isolated_stack_uninstall_streams_remote_cleanup_progress(self):
         uploaded = []
 
         class RemoteFile(io.StringIO):
@@ -772,8 +772,8 @@ class EditorDeviceApiTests(unittest.TestCase):
         )
         inspection = {
             "instances": [{
-                "instance_id": "instance-2",
-                "port": 8768,
+                "instance_id": "default",
+                "port": 8766,
                 "healthy": True,
             }],
         }
@@ -798,13 +798,14 @@ class EditorDeviceApiTests(unittest.TestCase):
                 username="robot",
                 password="ssh-password",
                 host_fingerprint="SHA256:trusted-device-key",
-                instance_id="instance-2",
-                runtime_port=8768,
+                instance_id="default",
+                runtime_port=8766,
                 stack_mode="isolated",
                 hardware_ports=[8765, 8767],
                 progress=progress.append,
             )
 
+        self.assertEqual(result["instance_id"], "default")
         self.assertEqual(result["stack_mode"], "isolated")
         self.assertTrue(any(item["progress"] == 60 for item in progress))
         self.assertEqual(result["hardware_ports"], [8765, 8767])


### PR DESCRIPTION
## What changed
- allow the `default` managed Runtime instance to own its organized Hardware checkout
- retain the existing isolated-stack cleanup safeguards during device deletion
- cover deletion of a default complete stack with a regression test

## Root cause
The complete-stack installer now records the default device as `stack_mode: isolated`, but the uninstall path still enforced the previous rule that rejected that combination before connecting.

## User impact
A default Runtime + Hardware installation can now be installed, updated, and deleted consistently.

## Validation
- `python -m py_compile editor-server/device_installer.py editor-server/server.py`
- `python -m unittest discover -s tests -p test_editor_devices.py` (99 passed)
- `python -m unittest discover -s tests` (468 passed, 8 skipped)