### PR TITLE
Add one-click preflight dependency repair

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -5243,6 +5243,7 @@ def _preflight_check(
     *,
     blocking: bool = False,
     action: str | None = None,
+    action_data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     check = {
         "id": check_id,
@@ -5253,6 +5254,8 @@ def _preflight_check(
     }
     if action:
         check["action"] = action
+    if action_data:
+        check["action_data"] = action_data
     return check
 
 
@@ -6069,12 +6072,68 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
             "The editor can resolve every node and declared package requirement.",
         ))
     else:
+        component_repairs = sorted({
+            (
+                str(item.get("package") or ""),
+                str(item.get("component") or ""),
+            )
+            for item in dependencies.get("missing_components", [])
+            if (
+                isinstance(item, dict)
+                and str(item.get("reason") or "") == "component is disabled"
+                and str(item.get("package") or "")
+                and str(item.get("component") or "")
+            )
+        })
+        adapter_repairs = sorted({
+            (
+                str(item.get("package") or ""),
+                str(item.get("component") or ""),
+                str(item.get("adapter") or ""),
+            )
+            for item in dependencies.get("missing_adapters", [])
+            if (
+                isinstance(item, dict)
+                and str(item.get("reason") or "") in {
+                    "adapter is disabled",
+                    "parent component is disabled",
+                }
+                and str(item.get("package") or "")
+                and str(item.get("component") or "")
+                and str(item.get("adapter") or "")
+            )
+        })
+        dependency_action_data = {
+            "components": [
+                {"package": package, "component": component}
+                for package, component in component_repairs
+            ],
+            "adapters": [
+                {
+                    "package": package,
+                    "component": component,
+                    "adapter": adapter,
+                }
+                for package, component, adapter in adapter_repairs
+            ],
+        }
+        can_repair_dependencies = bool(component_repairs or adapter_repairs)
         checks.append(_preflight_check(
             "local_dependencies",
             "Editor dependencies",
             "fail",
             str(dependencies.get("message") or "Workflow dependencies are incomplete."),
             blocking=True,
+            action=(
+                "enable_editor_dependencies"
+                if can_repair_dependencies
+                else None
+            ),
+            action_data=(
+                dependency_action_data
+                if can_repair_dependencies
+                else None
+            ),
         ))
 
     try:

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -604,7 +604,15 @@ export interface DeploymentPreflightCheck {
   status: DeploymentPreflightStatus
   message: string
   blocking: boolean
-  action?: 'activate_calibration' | 'select_calibration' | 'choose_matching_hardware'
+  action?:
+    | 'activate_calibration'
+    | 'select_calibration'
+    | 'choose_matching_hardware'
+    | 'enable_editor_dependencies'
+  action_data?: {
+    components?: Array<{ package: string; component: string }>
+    adapters?: Array<{ package: string; component: string; adapter: string }>
+  }
 }
 
 export interface DeploymentPreflight {

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -6,6 +6,7 @@ import {
   type DeviceRobotProfile,
   type Deployment,
   type DeploymentPreflight,
+  type DeploymentPreflightCheck,
   type DeploymentPreflightStatus,
   type DeploymentState,
   type HardwareDevice,
@@ -150,6 +151,7 @@ export default function DeploymentsPanel({
   const workflowRevision = useStore(s => s.workflowRevision)
   const workflowMetadata = useStore(s => s.workflowMetadata)
   const setWorkflowRequirements = useStore(s => s.setWorkflowRequirements)
+  const loadNodeTypes = useStore(s => s.loadNodeTypes)
   const nodes = useStore(s => s.nodes)
   const nodeDefs = useStore(s => s.nodeDefs)
   const updateParam = useStore(s => s.updateParam)
@@ -159,6 +161,7 @@ export default function DeploymentsPanel({
   const [targetStatus, setTargetStatus] = useState<HardwareDeviceStatus | null>(null)
   const [requirementsBusy, setRequirementsBusy] = useState(false)
   const [profileBusyId, setProfileBusyId] = useState<string | null>(null)
+  const [dependencyRepairBusy, setDependencyRepairBusy] = useState(false)
 
   const requiredCapabilities = Array.isArray(workflowMetadata.required_capabilities)
     ? workflowMetadata.required_capabilities.map(String)
@@ -498,6 +501,55 @@ export default function DeploymentsPanel({
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
+      setBusy(false)
+    }
+  }
+
+  const repairEditorDependencies = async (
+    check: DeploymentPreflightCheck,
+  ) => {
+    if (
+      !selectedDeviceId
+      || check.action !== 'enable_editor_dependencies'
+    ) return
+    const components = check.action_data?.components ?? []
+    const adapters = check.action_data?.adapters ?? []
+    if (components.length === 0 && adapters.length === 0) return
+
+    setBusy(true)
+    setDependencyRepairBusy(true)
+    setError(null)
+    setRemoteNotice(null)
+    try {
+      for (const requirement of components) {
+        await api.setPackageComponent(
+          requirement.package,
+          requirement.component,
+          true,
+        )
+      }
+      for (const requirement of adapters) {
+        await api.setPackageAdapter(
+          requirement.package,
+          requirement.component,
+          requirement.adapter,
+          true,
+        )
+      }
+      await api.reloadPackages()
+      await loadNodeTypes()
+      const result = await api.validateDeviceDeployment(selectedDeviceId)
+      setTargetStatus(result.status)
+      setPreflight(result)
+      setRemoteNotice(
+        result.ready
+          ? 'Required editor dependencies were enabled. Deployment is ready.'
+          : 'Available editor dependencies were enabled. Review the remaining preflight checks.',
+      )
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setDependencyRepairBusy(false)
       setBusy(false)
     }
   }
@@ -1216,7 +1268,13 @@ export default function DeploymentsPanel({
         </div>
       </div>
 
-      {preflight && <PreflightResult result={preflight} />}
+      {preflight && (
+        <PreflightResult
+          result={preflight}
+          actionBusy={dependencyRepairBusy}
+          onAction={repairEditorDependencies}
+        />
+      )}
 
       <div className="bn-deployment-section-head">
         <div>
@@ -1325,7 +1383,15 @@ const PREFLIGHT_LABEL: Record<DeploymentPreflightStatus, string> = {
   pending: 'WAIT',
 }
 
-function PreflightResult({ result }: { result: DeploymentPreflight }) {
+function PreflightResult({
+  result,
+  actionBusy,
+  onAction,
+}: {
+  result: DeploymentPreflight
+  actionBusy: boolean
+  onAction: (check: DeploymentPreflightCheck) => void
+}) {
   return (
     <div className="bn-preflight">
       <div className={`bn-preflight-summary ${result.ready ? 'is-ready' : 'is-blocked'}`}>
@@ -1341,6 +1407,22 @@ function PreflightResult({ result }: { result: DeploymentPreflight }) {
             <div>
               <strong>{check.label}</strong>
               <span>{check.message}</span>
+              {check.action === 'enable_editor_dependencies' && (
+                <button
+                  type="button"
+                  className="bn-device-action-button is-primary"
+                  disabled={actionBusy}
+                  onClick={() => onAction(check)}
+                  style={{ ...miniButton, marginTop: 7 }}
+                >
+                  {actionBusy ? 'Enabling dependencies…' : (
+                    (check.action_data?.adapters?.length ?? 0) === 1
+                    && (check.action_data?.components?.length ?? 0) === 0
+                      ? 'Enable required adapter'
+                      : 'Fix editor dependencies'
+                  )}
+                </button>
+              )}
             </div>
           </div>
         ))}

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -4670,6 +4670,63 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn("blacknode-skills", target_runtime["message"])
         self.assertTrue(response.json()["ready"])
 
+    def test_preflight_returns_one_click_repair_for_disabled_editor_adapter(self):
+        hardware = _HardwareService()
+        dependency_report = {
+            "ok": False,
+            "code": "missing_adapters",
+            "message": (
+                "Required adapters need attention: "
+                "blacknode-drivers/feetech@ros2 (adapter is disabled)"
+            ),
+            "missing_packages": [],
+            "missing_components": [],
+            "missing_adapters": [{
+                "package": "blacknode-drivers",
+                "component": "feetech",
+                "adapter": "ros2",
+                "reason": "adapter is disabled",
+            }],
+        }
+
+        with (
+            patch("device_registry.urllib.request.urlopen", side_effect=hardware),
+            patch.object(
+                server,
+                "_workflow_dependency_report",
+                return_value=dependency_report,
+            ),
+        ):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            response = self.client.post(
+                f"/devices/{device_id}/deployment-preflight",
+                json={"workflow": _workflow([])},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        dependency_check = next(
+            item
+            for item in response.json()["checks"]
+            if item["id"] == "local_dependencies"
+        )
+        self.assertEqual(
+            dependency_check["action"],
+            "enable_editor_dependencies",
+        )
+        self.assertEqual(dependency_check["action_data"], {
+            "components": [],
+            "adapters": [{
+                "package": "blacknode-drivers",
+                "component": "feetech",
+                "adapter": "ros2",
+            }],
+        })
+        self.assertTrue(dependency_check["blocking"])
+
     def test_staging_auto_installs_extension_packages_before_upload(self):
         hardware = _HardwareService()
         workflow = _workflow([])


### PR DESCRIPTION
## What changed
- return structured repair targets when deployment preflight finds disabled required components or adapters
- show an Enable required adapter / Fix editor dependencies button directly in the failing preflight row
- use the existing package dependency planner to enable components and adapters and install their declared prerequisites
- reload package and node definitions, rerun preflight, and update readiness automatically

## Root cause
Preflight knew `blacknode-drivers/feetech@ros2` was disabled but returned only a human-readable failure message. The editor therefore had no safe structured target to repair even though the package-management API already supported dependency-aware adapter enablement.

## User impact
The blocking Editor dependencies check now has a direct repair button. For the current workflow, pressing Enable required adapter enables `blacknode-drivers/feetech@ros2`, refreshes the editor, and reruns all deployment checks.

## Validation
- Python compilation passed
- device-management tests: 104 passed
- full backend suite: 473 passed, 8 skipped
- editor production build passed