### PR TITLE
Configure connected robots during discovery

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -22,6 +22,7 @@ _INSTANCE_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 _INSPECTION_MARKER = "__BLACKNODE_RUNTIME_INSPECTION__="
 _HARDWARE_PAIRING_INSPECTION_MARKER = "__BLACKNODE_HARDWARE_PAIRINGS__="
 _HARDWARE_ADOPTION_MARKER = "__BLACKNODE_HARDWARE_ADOPTION__="
+_HARDWARE_CONFIGURATION_MARKER = "__BLACKNODE_HARDWARE_CONFIGURATION__="
 _UPDATE_REPORT_MARKER = "__BLACKNODE_UPDATE_REPORT__="
 _INSPECTION_SCRIPT = r"""python3 - <<'PY'
 import glob
@@ -1041,6 +1042,208 @@ printf '%s{"adopted":%d}\n' "$marker" "${#legacy_units[@]}"
                 "The device returned invalid Robot Hardware migration information."
             ) from exc
         return {"ok": True, "adopted": max(0, adopted)}
+    finally:
+        try:
+            _run(
+                connection,
+                f"rm -f -- {remote_script_path}",
+                timeout=10.0,
+            )
+        except DeviceInstallError:
+            pass
+        connection.close()
+
+
+def configure_hardware_services(
+    *,
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    host_fingerprint: str,
+    instance_id: str,
+    runtime_port: int,
+) -> dict[str, Any]:
+    """Configure connected serial robots in an organized Hardware stack."""
+
+    selected_instance = _clean_instance_id(instance_id or "default")
+    selected_runtime_port = int(runtime_port)
+    if not 1 <= selected_runtime_port <= 65535:
+        raise DeviceInstallError("The managed Runtime port is invalid.")
+    expected = str(host_fingerprint or "").strip()
+    if not expected:
+        raise DeviceInstallError(
+            "Check the SSH connection and confirm its host fingerprint first."
+        )
+    connection = _connect(
+        host,
+        port,
+        username,
+        password,
+        expected_fingerprint=expected,
+        timeout=15.0,
+    )
+    script = r"""#!/usr/bin/env bash
+set -euo pipefail
+sudo() {
+  command sudo -S -p '' "$@"
+}
+export -f sudo
+instance="$1"
+runtime_port="$2"
+[[ "$instance" == "default" || "$instance" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || {
+  echo "Invalid Blacknode Hardware instance." >&2
+  exit 2
+}
+[[ "$runtime_port" =~ ^[0-9]+$ ]] \
+  && (( runtime_port >= 1 && runtime_port <= 65535 )) || {
+  echo "Invalid Blacknode Runtime port." >&2
+  exit 2
+}
+target="$HOME/Blacknode/devices/$instance/hardware"
+service_instance="$instance"
+legacy=""
+if [[ "$instance" == "default" ]]; then
+  service_instance=""
+  legacy="$HOME/blacknode-hardware"
+fi
+[[ -d "$target/.git" && -f "$target/pyproject.toml" ]] \
+  && grep -Eq '^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']blacknode-hardware["'"'"'][[:space:]]*$' \
+    "$target/pyproject.toml" || {
+  echo "The organized Hardware package is missing or invalid: $target" >&2
+  exit 4
+}
+[[ -x "$target/.venv/bin/python" && -x "$target/configure.sh" ]] || {
+  echo "The organized Hardware environment is not set up: $target" >&2
+  exit 4
+}
+
+orphan_units=()
+if [[ -n "$legacy" ]]; then
+  mapfile -t orphan_units < <(
+    {
+      systemctl list-unit-files 'blacknode-hardware*.service' --no-legend 2>/dev/null
+      systemctl list-units --all --type=service 'blacknode-hardware*.service' \
+        --no-legend 2>/dev/null
+    } | awk '{print $1}' | sort -u | while read -r unit; do
+      [[ "$unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\.service$ ]] \
+        || continue
+      directory="$(
+        systemctl show "$unit" --property=WorkingDirectory --value 2>/dev/null || true
+      )"
+      [[ "$directory" == "$legacy" ]] || continue
+      printf '%s\n' "$unit"
+    done
+  )
+fi
+restore_orphans=false
+restore_on_failure() {
+  exit_code=$?
+  if (( exit_code != 0 )) && [[ "$restore_orphans" == true ]]; then
+    for unit in "${orphan_units[@]}"; do
+      sudo systemctl start "$unit" >/dev/null 2>&1 || true
+    done
+  fi
+  exit "$exit_code"
+}
+trap restore_on_failure EXIT
+if (( ${#orphan_units[@]} > 0 )); then
+  echo "Stopping orphaned legacy Hardware services for a safe serial rescan..."
+  for unit in "${orphan_units[@]}"; do
+    sudo systemctl stop "$unit"
+  done
+  restore_orphans=true
+fi
+(
+  cd "$target"
+  BLACKNODE_HARDWARE_INSTANCE="$service_instance" \
+    BLACKNODE_RUNTIME_PORT="$runtime_port" \
+    ./configure.sh --all --install
+)
+
+for unit in "${orphan_units[@]}"; do
+  directory="$(
+    systemctl show "$unit" --property=WorkingDirectory --value 2>/dev/null || true
+  )"
+  if [[ "$directory" == "$legacy" ]]; then
+    sudo systemctl disable --now "$unit" >/dev/null 2>&1 || true
+    sudo rm -f -- "/etc/systemd/system/$unit" "/run/systemd/system/$unit"
+  fi
+done
+sudo systemctl daemon-reload
+
+configured=0
+while read -r unit; do
+  [[ "$unit" =~ ^blacknode-hardware([-.@][A-Za-z0-9_.@-]+)?\.service$ ]] \
+    || continue
+  directory="$(
+    systemctl show "$unit" --property=WorkingDirectory --value 2>/dev/null || true
+  )"
+  [[ "$directory" == "$target" ]] || continue
+  systemctl is-active --quiet "$unit" || {
+    echo "$unit is not running after configuration." >&2
+    exit 6
+  }
+  configured=$((configured + 1))
+done < <(
+  {
+    systemctl list-unit-files 'blacknode-hardware*.service' --no-legend 2>/dev/null
+    systemctl list-units --all --type=service 'blacknode-hardware*.service' \
+      --no-legend 2>/dev/null
+  } | awk '{print $1}' | sort -u
+)
+(( configured > 0 )) || {
+  echo "No connected serial robots were configured." >&2
+  exit 6
+}
+restore_orphans=false
+trap - EXIT
+printf '__BLACKNODE_HARDWARE_CONFIGURATION__={"configured":%d}\n' "$configured"
+"""
+    remote_script_path = (
+        f"/tmp/blacknode-hardware-configure-{secrets.token_hex(8)}.sh"
+    )
+    try:
+        sftp = connection.client.open_sftp()
+        try:
+            with sftp.file(remote_script_path, "w") as remote_script:
+                remote_script.write(script)
+            sftp.chmod(remote_script_path, 0o700)
+        finally:
+            sftp.close()
+        output = _run(
+            connection,
+            (
+                f"bash {remote_script_path} "
+                f"{selected_instance} {selected_runtime_port}"
+            ),
+            stdin_text=_sudo_input(password, attempts=32),
+            timeout=300.0,
+        )
+        marker_line = next(
+            (
+                line[len(_HARDWARE_CONFIGURATION_MARKER):]
+                for line in output.splitlines()
+                if line.startswith(_HARDWARE_CONFIGURATION_MARKER)
+            ),
+            "",
+        )
+        if not marker_line:
+            raise DeviceInstallError(
+                "The device did not confirm its configured Robot Hardware services."
+            )
+        try:
+            result = json.loads(marker_line)
+            configured = int(result.get("configured") or 0)
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise DeviceInstallError(
+                "The device returned invalid Robot Hardware configuration information."
+            ) from exc
+        if configured < 1:
+            raise DeviceInstallError(
+                "No connected serial robots were configured."
+            )
+        return {"ok": True, "configured": configured}
     finally:
         try:
             _run(

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -55,6 +55,7 @@ from blacknode.workflow import validate_workflow as validate_bn_workflow
 
 from device_installer import (
     adopt_legacy_hardware_services,
+    configure_hardware_services,
     control_runtime,
     DeviceInstallError,
     discover_hardware_pairings,
@@ -4831,6 +4832,7 @@ def discover_and_pair_host_robots(host_id: str, req: DiscoverHostRobotsReq):
             expected_hardware_dir=str(managed.get("hardware_dir") or ""),
         )
         adopted = 0
+        configured = 0
         if (
             int(discovered.get("discovered") or 0) == 0
             and str(managed.get("stack_mode") or "") == "isolated"
@@ -4854,6 +4856,28 @@ def discover_and_pair_host_robots(host_id: str, req: DiscoverHostRobotsReq):
                     host_fingerprint=str(managed.get("host_fingerprint") or ""),
                     expected_hardware_dir=str(managed.get("hardware_dir") or ""),
                 )
+            else:
+                configuration = configure_hardware_services(
+                    host=str(managed.get("ssh_host") or ""),
+                    port=int(managed.get("ssh_port") or 22),
+                    username=str(managed.get("ssh_username") or ""),
+                    password=req.password,
+                    host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                    instance_id="default",
+                    runtime_port=int(managed.get("runtime_port") or 0),
+                )
+                configured = int(configuration.get("configured") or 0)
+                if configured:
+                    discovered = discover_hardware_pairings(
+                        host=str(managed.get("ssh_host") or ""),
+                        port=int(managed.get("ssh_port") or 22),
+                        username=str(managed.get("ssh_username") or ""),
+                        password=req.password,
+                        host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                        expected_hardware_dir=str(
+                            managed.get("hardware_dir") or ""
+                        ),
+                    )
     except DeviceInstallError as exc:
         raise HTTPException(400, str(exc)) from exc
 
@@ -4930,6 +4954,12 @@ def discover_and_pair_host_robots(host_id: str, req: DiscoverHostRobotsReq):
         summary = (
             f"Moved {adopted} existing Robot Hardware service"
             f"{'s' if adopted != 1 else ''} into this device stack. "
+            + summary
+        )
+    elif configured:
+        summary = (
+            f"Configured {configured} connected robot"
+            f"{'s' if configured != 1 else ''} in this device stack. "
             + summary
         )
     if errors:

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -749,6 +749,89 @@ class EditorDeviceApiTests(unittest.TestCase):
             uploaded[0],
         )
 
+    def test_default_stack_can_configure_connected_serial_robots(self):
+        uploaded = []
+
+        class RemoteFile(io.StringIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                uploaded.append(self.getvalue())
+                self.close()
+                return False
+
+        class Sftp:
+            def file(self, _path, _mode):
+                return RemoteFile()
+
+            def chmod(self, _path, _mode):
+                return None
+
+            def close(self):
+                return None
+
+        connection = SimpleNamespace(
+            client=SimpleNamespace(open_sftp=lambda: Sftp()),
+            fingerprint="SHA256:trusted-device-key",
+            close=lambda: None,
+        )
+        commands = []
+        stdin_values = []
+
+        def fake_run(_connection, command, **kwargs):
+            commands.append(command)
+            stdin_values.append(kwargs.get("stdin_text"))
+            if (
+                "blacknode-hardware-configure-" in command
+                and command.startswith("bash ")
+            ):
+                return (
+                    "__BLACKNODE_HARDWARE_CONFIGURATION__="
+                    "{\"configured\":2}"
+                )
+            return ""
+
+        with (
+            patch.object(device_installer, "_connect", return_value=connection),
+            patch.object(device_installer, "_run", side_effect=fake_run),
+        ):
+            result = device_installer.configure_hardware_services(
+                host="192.168.1.87",
+                port=22,
+                username="alex",
+                password="ssh-password",
+                host_fingerprint="SHA256:trusted-device-key",
+                instance_id="default",
+                runtime_port=8766,
+            )
+
+        self.assertEqual(result["configured"], 2)
+        self.assertEqual(stdin_values[0], "ssh-password\n" * 32)
+        self.assertNotIn("ssh-password", uploaded[0])
+        self.assertIn(
+            'target="$HOME/Blacknode/devices/$instance/hardware"',
+            uploaded[0],
+        )
+        self.assertIn(
+            '[[ "$directory" == "$legacy" ]] || continue',
+            uploaded[0],
+        )
+        self.assertIn(
+            'BLACKNODE_RUNTIME_PORT="$runtime_port"',
+            uploaded[0],
+        )
+        self.assertIn("./configure.sh --all --install", uploaded[0])
+        self.assertIn(
+            'sudo systemctl stop "$unit"',
+            uploaded[0],
+        )
+        self.assertIn(
+            'systemctl is-active --quiet "$unit"',
+            uploaded[0],
+        )
+        self.assertIn(" default 8766", commands[0])
+
     def test_reinstall_of_incomplete_instance_uses_next_available_port(self):
         class RemoteFile(io.StringIO):
             def __enter__(self):
@@ -1343,6 +1426,101 @@ class EditorDeviceApiTests(unittest.TestCase):
             password="ssh-password",
             host_fingerprint="SHA256:trusted-device-key",
             instance_id="default",
+        )
+        self.assertNotIn(hardware_token, response.text)
+        self.assertNotIn("ssh-password", response.text)
+
+    def test_robot_discovery_configures_connected_robots_when_no_services_exist(self):
+        runtime_token = "runtime-pairing-token-1234567890"
+        hardware_token = "hardware-pairing-token-1234567890"
+        host = server._device_registry.pair_host(
+            name="alex-desktop",
+            runtime_url="http://192.168.1.87:8766",
+            runtime_token=runtime_token,
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "alex-desktop",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.1.87",
+                "ssh_port": 22,
+                "ssh_username": "alex",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "default",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime.service",
+                "install_root": "~/Blacknode/devices/default",
+                "runtime_dir": "~/Blacknode/devices/default/runtime",
+                "packages_dir": "~/Blacknode/devices/default/runtime/packages",
+                "stack_mode": "isolated",
+                "hardware_dir": "~/Blacknode/devices/default/hardware",
+            },
+        )
+        hardware = _HardwareService(
+            hardware_token,
+            status_overrides={"device_id": "follower-device"},
+        )
+        empty_discovery = {
+            "discovered": 0,
+            "errors": [],
+            "pairings": [],
+        }
+        configured_discovery = {
+            "discovered": 1,
+            "errors": [],
+            "pairings": [{
+                "service_name": "blacknode-hardware-follower.service",
+                "port": 8765,
+                "name": "Follower arm",
+                "device_id": "follower-device",
+                "token": hardware_token,
+                "active": True,
+            }],
+        }
+
+        with (
+            patch.object(
+                server,
+                "discover_hardware_pairings",
+                side_effect=[empty_discovery, configured_discovery],
+            ) as discover,
+            patch.object(
+                server,
+                "adopt_legacy_hardware_services",
+                return_value={"ok": True, "adopted": 0},
+            ) as adopt,
+            patch.object(
+                server,
+                "configure_hardware_services",
+                return_value={"ok": True, "configured": 1},
+            ) as configure,
+            patch(
+                "device_registry.urllib.request.urlopen",
+                side_effect=hardware,
+            ),
+        ):
+            response = self.client.post(
+                f"/device-hosts/{host['id']}/robots/discover",
+                json={"password": "ssh-password"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["robots"][0]["name"], "Follower arm")
+        self.assertIn(
+            "Configured 1 connected robot in this device stack.",
+            response.json()["summary"],
+        )
+        self.assertEqual(discover.call_count, 2)
+        adopt.assert_called_once()
+        configure.assert_called_once_with(
+            host="192.168.1.87",
+            port=22,
+            username="alex",
+            password="ssh-password",
+            host_fingerprint="SHA256:trusted-device-key",
+            instance_id="default",
+            runtime_port=8766,
         )
         self.assertNotIn(hardware_token, response.text)
         self.assertNotIn("ssh-password", response.text)


### PR DESCRIPTION
## What changed
- extend Find and attach robots with a final recovery path when neither organized nor recoverable legacy services exist
- stop only orphaned services owned by the legacy default Hardware path before scanning serial devices
- configure every connected serial robot from the organized Hardware checkout, generate fresh pairing credentials, install and validate services, then attach them
- restore legacy services on configuration failure when they can still start
- remove stale legacy units only after the new organized services are successfully installed

## Root cause
The previous migration fallback required the legacy Hardware checkout and its private configuration to still exist. In this device state, the old service processes remained reachable on ports 8765 and 8767, but their saved installation was no longer recoverable, so there was nothing to copy and discovery remained empty.

## User impact
Retrying Attach robot → Find and attach robots now rebuilds the two robot services directly from the physically connected serial devices. No terminal command or token entry is required.

## Safety
- the serial rescan runs only after the user enters the verified SSH password and explicitly presses Find and attach robots
- only default legacy-owned units are stopped
- other named and isolated stacks are preserved
- services start disarmed and must pass the Hardware package's required-hardware validation before attachment
- the runtime port is reserved during automatic Hardware port allocation

## Validation
- Python compilation passed
- device-management tests: 103 passed
- full backend suite: 472 passed, 8 skipped
- adoption and configuration scripts both passed `bash -n`