### PR TITLE
Add deployment progress and safe launcher handoff

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -7133,18 +7133,31 @@ def _start_replacing_device_deployment(
     return deployment, sorted(superseded_ids), cleanup_warnings
 
 
-@app.post("/devices/{device_id}/deployments")
-def stage_device_deployment(device_id: str, req: RemoteDeployReq):
+def _stage_device_deployment_payload(
+    device_id: str,
+    req: RemoteDeployReq,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    def report(percent: int, message: str) -> None:
+        if progress is not None:
+            progress({
+                "progress": max(0, min(100, int(percent))),
+                "message": message,
+            })
+
+    report(4, "Preparing deployment")
     deployment_owner = _remote_deployment_owner(device_id, req)
     workflow = _device_deployment_workflow()
     current_hash = _device_deployment_hash(workflow)
     requested_hash = req.workflow_hash.strip().lower()
+    report(10, "Confirming the validated graph revision")
     if not requested_hash or requested_hash != current_hash:
         raise HTTPException(
             409,
             "The graph changed after validation. Validate deployment again before staging.",
         )
 
+    report(18, "Running deployment safety checks")
     preflight = validate_device_deployment(
         device_id,
         DeploymentPreflightReq(workflow=workflow),
@@ -7160,6 +7173,7 @@ def stage_device_deployment(device_id: str, req: RemoteDeployReq):
             "Deployment preflight failed: " + "; ".join(blocking[:3]),
         )
 
+    report(28, "Exporting the workflow with motion disarmed")
     try:
         _bind_robot_to_device(workflow, preflight.get("status") or {})
         _disarm_workflow_motion_controls(workflow)
@@ -7204,10 +7218,17 @@ def stage_device_deployment(device_id: str, req: RemoteDeployReq):
     if req.deployment_id:
         payload["deployment_id"] = req.deployment_id
     try:
+        report(36, "Connecting to the target Runtime")
         client = _runtime_client_or_404(device_id)
         package_specs = _workflow_target_package_specs(workflow)
         if package_specs:
+            report(
+                42,
+                f"Synchronizing {len(package_specs)} required workflow "
+                f"package{'s' if len(package_specs) != 1 else ''}",
+            )
             client.sync_packages(package_specs)
+            report(62, "Verifying synchronized packages and workflow nodes")
             synced_manifest = client.manifest()
             synced_packages = {
                 str(item.get("name")): str(item.get("version") or "")
@@ -7247,10 +7268,15 @@ def stage_device_deployment(device_id: str, req: RemoteDeployReq):
                     409,
                     "Target package synchronization did not provide " + "; ".join(details),
                 )
+        else:
+            report(62, "No workflow package updates are required")
+        report(70, "Uploading the workflow bundle")
         deployment = client.stage_deployment(payload)
+        report(80, "Workflow stored on the target Runtime")
         superseded_deployments: list[str] = []
         cleanup_warnings: list[str] = []
         if req.start:
+            report(84, "Checking robot safety and replacing the previous workflow")
             (
                 deployment,
                 superseded_deployments,
@@ -7260,15 +7286,30 @@ def stage_device_deployment(device_id: str, req: RemoteDeployReq):
                 client,
                 str(deployment["id"]),
             )
+            report(98, "Workflow started; confirming replacement cleanup")
     except DeviceRegistryError as exc:
         raise HTTPException(502, str(exc)) from exc
-    return {
+    result = {
         "deployment": deployment,
         "workflow_hash": current_hash,
         "started": bool(req.start),
         "superseded_deployments": superseded_deployments,
         "cleanup_warnings": cleanup_warnings,
     }
+    report(100, "Workflow sent and started" if req.start else "Workflow sent to robot")
+    return result
+
+
+@app.post("/devices/{device_id}/deployments")
+def stage_device_deployment(device_id: str, req: RemoteDeployReq):
+    return _stage_device_deployment_payload(device_id, req)
+
+
+@app.post("/devices/{device_id}/deployments-stream")
+def stream_device_deployment(device_id: str, req: RemoteDeployReq):
+    return _lifecycle_stream(
+        lambda report: _stage_device_deployment_payload(device_id, req, report)
+    )
 
 
 @app.get("/devices/{device_id}/deployments/{deployment_id}")

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1526,20 +1526,20 @@ export const api = {
     deviceId: string,
     name: string,
     workflowHash: string,
-    start = false,
+    start: boolean,
+    onProgress: (progress: DeviceActionProgress) => void,
     deploymentId?: string,
     projectId?: string,
     workflowSlug?: string,
   ) =>
-    req<{
+    streamDeviceAction<{
       deployment: RemoteDeployment
       workflow_hash: string
       started: boolean
       superseded_deployments: string[]
       cleanup_warnings: string[]
     }>(
-      'POST',
-      `/devices/${encodeURIComponent(deviceId)}/deployments`,
+      `/devices/${encodeURIComponent(deviceId)}/deployments-stream`,
       {
         name,
         workflow_hash: workflowHash,
@@ -1548,7 +1548,7 @@ export const api = {
         project_id: projectId ?? null,
         workflow_slug: workflowSlug ?? null,
       },
-      600000,
+      onProgress,
     ),
   startRemoteDeployment: (deviceId: string, deploymentId: string) =>
     req<RemoteDeployment>(

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -9,6 +9,7 @@ import {
   type DeploymentPreflightCheck,
   type DeploymentPreflightStatus,
   type DeploymentState,
+  type DeviceActionProgress,
   type HardwareDevice,
   type HardwareDeviceStatus,
   type RemoteDeployment,
@@ -119,6 +120,7 @@ export default function DeploymentsPanel({
   const [remoteLogs, setRemoteLogs] = useState<Record<string, string>>({})
   const [remoteDeploymentName, setRemoteDeploymentName] = useState('')
   const [remoteAction, setRemoteAction] = useState<'send' | 'send-run' | null>(null)
+  const [remoteProgress, setRemoteProgress] = useState<DeviceActionProgress | null>(null)
   const [remoteNotice, setRemoteNotice] = useState<string | null>(null)
   const [rosDiagnostics, setRosDiagnostics] = useState('')
   const stopRuntimeServices = useStore(s => s.stopRuntimeServices)
@@ -629,6 +631,10 @@ export default function DeploymentsPanel({
     ) return
     setBusy(true)
     setRemoteAction(start ? 'send-run' : 'send')
+    setRemoteProgress({
+      progress: 1,
+      message: start ? 'Preparing to send and start workflow' : 'Preparing to send workflow',
+    })
     setRemoteNotice(null)
     setError(null)
     try {
@@ -637,6 +643,7 @@ export default function DeploymentsPanel({
         name,
         preflight.workflow.hash,
         start,
+        setRemoteProgress,
         existing?.id,
         deploymentProject?.id,
         deploymentProject?.workflowSlug,
@@ -662,6 +669,7 @@ export default function DeploymentsPanel({
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setRemoteAction(null)
+      setRemoteProgress(null)
       setBusy(false)
     }
   }
@@ -1254,10 +1262,23 @@ export default function DeploymentsPanel({
                   </>
                 )}
               </div>
-              {remoteAction && (
-                <div className="bn-robot-step-status is-info">
-                  Synchronizing required packages and sending the workflow. This can take a few
-                  minutes the first time.
+              {remoteAction && remoteProgress && (
+                <div
+                  className="bn-device-install-progress bn-device-action-progress is-compact"
+                  role="progressbar"
+                  aria-label="Workflow deployment progress"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={Math.round(remoteProgress.progress)}
+                  aria-valuetext={remoteProgress.message}
+                >
+                  <div>
+                    <strong>{remoteProgress.message}</strong>
+                    <span>{Math.round(remoteProgress.progress)}%</span>
+                  </div>
+                  <span className="bn-device-install-progress-track" aria-hidden="true">
+                    <span style={{ width: `${remoteProgress.progress}%` }} />
+                  </span>
                 </div>
               )}
               {remoteNotice && !remoteAction && (

--- a/start.ps1
+++ b/start.ps1
@@ -6,10 +6,12 @@ $ServerOut = Join-Path $LogDir "server.out.log"
 $ServerErr = Join-Path $LogDir "server.err.log"
 $EditorOut = Join-Path $LogDir "editor.out.log"
 $EditorErr = Join-Path $LogDir "editor.err.log"
+$LauncherOwner = Join-Path $LogDir "launcher.owner"
 $VenvDir = if ($env:BLACKNODE_VENV) { $env:BLACKNODE_VENV } else { Join-Path $Root ".venv" }
 
 $BackendProcess = $null
 $FrontendProcess = $null
+$LauncherId = [guid]::NewGuid().ToString("N")
 $BackendPort = 7777
 $FrontendPort = 3000
 $EditorUrl = "http://localhost:$FrontendPort"
@@ -121,6 +123,35 @@ function Test-BlacknodeEditorReady {
     }
 
     return $false
+}
+
+function Test-BlacknodeBackendReady {
+    try {
+        $Response = Invoke-WebRequest `
+            -Uri "http://127.0.0.1:$BackendPort/device-hosts" `
+            -UseBasicParsing `
+            -TimeoutSec 2
+        return $Response.StatusCode -ge 200
+    } catch {
+        return $false
+    }
+}
+
+function Set-LauncherOwnership {
+    Set-Content -LiteralPath $LauncherOwner -Value $script:LauncherId -NoNewline
+}
+
+function Test-LauncherReplaced {
+    if (-not (Test-Path -LiteralPath $LauncherOwner)) {
+        return $false
+    }
+
+    try {
+        $CurrentOwner = (Get-Content -LiteralPath $LauncherOwner -Raw).Trim()
+        return $CurrentOwner -and $CurrentOwner -ne $script:LauncherId
+    } catch {
+        return $false
+    }
 }
 
 function Test-BlacknodeEditorProcessOnPort {
@@ -290,7 +321,11 @@ function Assert-ProcessRunning {
 
     $Process.Refresh()
     if (-not $Process.HasExited) {
-        return
+        return $true
+    }
+
+    if (Test-LauncherReplaced) {
+        return $false
     }
 
     Write-Host ""
@@ -416,6 +451,17 @@ try {
 
     New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
 
+    if (
+        $env:BLACKNODE_FORCE_RESTART -ne "1" `
+        -and $env:BLACKNODE_BOOTSTRAP_ONLY -ne "1" `
+        -and (Test-BlacknodeBackendReady) `
+        -and (Test-BlacknodeEditorReady)
+    ) {
+        Write-Step "Blacknode is already running. Reusing the active services."
+        Open-Browser
+        return
+    }
+
     $Python = Resolve-ProjectPython
     $Npm = Resolve-RequiredCommand -Names @("npm.cmd", "npm") -ErrorMessage "npm is required. Install Node.js 20.19+ or 22.12+."
 
@@ -451,6 +497,7 @@ try {
         return
     }
 
+    Set-LauncherOwnership
     Stop-PortListener -Port $BackendPort
     if (-not (Wait-PortFree -Port $BackendPort)) {
         Write-PortBusyError -Port $BackendPort
@@ -466,7 +513,10 @@ try {
         -ErrLog $ServerErr
 
     Start-Sleep -Seconds 3
-    Assert-ProcessRunning -Process $script:BackendProcess -Name "Python server" -ErrorLog $ServerErr
+    if (-not (Assert-ProcessRunning -Process $script:BackendProcess -Name "Python server" -ErrorLog $ServerErr)) {
+        Write-Step "Startup handed off to a newer Blacknode launcher."
+        return
+    }
 
     if (Test-PortInUse -Port $FrontendPort) {
         $ExistingBlacknodeEditor = (Wait-BlacknodeEditorReady) -or (Test-BlacknodeEditorProcessOnPort -Port $FrontendPort)
@@ -492,7 +542,10 @@ try {
         -ErrLog $EditorErr
 
     Start-Sleep -Seconds 5
-    Assert-ProcessRunning -Process $script:FrontendProcess -Name "Visual editor" -ErrorLog $EditorErr
+    if (-not (Assert-ProcessRunning -Process $script:FrontendProcess -Name "Visual editor" -ErrorLog $EditorErr)) {
+        Write-Step "Startup handed off to a newer Blacknode launcher."
+        return
+    }
 
     Open-Browser
     Write-Host ""
@@ -501,8 +554,14 @@ try {
     Write-Host ""
 
     while ($true) {
-        Assert-ProcessRunning -Process $script:BackendProcess -Name "Python server" -ErrorLog $ServerErr
-        Assert-ProcessRunning -Process $script:FrontendProcess -Name "Visual editor" -ErrorLog $EditorErr
+        if (-not (Assert-ProcessRunning -Process $script:BackendProcess -Name "Python server" -ErrorLog $ServerErr)) {
+            Write-Step "Blacknode was restarted by another launcher."
+            return
+        }
+        if (-not (Assert-ProcessRunning -Process $script:FrontendProcess -Name "Visual editor" -ErrorLog $EditorErr)) {
+            Write-Step "Blacknode was restarted by another launcher."
+            return
+        }
         Start-Sleep -Seconds 1
     }
 } finally {

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -4873,6 +4873,59 @@ class EditorDeviceApiTests(unittest.TestCase):
         )
         self.assertFalse(stage_request[3]["manifest"]["telemetry_required"])
 
+    def test_deployment_stream_reports_package_upload_and_start_progress(self):
+        hardware = _HardwareService()
+        workflow = _workflow([])
+        package_specs = [_target_package_spec()]
+        with (
+            patch("device_registry.urllib.request.urlopen", side_effect=hardware),
+            patch.object(
+                server,
+                "_workflow_target_package_specs",
+                return_value=package_specs,
+            ),
+            patch.object(
+                server,
+                "_workflow_target_packages",
+                return_value=[package_specs[0]["name"]],
+            ),
+        ):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            with patch.object(server, "_workflow_payload", return_value=workflow):
+                preflight = self.client.post(
+                    f"/devices/{device_id}/deployment-preflight",
+                    json={},
+                ).json()
+                response = self.client.post(
+                    f"/devices/{device_id}/deployments-stream",
+                    json={
+                        "name": "Camera workflow",
+                        "workflow_hash": preflight["workflow"]["hash"],
+                        "start": True,
+                    },
+                )
+
+        self.assertEqual(response.status_code, 200)
+        events = [
+            json.loads(line)
+            for line in response.text.splitlines()
+            if line.strip()
+        ]
+        progress = [event for event in events if event["type"] == "progress"]
+        self.assertEqual(progress[0]["progress"], 1)
+        self.assertEqual(progress[-1]["progress"], 100)
+        messages = [event["message"] for event in progress]
+        self.assertTrue(any("Synchronizing 1 required" in item for item in messages))
+        self.assertIn("Uploading the workflow bundle", messages)
+        self.assertTrue(any("replacing the previous workflow" in item for item in messages))
+        self.assertEqual(events[-1]["type"], "done")
+        self.assertTrue(events[-1]["result"]["started"])
+        self.assertEqual(events[-1]["result"]["deployment"]["state"], "running")
+
     def test_leader_follower_deployment_declares_one_remote_armed_gate(self):
         workflow = _workflow([])
         workflow["node_meta"]["follow"] = {

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -49,6 +49,23 @@ def test_windows_launcher_waits_for_backend_port_cleanup_before_starting():
     assert 'throw "Python server port is busy."' in powershell
 
 
+def test_windows_launcher_reuses_healthy_services_and_hands_off_cleanly():
+    powershell = (ROOT / "start.ps1").read_text(encoding="utf-8")
+
+    reuse = 'Write-Step "Blacknode is already running. Reusing the active services."'
+    ownership = "Set-LauncherOwnership"
+    stop = "Stop-PortListener -Port $BackendPort"
+
+    assert "Test-BlacknodeBackendReady" in powershell
+    assert "Test-BlacknodeEditorReady" in powershell
+    assert "BLACKNODE_FORCE_RESTART" in powershell
+    assert reuse in powershell
+    assert powershell.index(reuse) < powershell.index(ownership, powershell.index(reuse))
+    assert powershell.index(ownership, powershell.index(reuse)) < powershell.index(stop)
+    assert "Test-LauncherReplaced" in powershell
+    assert 'Write-Step "Blacknode was restarted by another launcher."' in powershell
+
+
 def test_windows_markdown_launch_commands_are_powershell_explicit():
     markdown_files = [ROOT / "README.md", *ROOT.joinpath("docs").rglob("*.md")]
     markdown_files.extend([


### PR DESCRIPTION
## What changed

- stream real workflow deployment phases from validation through package sync, upload, replacement, and start
- show those phases and percentages in the editor while Send or Send & run is active
- reuse an already healthy local backend/editor instead of killing them on repeated launcher starts
- add launcher ownership handoff so an older launcher exits cleanly when a newer forced restart replaces its processes

## Root cause

The deployment request used a single long-running JSON response, so the editor could only show static busy text. The Windows launcher also treated any child-process exit as a startup failure, including the expected exit caused by another launcher replacing that process, which produced the misleading repeated socket errors.

## Validation

- `.venv\Scripts\python.exe -m unittest discover -s tests` — 474 passed, 8 skipped
- `npm run build` — passed
- `cargo test` — passed
- PowerShell parser and bootstrap-only launcher check — passed
- healthy-service launcher reuse check — passed