### PR TITLE
Wait for backend port before startup

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -452,6 +452,10 @@ try {
     }
 
     Stop-PortListener -Port $BackendPort
+    if (-not (Wait-PortFree -Port $BackendPort)) {
+        Write-PortBusyError -Port $BackendPort
+        throw "Python server port is busy."
+    }
 
     Write-Step "[1/2] Starting Python server  (http://127.0.0.1:$BackendPort)"
     $script:BackendProcess = Start-HiddenProcess `

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -36,6 +36,19 @@ def test_launchers_stream_extension_dependency_setup_output():
     assert 'PYTHONPATH="$ROOT_DIR/python" "$PYTHON_BIN" -m blacknode.cli packages setup --missing' in shell
 
 
+def test_windows_launcher_waits_for_backend_port_cleanup_before_starting():
+    powershell = (ROOT / "start.ps1").read_text(encoding="utf-8")
+
+    stop = "Stop-PortListener -Port $BackendPort"
+    wait = "Wait-PortFree -Port $BackendPort"
+    start = 'Write-Step "[1/2] Starting Python server'
+
+    assert stop in powershell
+    assert wait in powershell
+    assert powershell.index(stop) < powershell.index(wait) < powershell.index(start)
+    assert 'throw "Python server port is busy."' in powershell
+
+
 def test_windows_markdown_launch_commands_are_powershell_explicit():
     markdown_files = [ROOT / "README.md", *ROOT.joinpath("docs").rglob("*.md")]
     markdown_files.extend([


### PR DESCRIPTION
## What changed
- wait for port 7777 to be released after stopping the previous backend on Windows
- report the busy port and owning process when cleanup cannot complete
- add a launcher regression test that enforces stop → wait → start ordering

## Root cause
The Windows launcher requested termination of the old backend and immediately started the replacement. Windows can retain the listening socket briefly, causing the new Python server to exit during startup. The Linux launcher already waited for the port to become free.

## User impact
Restarting Blacknode on Windows no longer races the previous backend process or produces the misleading `Python server failed to start` error for this port-release case.

## Validation
- `python -m pytest tests/test_launchers.py -q` (5 passed)
- `BLACKNODE_BOOTSTRAP_ONLY=1` launcher bootstrap (passed)
- real backend/editor replacement restart (both endpoints healthy)
- `python -m unittest discover -s tests` (468 passed, 8 skipped)