### PR TITLE
Register ROS 2 relay and robot attachment nodes

### DIFF
--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -373,7 +373,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                         "ROS2TopicEcho",
                         "ROS2TopicList",
                         "ROS2TopicPublish",
-                        "ROS2TopicPublisher"
+                        "ROS2TopicPublisher",
+                        "ROS2TopicRelay"
                     ],
                     "dependencies": {
                         "requires": [{"component": "core"}]
@@ -435,6 +436,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "ROS2TopicList",
                 "ROS2TopicPublish",
                 "ROS2TopicPublisher",
+                "ROS2TopicRelay",
                 "ROS2VisualDashboard"
             ]
         },
@@ -487,6 +489,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "name": "capabilities",
                     "default": True,
                     "node_types": [
+                        "RobotAttachment",
+                        "RobotAttachmentList",
                         "RobotCapabilityBinding",
                         "RobotCapabilityInspect",
                         "RobotCapabilityList",
@@ -508,6 +512,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "description": "Generic robot setup: USB discovery, serial permission diagnostics, driver launch, and standard robot profiles.",
             "node_types": [
                 "Robot",
+                "RobotAttachment",
+                "RobotAttachmentList",
                 "RobotCalibrationRecorder",
                 "RobotCapabilityBinding",
                 "RobotCapabilityInspect",


### PR DESCRIPTION
## Summary
- register the generic ROS 2 topic relay in the official package catalog
- register robot attachment and attachment-list nodes in the official package catalog
- keep package catalog validation synchronized with the extension manifests

## Validation
- catalog validation passes for blacknode-ros2 and blacknode-robot
- 474 core tests pass (8 skipped)