### PR TITLE
Adopt existing robot services into device stack

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -21,6 +21,7 @@ class DeviceInstallError(RuntimeError):
 _INSTANCE_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 _INSPECTION_MARKER = "__BLACKNODE_RUNTIME_INSPECTION__="
 _HARDWARE_PAIRING_INSPECTION_MARKER = "__BLACKNODE_HARDWARE_PAIRINGS__="
+_HARDWARE_ADOPTION_MARKER = "__BLACKNODE_HARDWARE_ADOPTION__="
 _UPDATE_REPORT_MARKER = "__BLACKNODE_UPDATE_REPORT__="
 _INSPECTION_SCRIPT = r"""python3 - <<'PY'
 import glob
@@ -888,6 +889,167 @@ PY"""
             "Could not read installed Robot Hardware pairing credentials."
         ) from exc
     finally:
+        connection.close()
+
+
+def adopt_legacy_hardware_services(
+    *,
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    host_fingerprint: str,
+    instance_id: str,
+) -> dict[str, Any]:
+    """Move legacy default Hardware services into the organized default stack."""
+
+    selected_instance = _clean_instance_id(instance_id or "default")
+    if selected_instance != "default":
+        return {"ok": True, "adopted": 0}
+    expected = str(host_fingerprint or "").strip()
+    if not expected:
+        raise DeviceInstallError(
+            "Check the SSH connection and confirm its host fingerprint first."
+        )
+    connection = _connect(
+        host,
+        port,
+        username,
+        password,
+        expected_fingerprint=expected,
+        timeout=15.0,
+    )
+    script = r"""#!/usr/bin/env bash
+set -euo pipefail
+sudo() {
+  command sudo -S -p '' "$@"
+}
+export -f sudo
+target="$HOME/Blacknode/devices/default/hardware"
+legacy="$HOME/blacknode-hardware"
+target_private="$target/.blacknode-hardware"
+legacy_private="$legacy/.blacknode-hardware"
+marker="__BLACKNODE_HARDWARE_ADOPTION__="
+
+valid_hardware_checkout() {
+  [[ -d "$1/.git" && -f "$1/pyproject.toml" ]] \
+    && grep -Eq '^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']blacknode-hardware["'"'"'][[:space:]]*$' \
+      "$1/pyproject.toml"
+}
+
+valid_hardware_checkout "$target" || {
+  echo "The organized Hardware package is missing or invalid: $target" >&2
+  exit 4
+}
+valid_hardware_checkout "$legacy" || {
+  printf '%s{"adopted":0}\n' "$marker"
+  exit 0
+}
+[[ -f "$legacy_private/devices.json" ]] || {
+  printf '%s{"adopted":0}\n' "$marker"
+  exit 0
+}
+
+mapfile -t legacy_units < <(
+  {
+    systemctl list-unit-files 'blacknode-hardware*.service' --no-legend 2>/dev/null
+    systemctl list-units --all --type=service 'blacknode-hardware*.service' \
+      --no-legend 2>/dev/null
+  } | awk '{print $1}' | sort -u | while read -r unit; do
+    [[ "$unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\.service$ ]] \
+      || continue
+    directory="$(
+      systemctl show "$unit" --property=WorkingDirectory --value 2>/dev/null || true
+    )"
+    [[ "$directory" == "$legacy" ]] || continue
+    printf '%s\n' "$unit"
+  done
+)
+if (( ${#legacy_units[@]} == 0 )); then
+  printf '%s{"adopted":0}\n' "$marker"
+  exit 0
+fi
+if [[ -e "$target_private" ]] \
+  && [[ -n "$(find "$target_private" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+  echo "The organized Hardware stack already has robot configuration. Its services must be installed or repaired instead of replacing it with the legacy configuration." >&2
+  exit 5
+fi
+
+temporary_private="${target_private}.adopting.$$"
+cleanup() {
+  rm -rf -- "$temporary_private"
+}
+trap cleanup EXIT
+rm -rf -- "$temporary_private"
+cp -a -- "$legacy_private" "$temporary_private"
+rm -rf -- "$target_private"
+mv -- "$temporary_private" "$target_private"
+(
+  cd "$target"
+  BLACKNODE_HARDWARE_INSTANCE="" ./install-service.sh --all
+)
+for unit in "${legacy_units[@]}"; do
+  directory="$(
+    systemctl show "$unit" --property=WorkingDirectory --value 2>/dev/null || true
+  )"
+  [[ "$directory" == "$target" ]] || {
+    echo "$unit did not move into the organized Hardware stack." >&2
+    exit 6
+  }
+  systemctl is-active --quiet "$unit" || {
+    echo "$unit is not running after migration." >&2
+    exit 6
+  }
+done
+printf '%s{"adopted":%d}\n' "$marker" "${#legacy_units[@]}"
+"""
+    remote_script_path = (
+        f"/tmp/blacknode-hardware-adopt-{secrets.token_hex(8)}.sh"
+    )
+    try:
+        sftp = connection.client.open_sftp()
+        try:
+            with sftp.file(remote_script_path, "w") as remote_script:
+                remote_script.write(script)
+            sftp.chmod(remote_script_path, 0o700)
+        finally:
+            sftp.close()
+        output = _run(
+            connection,
+            f"bash {remote_script_path}",
+            stdin_text=_sudo_input(password, attempts=16),
+            timeout=300.0,
+        )
+        marker_line = next(
+            (
+                line[len(_HARDWARE_ADOPTION_MARKER):]
+                for line in output.splitlines()
+                if line.startswith(_HARDWARE_ADOPTION_MARKER)
+            ),
+            "",
+        )
+        if not marker_line:
+            raise DeviceInstallError(
+                "The device did not confirm whether legacy Robot Hardware "
+                "services were migrated."
+            )
+        try:
+            result = json.loads(marker_line)
+            adopted = int(result.get("adopted") or 0)
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise DeviceInstallError(
+                "The device returned invalid Robot Hardware migration information."
+            ) from exc
+        return {"ok": True, "adopted": max(0, adopted)}
+    finally:
+        try:
+            _run(
+                connection,
+                f"rm -f -- {remote_script_path}",
+                timeout=10.0,
+            )
+        except DeviceInstallError:
+            pass
         connection.close()
 
 

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -54,6 +54,7 @@ from blacknode.workflow import validate_graph as validate_bn_graph
 from blacknode.workflow import validate_workflow as validate_bn_workflow
 
 from device_installer import (
+    adopt_legacy_hardware_services,
     control_runtime,
     DeviceInstallError,
     discover_hardware_pairings,
@@ -4829,6 +4830,30 @@ def discover_and_pair_host_robots(host_id: str, req: DiscoverHostRobotsReq):
             host_fingerprint=str(managed.get("host_fingerprint") or ""),
             expected_hardware_dir=str(managed.get("hardware_dir") or ""),
         )
+        adopted = 0
+        if (
+            int(discovered.get("discovered") or 0) == 0
+            and str(managed.get("stack_mode") or "") == "isolated"
+            and str(managed.get("instance_id") or "default") == "default"
+        ):
+            adoption = adopt_legacy_hardware_services(
+                host=str(managed.get("ssh_host") or ""),
+                port=int(managed.get("ssh_port") or 22),
+                username=str(managed.get("ssh_username") or ""),
+                password=req.password,
+                host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                instance_id="default",
+            )
+            adopted = int(adoption.get("adopted") or 0)
+            if adopted:
+                discovered = discover_hardware_pairings(
+                    host=str(managed.get("ssh_host") or ""),
+                    port=int(managed.get("ssh_port") or 22),
+                    username=str(managed.get("ssh_username") or ""),
+                    password=req.password,
+                    host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                    expected_hardware_dir=str(managed.get("hardware_dir") or ""),
+                )
     except DeviceInstallError as exc:
         raise HTTPException(400, str(exc)) from exc
 
@@ -4901,6 +4926,12 @@ def discover_and_pair_host_robots(host_id: str, req: DiscoverHostRobotsReq):
         f"Attached {len(attached)} installed robot"
         f"{'s' if len(attached) != 1 else ''} securely over verified SSH."
     )
+    if adopted:
+        summary = (
+            f"Moved {adopted} existing Robot Hardware service"
+            f"{'s' if adopted != 1 else ''} into this device stack. "
+            + summary
+        )
     if errors:
         summary += (
             f" {len(errors)} service"

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -599,6 +599,7 @@ export default function DevicesPanel() {
   )
   const selectedManagedHardwareReady = (
     !selectedManagedHardwareInstalled
+    || !selectedDeviceManagedLocally
     || selectedDeviceState?.runtime?.hardware?.ok === true
   )
   const selectedHardwareReady = selectedRobotChecks.every(item => Boolean(
@@ -641,10 +642,6 @@ export default function DevicesPanel() {
     ? 'checking'
     : selectedDeviceManagedLocally
       ? selectedDeviceState?.runtime?.hardware?.state || 'unchecked'
-      : selectedDevice?.managed_runtime?.hardware_state === 'stopped'
-        ? 'stopped'
-      : selectedDevice?.managed_runtime?.hardware_state === 'running'
-        ? 'running'
       : selectedRobotChecks.some(item => item.state?.loading)
         ? 'checking'
         : selectedRobotChecks.some(item => item.state?.error)
@@ -653,7 +650,9 @@ export default function DevicesPanel() {
             ? 'running'
             : selectedDevice?.robots.length
               ? 'unchecked'
-              : 'unavailable'
+              : selectedManagedHardwareInstalled
+                ? 'configured'
+                : 'unavailable'
   const selectedRuntimePackageState = selectedDeviceState?.loading
     ? 'checking'
     : selectedDeviceState?.runtime?.state
@@ -676,10 +675,12 @@ export default function DevicesPanel() {
       ? selectedDeviceState?.runtime
         ? 'unreachable'
         : 'unchecked'
-      : selectedManagedHardwareInstalled
+      : selectedDeviceManagedLocally
+        && selectedManagedHardwareInstalled
         && selectedDeviceState.runtime.hardware?.state === 'stopped'
         ? 'stopped'
-        : selectedManagedHardwareInstalled
+        : selectedDeviceManagedLocally
+        && selectedManagedHardwareInstalled
         && selectedDeviceState.runtime.hardware?.ok !== true
         ? 'unreachable'
         : selectedAttachedHardwareServiceFailed
@@ -695,10 +696,12 @@ export default function DevicesPanel() {
             ? ` · ${selectedDeviceState.runtime.error}`
             : ''
         }`
-      : selectedManagedHardwareInstalled
+      : selectedDeviceManagedLocally
+        && selectedManagedHardwareInstalled
         && selectedDeviceState.runtime.hardware?.state === 'stopped'
         ? `Runtime ${selectedRuntimeVersion} · Hardware ${selectedHardwareVersionLabel} · service stopped`
-        : selectedManagedHardwareInstalled
+        : selectedDeviceManagedLocally
+        && selectedManagedHardwareInstalled
         && selectedDeviceState.runtime.hardware?.ok !== true
         ? `Runtime ${selectedRuntimeVersion} · Hardware service unreachable${
             selectedDeviceState.runtime.hardware?.error
@@ -707,6 +710,8 @@ export default function DevicesPanel() {
           }`
         : selectedAttachedHardwareServiceFailed
           ? `Runtime ${selectedRuntimeVersion} · Hardware service unreachable`
+          : selectedManagedHardwareInstalled && selectedDevice?.robots.length === 0
+            ? `Runtime ${selectedRuntimeVersion} · Hardware environment ready`
           : `Runtime ${selectedRuntimeVersion} · Hardware ${selectedHardwareVersionLabel}`
   const selectedServiceChecks: Array<{
     id: string

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -684,6 +684,71 @@ class EditorDeviceApiTests(unittest.TestCase):
         remote_python = uploaded[0].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
         compile(remote_python, "<hardware-environment-install>", "exec")
 
+    def test_default_stack_can_adopt_recognized_legacy_hardware_services(self):
+        uploaded = []
+
+        class RemoteFile(io.StringIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                uploaded.append(self.getvalue())
+                self.close()
+                return False
+
+        class Sftp:
+            def file(self, _path, _mode):
+                return RemoteFile()
+
+            def chmod(self, _path, _mode):
+                return None
+
+            def close(self):
+                return None
+
+        connection = SimpleNamespace(
+            client=SimpleNamespace(open_sftp=lambda: Sftp()),
+            fingerprint="SHA256:trusted-device-key",
+            close=lambda: None,
+        )
+        commands = []
+        stdin_values = []
+
+        def fake_run(_connection, command, **kwargs):
+            commands.append(command)
+            stdin_values.append(kwargs.get("stdin_text"))
+            if "blacknode-hardware-adopt-" in command and command.startswith("bash "):
+                return "__BLACKNODE_HARDWARE_ADOPTION__={\"adopted\":2}"
+            return ""
+
+        with (
+            patch.object(device_installer, "_connect", return_value=connection),
+            patch.object(device_installer, "_run", side_effect=fake_run),
+        ):
+            result = device_installer.adopt_legacy_hardware_services(
+                host="192.168.1.87",
+                port=22,
+                username="alex",
+                password="ssh-password",
+                host_fingerprint="SHA256:trusted-device-key",
+                instance_id="default",
+            )
+
+        self.assertEqual(result["adopted"], 2)
+        self.assertEqual(stdin_values[0], "ssh-password\n" * 16)
+        self.assertNotIn("ssh-password", uploaded[0])
+        self.assertIn('target="$HOME/Blacknode/devices/default/hardware"', uploaded[0])
+        self.assertIn('legacy="$HOME/blacknode-hardware"', uploaded[0])
+        self.assertIn('cp -a -- "$legacy_private" "$temporary_private"', uploaded[0])
+        self.assertIn(
+            'BLACKNODE_HARDWARE_INSTANCE="" ./install-service.sh --all',
+            uploaded[0],
+        )
+        self.assertIn(
+            '[[ "$directory" == "$legacy" ]] || continue',
+            uploaded[0],
+        )
+
     def test_reinstall_of_incomplete_instance_uses_next_available_port(self):
         class RemoteFile(io.StringIO):
             def __enter__(self):
@@ -1193,6 +1258,94 @@ class EditorDeviceApiTests(unittest.TestCase):
             saved["devices"]["follower-device"]["token"],
             hardware_token,
         )
+
+    def test_robot_discovery_adopts_legacy_default_services_before_pairing(self):
+        runtime_token = "runtime-pairing-token-1234567890"
+        hardware_token = "hardware-pairing-token-1234567890"
+        host = server._device_registry.pair_host(
+            name="alex-desktop",
+            runtime_url="http://192.168.1.87:8766",
+            runtime_token=runtime_token,
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "alex-desktop",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.1.87",
+                "ssh_port": 22,
+                "ssh_username": "alex",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "default",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime.service",
+                "install_root": "~/Blacknode/devices/default",
+                "runtime_dir": "~/Blacknode/devices/default/runtime",
+                "packages_dir": "~/Blacknode/devices/default/runtime/packages",
+                "stack_mode": "isolated",
+                "hardware_dir": "~/Blacknode/devices/default/hardware",
+            },
+        )
+        hardware = _HardwareService(
+            hardware_token,
+            status_overrides={"device_id": "follower-device"},
+        )
+        empty_discovery = {
+            "discovered": 0,
+            "errors": [],
+            "pairings": [],
+        }
+        migrated_discovery = {
+            "discovered": 1,
+            "errors": [],
+            "pairings": [{
+                "service_name": "blacknode-hardware-follower.service",
+                "port": 8765,
+                "name": "Follower arm",
+                "device_id": "follower-device",
+                "token": hardware_token,
+                "active": True,
+            }],
+        }
+
+        with (
+            patch.object(
+                server,
+                "discover_hardware_pairings",
+                side_effect=[empty_discovery, migrated_discovery],
+            ) as discover,
+            patch.object(
+                server,
+                "adopt_legacy_hardware_services",
+                return_value={"ok": True, "adopted": 1},
+            ) as adopt,
+            patch(
+                "device_registry.urllib.request.urlopen",
+                side_effect=hardware,
+            ),
+        ):
+            response = self.client.post(
+                f"/device-hosts/{host['id']}/robots/discover",
+                json={"password": "ssh-password"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["robots"][0]["name"], "Follower arm")
+        self.assertIn(
+            "Moved 1 existing Robot Hardware service into this device stack.",
+            response.json()["summary"],
+        )
+        self.assertEqual(discover.call_count, 2)
+        adopt.assert_called_once_with(
+            host="192.168.1.87",
+            port=22,
+            username="alex",
+            password="ssh-password",
+            host_fingerprint="SHA256:trusted-device-key",
+            instance_id="default",
+        )
+        self.assertNotIn(hardware_token, response.text)
+        self.assertNotIn("ssh-password", response.text)
 
     def test_runtime_only_device_can_install_managed_hardware_package(self):
         managed = {


### PR DESCRIPTION
## What changed
- treat an installed remote Hardware environment with no attached robots as ready for onboarding instead of unreachable
- when Find and attach robots sees no services in the organized default stack, safely adopt recognized services from the legacy default Hardware checkout
- copy private robot configuration, pairing tokens, and calibration state into the organized checkout, then replace and validate the same systemd units
- preserve the legacy checkout as rollback data and refuse cross-instance adoption
- attach the migrated robots without exposing SSH passwords or Hardware tokens

## Root cause
The new complete-stack install created `~/Blacknode/devices/default/hardware`, while existing robot services still used `~/blacknode-hardware`. Discovery intentionally scoped itself to the new checkout, so the editor reported no robots. The UI also expected a local-only Hardware inspection field for remote stacks and therefore labeled the ready environment as unreachable.

## User impact
The device health check correctly reports `Hardware environment ready`. Entering the SSH password under Attach robot → Find and attach robots migrates the existing default services into the organized stack and attaches them automatically.

## Safety
- only the legacy default checkout may be adopted into the organized default stack
- named or other isolated stacks are never adopted
- recognized checkout manifests, systemd unit names, working directories, active services, and target ownership are validated
- the old files are preserved

## Validation
- Python compilation passed
- device-management tests: 101 passed
- full backend suite: 470 passed, 8 skipped
- editor production build passed
- generated migration script passed `bash -n`