### PR TITLE
Add robot attachment management UI

### DIFF
--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 import threading
@@ -17,6 +18,19 @@ from typing import Any
 
 _MAX_RESPONSE_BYTES = 1024 * 1024
 _ID_RE = re.compile(r"[^a-z0-9]+")
+_ATTACHMENT_ID_RE = re.compile(r"[^a-z0-9]+")
+_ROS_MESSAGE_TYPE_RE = re.compile(
+    r"^[A-Za-z][A-Za-z0-9_]*/(?:msg|srv|action)/[A-Za-z][A-Za-z0-9_]*$"
+)
+_ATTACHMENT_TYPES = {
+    "camera",
+    "depth_camera",
+    "lidar",
+    "imu",
+    "gps",
+    "microphone",
+    "custom",
+}
 
 
 class DeviceRegistryError(RuntimeError):
@@ -63,6 +77,199 @@ def default_runtime_url(hardware_url: str) -> str:
 
 def _slug(value: str) -> str:
     return _ID_RE.sub("-", value.strip().lower()).strip("-")[:48] or "device"
+
+
+def _attachment_identifier(value: Any, fallback: str = "attachment") -> str:
+    text = _ATTACHMENT_ID_RE.sub(
+        "_",
+        str(value or "").strip().lower(),
+    ).strip("_")
+    if not text:
+        text = fallback
+    if not text[0].isalpha():
+        text = f"attachment_{text}"
+    return text[:64]
+
+
+def _finite_attachment_number(value: Any, field: str) -> float:
+    try:
+        result = float(value or 0.0)
+    except (TypeError, ValueError) as exc:
+        raise DeviceRegistryError(f"{field} must be a number.") from exc
+    if not math.isfinite(result):
+        raise DeviceRegistryError(f"{field} must be finite.")
+    return result
+
+
+def _normalize_attachment(
+    values: dict[str, Any],
+    *,
+    existing_id: str = "",
+) -> dict[str, Any]:
+    requested_id = _attachment_identifier(
+        values.get("attachment_id")
+        or values.get("id")
+        or values.get("display_name"),
+    )
+    if existing_id and requested_id != existing_id:
+        raise DeviceRegistryError(
+            "Attachment IDs are stable. Duplicate the attachment to use a new ID."
+        )
+    attachment_id = existing_id or requested_id
+    display_name = str(
+        values.get("display_name")
+        or attachment_id.replace("_", " ").title()
+    ).strip()
+    if not display_name:
+        raise DeviceRegistryError("Attachment name is required.")
+    attachment_type = str(
+        values.get("attachment_type") or "custom"
+    ).strip().lower()
+    if attachment_type not in _ATTACHMENT_TYPES:
+        raise DeviceRegistryError(
+            "Attachment type must be camera, depth camera, LiDAR, IMU, GPS, "
+            "microphone, or custom."
+        )
+    capability = _attachment_identifier(
+        values.get("capability") or attachment_type,
+        attachment_type,
+    )
+    provider = values.get("provider") if isinstance(values.get("provider"), dict) else {}
+    provider_package = str(
+        values.get("provider_package") or provider.get("package") or ""
+    ).strip()
+    provider_component = str(
+        values.get("provider_component") or provider.get("component") or ""
+    ).strip()
+    provider_adapter = str(
+        values.get("provider_adapter") or provider.get("adapter") or "ros2"
+    ).strip()
+    if not provider_package or not provider_component:
+        raise DeviceRegistryError(
+            "Attachment provider package and component are required."
+        )
+    topic = str(values.get("topic") or "").strip()
+    if not topic.startswith("/") or any(character.isspace() for character in topic):
+        raise DeviceRegistryError(
+            "ROS 2 topic must start with / and cannot contain spaces."
+        )
+    message_type = str(values.get("message_type") or "").strip()
+    if not _ROS_MESSAGE_TYPE_RE.fullmatch(message_type):
+        raise DeviceRegistryError(
+            "ROS 2 message type must look like sensor_msgs/msg/Image."
+        )
+    parent_frame = str(values.get("parent_frame") or "base_link").strip()
+    frame_id = str(values.get("frame_id") or f"{attachment_id}_link").strip()
+    if not parent_frame or not frame_id:
+        raise DeviceRegistryError("Parent frame and attachment frame are required.")
+    if any(character.isspace() for character in parent_frame + frame_id):
+        raise DeviceRegistryError("ROS 2 frame names cannot contain spaces.")
+    mount = values.get("mount") if isinstance(values.get("mount"), dict) else {}
+    translation = (
+        mount.get("translation_m")
+        if isinstance(mount.get("translation_m"), list)
+        else []
+    )
+    rotation = (
+        mount.get("rotation_rpy_rad")
+        if isinstance(mount.get("rotation_rpy_rad"), list)
+        else []
+    )
+    x_m = values.get("x_m", translation[0] if len(translation) > 0 else 0.0)
+    y_m = values.get("y_m", translation[1] if len(translation) > 1 else 0.0)
+    z_m = values.get("z_m", translation[2] if len(translation) > 2 else 0.0)
+    roll_rad = values.get(
+        "roll_rad",
+        rotation[0] if len(rotation) > 0 else 0.0,
+    )
+    pitch_rad = values.get(
+        "pitch_rad",
+        rotation[1] if len(rotation) > 1 else 0.0,
+    )
+    yaw_rad = values.get(
+        "yaw_rad",
+        rotation[2] if len(rotation) > 2 else 0.0,
+    )
+    hardware_identity = (
+        values.get("hardware_identity")
+        if isinstance(values.get("hardware_identity"), dict)
+        else {}
+    )
+    hardware_id = str(
+        values.get("hardware_id") or hardware_identity.get("id") or ""
+    ).strip()
+    required = bool(values.get("required", True))
+    enabled = bool(values.get("enabled", True))
+    provider_record = {
+        "package": provider_package,
+        "component": provider_component,
+        "adapter": provider_adapter,
+    }
+    interface = {
+        "kind": "topic",
+        "direction": "output",
+        "topic": topic,
+        "candidates": [topic],
+        "message_type": message_type,
+        "frame_id": frame_id,
+    }
+    mount_record = {
+        "translation_m": [
+            _finite_attachment_number(x_m, "Mount X"),
+            _finite_attachment_number(y_m, "Mount Y"),
+            _finite_attachment_number(z_m, "Mount Z"),
+        ],
+        "rotation_rpy_rad": [
+            _finite_attachment_number(roll_rad, "Mount roll"),
+            _finite_attachment_number(pitch_rad, "Mount pitch"),
+            _finite_attachment_number(yaw_rad, "Mount yaw"),
+        ],
+    }
+    identity_record = {
+        "id": hardware_id,
+        "serial": str(hardware_identity.get("serial") or "").strip(),
+        "vendor_id": str(hardware_identity.get("vendor_id") or "").strip(),
+        "product_id": str(hardware_identity.get("product_id") or "").strip(),
+        "path": str(hardware_identity.get("path") or "").strip(),
+    }
+    configuration = {
+        "attachment_id": attachment_id,
+        "attachment_type": attachment_type,
+        "parent_frame": parent_frame,
+        "frame_id": frame_id,
+        "mount": mount_record,
+        "ros2_interfaces": [interface],
+    }
+    binding = {
+        "kind": "blacknode.robot-capability-binding",
+        "schema_version": 1,
+        "capability": capability,
+        "provider": provider_record,
+        "configuration": configuration,
+        "hardware_identity": identity_record,
+        "required": required,
+    }
+    attachment = {
+        "kind": "blacknode.robot-attachment",
+        "schema_version": 1,
+        "id": attachment_id,
+        "display_name": display_name,
+        "attachment_type": attachment_type,
+        "capability": capability,
+        "provider": provider_record,
+        "hardware_identity": identity_record,
+        "parent_frame": parent_frame,
+        "frame_id": frame_id,
+        "mount": mount_record,
+        "interfaces": [interface],
+        "required": required,
+        "enabled": enabled,
+        "binding": binding,
+    }
+    previous_check = values.get("last_check")
+    if isinstance(previous_check, dict):
+        attachment["last_check"] = dict(previous_check)
+    return attachment
 
 
 def _host_id(runtime_url: str) -> str:
@@ -832,6 +1039,11 @@ class DeviceRegistry:
                     or str((existing or {}).get("software_version") or "").strip()
                 ),
                 "paused": False,
+                "attachments": [
+                    dict(item)
+                    for item in ((existing or {}).get("attachments") or [])
+                    if isinstance(item, dict)
+                ],
                 "created_at": created_at,
                 "updated_at": now,
             }
@@ -908,6 +1120,125 @@ class DeviceRegistry:
             record["updated_at"] = _iso_now()
             self._save_payload(hosts, records)
             return self._public(record)
+
+    def save_attachment(
+        self,
+        device_id: str,
+        values: dict[str, Any],
+        *,
+        attachment_id: str = "",
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        with self._lock:
+            hosts, records = self._load_payload()
+            record = records.get(device_id)
+            if record is None:
+                raise KeyError(device_id)
+            clean_existing_id = (
+                _attachment_identifier(attachment_id)
+                if attachment_id
+                else ""
+            )
+            attachment = _normalize_attachment(
+                values,
+                existing_id=clean_existing_id,
+            )
+            attachments = [
+                dict(item)
+                for item in (record.get("attachments") or [])
+                if isinstance(item, dict) and str(item.get("id") or "")
+            ]
+            index = next(
+                (
+                    index
+                    for index, item in enumerate(attachments)
+                    if str(item.get("id") or "") == attachment["id"]
+                ),
+                None,
+            )
+            if clean_existing_id:
+                if index is None:
+                    raise KeyError(clean_existing_id)
+                attachments[index] = attachment
+            elif index is not None:
+                raise DeviceRegistryError(
+                    f"Attachment '{attachment['id']}' already exists."
+                )
+            else:
+                attachments.append(attachment)
+            attachments.sort(
+                key=lambda item: (
+                    str(item.get("display_name") or "").casefold(),
+                    str(item.get("id") or ""),
+                )
+            )
+            record["attachments"] = attachments
+            record["updated_at"] = _iso_now()
+            records[device_id] = record
+            self._save_payload(hosts, records)
+            return self._public(record), attachment
+
+    def delete_attachment(
+        self,
+        device_id: str,
+        attachment_id: str,
+    ) -> dict[str, Any]:
+        clean_id = _attachment_identifier(attachment_id)
+        with self._lock:
+            hosts, records = self._load_payload()
+            record = records.get(device_id)
+            if record is None:
+                raise KeyError(device_id)
+            attachments = [
+                dict(item)
+                for item in (record.get("attachments") or [])
+                if isinstance(item, dict) and str(item.get("id") or "")
+            ]
+            filtered = [
+                item
+                for item in attachments
+                if str(item.get("id") or "") != clean_id
+            ]
+            if len(filtered) == len(attachments):
+                raise KeyError(clean_id)
+            record["attachments"] = filtered
+            record["updated_at"] = _iso_now()
+            records[device_id] = record
+            self._save_payload(hosts, records)
+            return self._public(record)
+
+    def remember_attachment_check(
+        self,
+        device_id: str,
+        attachment_id: str,
+        check: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        clean_id = _attachment_identifier(attachment_id)
+        with self._lock:
+            hosts, records = self._load_payload()
+            record = records.get(device_id)
+            if record is None:
+                raise KeyError(device_id)
+            attachments = [
+                dict(item)
+                for item in (record.get("attachments") or [])
+                if isinstance(item, dict) and str(item.get("id") or "")
+            ]
+            attachment = next(
+                (
+                    item
+                    for item in attachments
+                    if str(item.get("id") or "") == clean_id
+                ),
+                None,
+            )
+            if attachment is None:
+                raise KeyError(clean_id)
+            attachment["last_check"] = dict(check)
+            record["attachments"] = attachments
+            record["updated_at"] = _iso_now()
+            records[device_id] = record
+            self._save_payload(hosts, records)
+            return self._public(record), attachment
 
     def _load_payload(
         self,

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -492,6 +492,30 @@ class RobotLifecycleReq(BaseModel):
 class RenameDeviceReq(BaseModel):
     name: str
 
+
+class RobotAttachmentReq(BaseModel):
+    attachment_id: str
+    display_name: str
+    attachment_type: str
+    capability: str
+    provider_package: str
+    provider_component: str
+    provider_adapter: str = "ros2"
+    topic: str
+    message_type: str
+    parent_frame: str = "base_link"
+    frame_id: str
+    x_m: float = 0.0
+    y_m: float = 0.0
+    z_m: float = 0.0
+    roll_rad: float = 0.0
+    pitch_rad: float = 0.0
+    yaw_rad: float = 0.0
+    hardware_id: str = ""
+    required: bool = True
+    enabled: bool = True
+
+
 class DeploymentPreflightReq(BaseModel):
     # Omit to validate the graph currently open in the editor.
     workflow: dict[str, Any] | None = None
@@ -5145,6 +5169,268 @@ def get_device(device_id: str):
     return device
 
 
+def _robot_attachment_values(req: RobotAttachmentReq) -> dict[str, Any]:
+    return {
+        "attachment_id": req.attachment_id,
+        "display_name": req.display_name,
+        "attachment_type": req.attachment_type,
+        "capability": req.capability,
+        "provider_package": req.provider_package,
+        "provider_component": req.provider_component,
+        "provider_adapter": req.provider_adapter,
+        "topic": req.topic,
+        "message_type": req.message_type,
+        "parent_frame": req.parent_frame,
+        "frame_id": req.frame_id,
+        "x_m": req.x_m,
+        "y_m": req.y_m,
+        "z_m": req.z_m,
+        "roll_rad": req.roll_rad,
+        "pitch_rad": req.pitch_rad,
+        "yaw_rad": req.yaw_rad,
+        "hardware_id": req.hardware_id,
+        "required": req.required,
+        "enabled": req.enabled,
+    }
+
+
+def _attachment_primary_interface(
+    attachment: dict[str, Any],
+) -> dict[str, Any]:
+    return next(
+        (
+            dict(item)
+            for item in (attachment.get("interfaces") or [])
+            if isinstance(item, dict)
+            and str(item.get("kind") or "topic") == "topic"
+            and str(item.get("topic") or "")
+        ),
+        {},
+    )
+
+
+def _attachment_topic_check(
+    attachment: dict[str, Any],
+    diagnostics: dict[str, Any],
+) -> dict[str, Any]:
+    interface = _attachment_primary_interface(attachment)
+    topic = str(interface.get("topic") or "")
+    expected_type = str(interface.get("message_type") or "")
+    checked_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    if not diagnostics.get("available", diagnostics.get("ok", False)):
+        return {
+            "ok": False,
+            "status": "unavailable",
+            "topic": topic,
+            "expected_message_type": expected_type,
+            "actual_message_type": "",
+            "publisher_count": None,
+            "checked_at": checked_at,
+            "message": str(
+                diagnostics.get("error")
+                or diagnostics.get("summary")
+                or "ROS 2 diagnostics are unavailable on this device."
+            ),
+        }
+
+    actual_type = ""
+    topic_found = False
+    for value in diagnostics.get("topics") or []:
+        if isinstance(value, dict):
+            candidate_topic = str(value.get("name") or value.get("topic") or "")
+            candidate_type = str(value.get("type") or value.get("message_type") or "")
+        else:
+            text = str(value or "")
+            match = re.match(r"^(\S+)\s+\[([^\]]+)\]\s*$", text)
+            candidate_topic = match.group(1) if match else text.strip()
+            candidate_type = match.group(2) if match else ""
+        if candidate_topic == topic:
+            topic_found = True
+            actual_type = candidate_type
+            break
+    if not topic_found:
+        return {
+            "ok": False,
+            "status": "missing",
+            "topic": topic,
+            "expected_message_type": expected_type,
+            "actual_message_type": "",
+            "publisher_count": 0,
+            "checked_at": checked_at,
+            "message": f"{topic} is not present in the live ROS 2 graph.",
+        }
+    if actual_type and expected_type and actual_type != expected_type:
+        return {
+            "ok": False,
+            "status": "type_mismatch",
+            "topic": topic,
+            "expected_message_type": expected_type,
+            "actual_message_type": actual_type,
+            "publisher_count": None,
+            "checked_at": checked_at,
+            "message": (
+                f"{topic} publishes {actual_type}, but this attachment expects "
+                f"{expected_type}."
+            ),
+        }
+
+    publisher_count: int | None = None
+    topic_detail = next(
+        (
+            item
+            for item in (diagnostics.get("topic_details") or [])
+            if isinstance(item, dict)
+            and str(item.get("topic") or "") == topic
+        ),
+        None,
+    )
+    if topic_detail and topic_detail.get("ok", True):
+        match = re.search(
+            r"Publisher count:\s*(\d+)",
+            str(topic_detail.get("stdout") or ""),
+            re.IGNORECASE,
+        )
+        if match:
+            publisher_count = int(match.group(1))
+    if publisher_count == 0:
+        return {
+            "ok": False,
+            "status": "no_publisher",
+            "topic": topic,
+            "expected_message_type": expected_type,
+            "actual_message_type": actual_type or expected_type,
+            "publisher_count": 0,
+            "checked_at": checked_at,
+            "message": f"{topic} exists, but no ROS 2 publisher is active.",
+        }
+    if publisher_count is None:
+        return {
+            "ok": True,
+            "status": "topic_present",
+            "topic": topic,
+            "expected_message_type": expected_type,
+            "actual_message_type": actual_type or expected_type,
+            "publisher_count": None,
+            "checked_at": checked_at,
+            "message": (
+                f"{topic} is present with the expected type. Publisher count "
+                "was not sampled."
+            ),
+        }
+    return {
+        "ok": True,
+        "status": "streaming",
+        "topic": topic,
+        "expected_message_type": expected_type,
+        "actual_message_type": actual_type or expected_type,
+        "publisher_count": publisher_count,
+        "checked_at": checked_at,
+        "message": (
+            f"{topic} has {publisher_count} active ROS 2 "
+            f"publisher{'s' if publisher_count != 1 else ''}."
+        ),
+    }
+
+
+@app.get("/devices/{device_id}/attachments")
+def list_robot_attachments(device_id: str):
+    try:
+        device = _device_registry.get_public(device_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    if device is None:
+        raise HTTPException(404, "Device not found")
+    return {
+        "device_id": device_id,
+        "attachments": list(device.get("attachments") or []),
+    }
+
+
+@app.post("/devices/{device_id}/attachments")
+def create_robot_attachment(device_id: str, req: RobotAttachmentReq):
+    try:
+        device, attachment = _device_registry.save_attachment(
+            device_id,
+            _robot_attachment_values(req),
+        )
+    except KeyError as exc:
+        raise HTTPException(404, "Device not found") from exc
+    except DeviceRegistryError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    return {"device": device, "attachment": attachment}
+
+
+@app.put("/devices/{device_id}/attachments/{attachment_id}")
+def update_robot_attachment(
+    device_id: str,
+    attachment_id: str,
+    req: RobotAttachmentReq,
+):
+    try:
+        device, attachment = _device_registry.save_attachment(
+            device_id,
+            _robot_attachment_values(req),
+            attachment_id=attachment_id,
+        )
+    except KeyError as exc:
+        raise HTTPException(404, "Device or attachment not found") from exc
+    except DeviceRegistryError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    return {"device": device, "attachment": attachment}
+
+
+@app.delete("/devices/{device_id}/attachments/{attachment_id}")
+def delete_robot_attachment(device_id: str, attachment_id: str):
+    try:
+        device = _device_registry.delete_attachment(device_id, attachment_id)
+    except KeyError as exc:
+        raise HTTPException(404, "Device or attachment not found") from exc
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    return {"ok": True, "device": device, "id": attachment_id}
+
+
+@app.post("/devices/{device_id}/attachments/{attachment_id}/check")
+def check_robot_attachment(device_id: str, attachment_id: str):
+    try:
+        device = _device_registry.get_public(device_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    if device is None:
+        raise HTTPException(404, "Device not found")
+    attachment = next(
+        (
+            item
+            for item in (device.get("attachments") or [])
+            if isinstance(item, dict)
+            and str(item.get("id") or "") == attachment_id
+        ),
+        None,
+    )
+    if attachment is None:
+        raise HTTPException(404, "Attachment not found")
+    try:
+        diagnostics = _runtime_client_or_404(device_id).ros2_diagnostics()
+    except DeviceRegistryError as exc:
+        raise HTTPException(502, str(exc)) from exc
+    check = _attachment_topic_check(attachment, diagnostics)
+    try:
+        updated_device, updated_attachment = (
+            _device_registry.remember_attachment_check(
+                device_id,
+                attachment_id,
+                check,
+            )
+        )
+    except KeyError as exc:
+        raise HTTPException(404, "Device or attachment not found") from exc
+    return {
+        "device": updated_device,
+        "attachment": updated_attachment,
+        "check": check,
+    }
+
+
 @app.patch("/devices/{device_id}")
 def rename_device(device_id: str, req: RenameDeviceReq):
     try:
@@ -6030,6 +6316,24 @@ def _device_deployment_hash(workflow: dict[str, Any]) -> str:
         separators=(",", ":"),
     ).encode("utf-8")
     return hashlib.sha256(canonical).hexdigest()
+
+
+def _device_deployment_attachments(device_id: str) -> list[dict[str, Any]]:
+    """Return enabled robot attachments as stable deployment configuration."""
+    try:
+        device = _device_registry.get_public(device_id)
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    if device is None:
+        raise HTTPException(404, "Device not found")
+    attachments: list[dict[str, Any]] = []
+    for item in device.get("attachments") or []:
+        if not isinstance(item, dict) or item.get("enabled") is False:
+            continue
+        attachment = json.loads(json.dumps(item))
+        attachment.pop("last_check", None)
+        attachments.append(attachment)
+    return attachments
 
 
 @app.post("/devices/{device_id}/deployment-preflight")
@@ -7173,6 +7477,7 @@ def _stage_device_deployment_payload(
             "Deployment preflight failed: " + "; ".join(blocking[:3]),
         )
 
+    robot_attachments = _device_deployment_attachments(device_id)
     report(28, "Exporting the workflow with motion disarmed")
     try:
         _bind_robot_to_device(workflow, preflight.get("status") or {})
@@ -7211,6 +7516,7 @@ def _stage_device_deployment_payload(
             "blacknode_version": str(getattr(bn, "__version__", "")),
             "runtime_protocol_version": runtime_manifest.get("protocol_version"),
             "target_device_id": device_id,
+            "robot_attachments": robot_attachments,
             "created_at": datetime.now().astimezone().isoformat(timespec="seconds"),
             **deployment_owner,
         },

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -91,6 +91,94 @@ export interface ApiKeyStatus {
   env_var: string
 }
 
+export type RobotAttachmentType =
+  | 'camera'
+  | 'depth_camera'
+  | 'lidar'
+  | 'imu'
+  | 'gps'
+  | 'microphone'
+  | 'custom'
+
+export interface RobotAttachmentCheck {
+  ok: boolean
+  status:
+    | 'streaming'
+    | 'topic_present'
+    | 'missing'
+    | 'no_publisher'
+    | 'type_mismatch'
+    | 'unavailable'
+  topic: string
+  expected_message_type: string
+  actual_message_type: string
+  publisher_count: number | null
+  checked_at: string
+  message: string
+}
+
+export interface RobotAttachment {
+  kind: 'blacknode.robot-attachment'
+  schema_version: 1
+  id: string
+  display_name: string
+  attachment_type: RobotAttachmentType
+  capability: string
+  provider: {
+    package: string
+    component: string
+    adapter: string
+  }
+  hardware_identity: {
+    id: string
+    serial?: string
+    vendor_id?: string
+    product_id?: string
+    path?: string
+  }
+  parent_frame: string
+  frame_id: string
+  mount: {
+    translation_m: [number, number, number]
+    rotation_rpy_rad: [number, number, number]
+  }
+  interfaces: Array<{
+    kind: 'topic'
+    direction: 'output'
+    topic: string
+    candidates: string[]
+    message_type: string
+    frame_id: string
+  }>
+  required: boolean
+  enabled: boolean
+  last_check?: RobotAttachmentCheck
+  binding: Record<string, unknown>
+}
+
+export interface RobotAttachmentInput {
+  attachment_id: string
+  display_name: string
+  attachment_type: RobotAttachmentType
+  capability: string
+  provider_package: string
+  provider_component: string
+  provider_adapter: string
+  topic: string
+  message_type: string
+  parent_frame: string
+  frame_id: string
+  x_m: number
+  y_m: number
+  z_m: number
+  roll_rad: number
+  pitch_rad: number
+  yaw_rad: number
+  hardware_id: string
+  required: boolean
+  enabled: boolean
+}
+
 export interface HardwareDevice {
   id: string
   name: string
@@ -103,6 +191,7 @@ export interface HardwareDevice {
   runtime_token_configured?: boolean
   software_version?: string
   paused?: boolean
+  attachments?: RobotAttachment[]
   created_at: string
   updated_at: string
 }
@@ -1469,6 +1558,43 @@ export const api = {
     ),
   deviceStatus:     (id: string) =>
     req<HardwareDeviceStatus>('GET', `/devices/${encodeURIComponent(id)}/status`, undefined, 7000),
+  listRobotAttachments: (id: string) =>
+    req<{ device_id: string; attachments: RobotAttachment[] }>(
+      'GET',
+      `/devices/${encodeURIComponent(id)}/attachments`,
+    ),
+  createRobotAttachment: (id: string, attachment: RobotAttachmentInput) =>
+    req<{ device: HardwareDevice; attachment: RobotAttachment }>(
+      'POST',
+      `/devices/${encodeURIComponent(id)}/attachments`,
+      attachment,
+    ),
+  updateRobotAttachment: (
+    id: string,
+    attachmentId: string,
+    attachment: RobotAttachmentInput,
+  ) =>
+    req<{ device: HardwareDevice; attachment: RobotAttachment }>(
+      'PUT',
+      `/devices/${encodeURIComponent(id)}/attachments/${encodeURIComponent(attachmentId)}`,
+      attachment,
+    ),
+  deleteRobotAttachment: (id: string, attachmentId: string) =>
+    req<{ ok: boolean; id: string; device: HardwareDevice }>(
+      'DELETE',
+      `/devices/${encodeURIComponent(id)}/attachments/${encodeURIComponent(attachmentId)}`,
+    ),
+  checkRobotAttachment: (id: string, attachmentId: string) =>
+    req<{
+      device: HardwareDevice
+      attachment: RobotAttachment
+      check: RobotAttachmentCheck
+    }>(
+      'POST',
+      `/devices/${encodeURIComponent(id)}/attachments/${encodeURIComponent(attachmentId)}/check`,
+      {},
+      90000,
+    ),
   deviceMonitor:    (id: string) =>
     req<RobotTelemetrySample>(
       'GET',

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -15,6 +15,7 @@ import {
   type SshRuntimeInspection,
 } from '../api'
 import { useStore } from '../store'
+import { RobotAttachmentsPanel } from './RobotAttachmentsPanel'
 import { RobotLiveMonitor } from './RobotMonitorNode'
 
 type RobotState = {
@@ -529,6 +530,18 @@ export default function DevicesPanel() {
   const rosChecksInFlight = useRef(new Set<string>())
 
   const selectedDevice = devices.find(device => device.id === selectedDeviceId) ?? null
+  const rememberUpdatedRobot = (updatedRobot: HardwareDevice) => {
+    setDevices(current => current.map(device => (
+      device.robots.some(robot => robot.id === updatedRobot.id)
+        ? {
+            ...device,
+            robots: device.robots.map(robot => (
+              robot.id === updatedRobot.id ? updatedRobot : robot
+            )),
+          }
+        : device
+    )))
+  }
   const selectedRosHealth = selectedDevice
     ? rosHealthByDevice[selectedDevice.id]
     : undefined
@@ -4675,6 +4688,7 @@ export default function DevicesPanel() {
                 onReleaseTorque={() => releaseRobotTorque(robot)}
                 onControl={action => controlRobot(robot, action)}
                 onRestartService={password => controlRobot(robot, 'restart', password)}
+                onRobotUpdated={rememberUpdatedRobot}
               />
             ))}
           </div>
@@ -4911,6 +4925,7 @@ function RobotRow({
   onReleaseTorque,
   onControl,
   onRestartService,
+  onRobotUpdated,
 }: {
   robot: HardwareDevice
   state?: RobotState
@@ -4938,9 +4953,11 @@ function RobotRow({
   onReleaseTorque: () => void
   onControl: (action: 'pause' | 'resume') => void
   onRestartService: (password: string) => Promise<boolean>
+  onRobotUpdated: (robot: HardwareDevice) => void
 }) {
   const [expanded, setExpanded] = useState(false)
   const [showMonitor, setShowMonitor] = useState(false)
+  const [showAttachments, setShowAttachments] = useState(false)
   const [showRestart, setShowRestart] = useState(false)
   const [showTorqueDetails, setShowTorqueDetails] = useState(false)
   const [restartPassword, setRestartPassword] = useState('')
@@ -5111,6 +5128,7 @@ function RobotRow({
             <span>{robot.remote_device_id}</span>
             <span>token {robot.token_fingerprint}</span>
             {status?.joint_names && <span>{status.joint_names.length} joints</span>}
+            <span>{robot.attachments?.length ?? 0} attachments</span>
           </div>
           {state?.error && (
             <div className="bn-run-error-line bn-device-error" role="alert">{state.error}</div>
@@ -5290,6 +5308,17 @@ function RobotRow({
             >
               {showMonitor ? 'Hide monitor' : 'Monitor'}
             </button>
+            <button
+              type="button"
+              onClick={() => setShowAttachments(current => !current)}
+              className={`bn-device-action-button${showAttachments ? ' is-primary' : ''}`}
+              aria-expanded={showAttachments}
+              title="Add and check cameras, LiDAR, IMU, and other ROS 2 attachments"
+            >
+              {showAttachments
+                ? 'Hide attachments'
+                : `Attachments (${robot.attachments?.length ?? 0})`}
+            </button>
             {runningDeployment?.id && (
               <button
                 type="button"
@@ -5338,6 +5367,12 @@ function RobotRow({
                 emptyMessage=""
               />
             </div>
+          )}
+          {showAttachments && (
+            <RobotAttachmentsPanel
+              robot={robot}
+              onRobotUpdated={onRobotUpdated}
+            />
           )}
           <div className="bn-run-detail-actions bn-robot-card-actions is-secondary">
             <button

--- a/editor/src/components/RobotAttachmentsPanel.css
+++ b/editor/src/components/RobotAttachmentsPanel.css
@@ -1,0 +1,298 @@
+.bn-robot-attachments {
+  margin-top: 10px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #00d2ff 62%, var(--line));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 94%, #00151b);
+}
+
+.bn-robot-attachments-head,
+.bn-robot-attachment-form-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--line);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, #00d2ff 11%, transparent), transparent 65%),
+    var(--lift);
+}
+
+.bn-robot-attachments-head > div,
+.bn-robot-attachment-form-title > div {
+  min-width: 0;
+}
+
+.bn-robot-attachments-head strong,
+.bn-robot-attachments-head span,
+.bn-robot-attachment-form-title strong,
+.bn-robot-attachment-form-title span {
+  display: block;
+}
+
+.bn-robot-attachments-head strong,
+.bn-robot-attachment-form-title strong {
+  color: var(--tx1);
+  font-size: 13px;
+}
+
+.bn-robot-attachments-head span,
+.bn-robot-attachment-form-title span {
+  margin-top: 3px;
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.bn-robot-attachments-empty {
+  display: grid;
+  justify-items: start;
+  gap: 6px;
+  margin: 10px;
+  padding: 14px;
+  border: 1px dashed var(--line2);
+  border-radius: 6px;
+  color: var(--tx3);
+  font-size: 12px;
+}
+
+.bn-robot-attachments-empty strong {
+  color: var(--tx1);
+}
+
+.bn-robot-attachment-list {
+  display: grid;
+  gap: 9px;
+  padding: 10px;
+}
+
+.bn-robot-attachment-card {
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--lift);
+}
+
+.bn-robot-attachment-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.bn-robot-attachment-card-head > div {
+  min-width: 0;
+}
+
+.bn-robot-attachment-card-head strong,
+.bn-robot-attachment-kind {
+  display: block;
+}
+
+.bn-robot-attachment-card-head strong {
+  margin-top: 3px;
+  overflow: hidden;
+  color: var(--tx1);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-robot-attachment-kind {
+  color: #00d2ff;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.bn-robot-attachment-status {
+  flex: 0 0 auto;
+  padding: 3px 7px;
+  border: 1px solid var(--line2);
+  border-radius: 999px;
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: .04em;
+}
+
+.bn-robot-attachment-status.is-healthy {
+  border-color: color-mix(in srgb, var(--ok) 70%, var(--line));
+  color: var(--ok);
+}
+
+.bn-robot-attachment-status.is-present {
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--line));
+  color: var(--accent);
+}
+
+.bn-robot-attachment-status.is-attention {
+  border-color: color-mix(in srgb, var(--warn) 70%, var(--line));
+  color: var(--warn);
+}
+
+.bn-robot-attachment-status.is-disabled {
+  opacity: .7;
+}
+
+.bn-robot-attachment-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px 12px;
+  margin: 10px 0 0;
+}
+
+.bn-robot-attachment-facts div {
+  min-width: 0;
+}
+
+.bn-robot-attachment-facts dt {
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.bn-robot-attachment-facts dd {
+  overflow: hidden;
+  margin: 2px 0 0;
+  color: var(--tx2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-robot-attachment-message {
+  margin: 9px 0 0;
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.bn-robot-attachment-actions,
+.bn-robot-attachment-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 9px;
+}
+
+.bn-robot-attachment-actions .bn-device-action-button {
+  min-height: 30px;
+}
+
+.bn-robot-attachment-form {
+  padding-bottom: 11px;
+}
+
+.bn-robot-attachment-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+  padding: 11px 12px 0;
+}
+
+.bn-robot-attachment-form-grid label {
+  min-width: 0;
+}
+
+.bn-robot-attachment-form-grid label.is-wide {
+  grid-column: 1 / -1;
+}
+
+.bn-robot-attachment-form-grid label > span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--tx3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.bn-robot-attachment-form-grid input,
+.bn-robot-attachment-form-grid select {
+  width: 100%;
+  min-height: 34px;
+  padding: 6px 8px;
+  border: 1px solid var(--line2);
+  border-radius: 5px;
+  outline: none;
+  background: var(--panel);
+  color: var(--tx1);
+  font: 12px var(--font-ui);
+}
+
+.bn-robot-attachment-form-grid input:focus,
+.bn-robot-attachment-form-grid select:focus {
+  border-color: #00d2ff;
+  box-shadow: 0 0 0 2px color-mix(in srgb, #00d2ff 12%, transparent);
+}
+
+.bn-robot-attachment-form-grid input:disabled,
+.bn-robot-attachment-form-grid select:disabled {
+  color: var(--tx3);
+  cursor: not-allowed;
+  opacity: .7;
+}
+
+.bn-robot-attachment-advanced {
+  margin: 11px 12px 0;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+}
+
+.bn-robot-attachment-advanced summary {
+  padding: 9px 10px;
+  color: var(--tx2);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.bn-robot-attachment-advanced .bn-robot-attachment-form-grid {
+  padding: 2px 10px 10px;
+}
+
+.bn-robot-attachment-switches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  padding: 11px 12px 0;
+}
+
+.bn-robot-attachment-switches label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--tx2);
+  font-size: 11px;
+}
+
+.bn-robot-attachment-form-actions {
+  justify-content: flex-end;
+  padding: 0 12px;
+}
+
+@media (max-width: 760px) {
+  .bn-robot-attachment-facts,
+  .bn-robot-attachment-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bn-robot-attachment-form-grid label.is-wide {
+    grid-column: auto;
+  }
+
+  .bn-robot-attachments-head,
+  .bn-robot-attachment-form-title {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/editor/src/components/RobotAttachmentsPanel.tsx
+++ b/editor/src/components/RobotAttachmentsPanel.tsx
@@ -1,0 +1,621 @@
+import { useState, type FormEvent } from 'react'
+import {
+  api,
+  type HardwareDevice,
+  type RobotAttachment,
+  type RobotAttachmentInput,
+  type RobotAttachmentType,
+} from '../api'
+import './RobotAttachmentsPanel.css'
+
+type AttachmentPreset = Pick<
+  RobotAttachmentInput,
+  | 'display_name'
+  | 'attachment_type'
+  | 'capability'
+  | 'provider_package'
+  | 'provider_component'
+  | 'provider_adapter'
+  | 'topic'
+  | 'message_type'
+  | 'parent_frame'
+  | 'frame_id'
+>
+
+const ATTACHMENT_TYPES: Array<{ value: RobotAttachmentType; label: string }> = [
+  { value: 'camera', label: 'Camera' },
+  { value: 'depth_camera', label: 'Depth camera' },
+  { value: 'lidar', label: 'LiDAR' },
+  { value: 'imu', label: 'IMU' },
+  { value: 'gps', label: 'GPS' },
+  { value: 'microphone', label: 'Microphone' },
+  { value: 'custom', label: 'Custom ROS 2 device' },
+]
+
+const PRESETS: Record<RobotAttachmentType, AttachmentPreset> = {
+  camera: {
+    display_name: 'Front camera',
+    attachment_type: 'camera',
+    capability: 'camera',
+    provider_package: 'blacknode-perception',
+    provider_component: 'camera',
+    provider_adapter: 'ros2',
+    topic: '/camera/image_raw',
+    message_type: 'sensor_msgs/msg/Image',
+    parent_frame: 'base_link',
+    frame_id: 'camera_link',
+  },
+  depth_camera: {
+    display_name: 'Front depth camera',
+    attachment_type: 'depth_camera',
+    capability: 'depth_camera',
+    provider_package: 'blacknode-perception',
+    provider_component: 'depth',
+    provider_adapter: 'ros2',
+    topic: '/depth_cam/rgb/image_raw',
+    message_type: 'sensor_msgs/msg/Image',
+    parent_frame: 'base_link',
+    frame_id: 'depth_camera_link',
+  },
+  lidar: {
+    display_name: 'Front LiDAR',
+    attachment_type: 'lidar',
+    capability: 'lidar',
+    provider_package: 'blacknode-perception',
+    provider_component: 'lidar',
+    provider_adapter: 'ros2',
+    topic: '/scan',
+    message_type: 'sensor_msgs/msg/LaserScan',
+    parent_frame: 'base_link',
+    frame_id: 'lidar_link',
+  },
+  imu: {
+    display_name: 'Body IMU',
+    attachment_type: 'imu',
+    capability: 'imu',
+    provider_package: 'blacknode-perception',
+    provider_component: 'imu',
+    provider_adapter: 'ros2',
+    topic: '/imu',
+    message_type: 'sensor_msgs/msg/Imu',
+    parent_frame: 'base_link',
+    frame_id: 'imu_link',
+  },
+  gps: {
+    display_name: 'GPS',
+    attachment_type: 'gps',
+    capability: 'gps',
+    provider_package: 'blacknode-perception',
+    provider_component: 'localization',
+    provider_adapter: 'ros2',
+    topic: '/fix',
+    message_type: 'sensor_msgs/msg/NavSatFix',
+    parent_frame: 'base_link',
+    frame_id: 'gps_link',
+  },
+  microphone: {
+    display_name: 'Microphone',
+    attachment_type: 'microphone',
+    capability: 'microphone',
+    provider_package: 'blacknode-perception',
+    provider_component: 'audio',
+    provider_adapter: 'ros2',
+    topic: '/audio',
+    message_type: 'audio_common_msgs/msg/AudioData',
+    parent_frame: 'base_link',
+    frame_id: 'microphone_link',
+  },
+  custom: {
+    display_name: 'ROS 2 attachment',
+    attachment_type: 'custom',
+    capability: 'sensor',
+    provider_package: 'blacknode-ros2',
+    provider_component: 'topics',
+    provider_adapter: 'ros2',
+    topic: '/sensor/data',
+    message_type: 'std_msgs/msg/String',
+    parent_frame: 'base_link',
+    frame_id: 'sensor_link',
+  },
+}
+
+function attachmentId(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+  if (!normalized) return 'attachment'
+  return /^[a-z]/.test(normalized) ? normalized.slice(0, 64) : `attachment_${normalized}`.slice(0, 64)
+}
+
+function emptyDraft(type: RobotAttachmentType = 'camera'): RobotAttachmentInput {
+  const preset = PRESETS[type]
+  return {
+    ...preset,
+    attachment_id: attachmentId(preset.display_name),
+    x_m: 0,
+    y_m: 0,
+    z_m: 0,
+    roll_rad: 0,
+    pitch_rad: 0,
+    yaw_rad: 0,
+    hardware_id: '',
+    required: true,
+    enabled: true,
+  }
+}
+
+function attachmentInterface(attachment: RobotAttachment) {
+  return attachment.interfaces.find(item => item.kind === 'topic')
+}
+
+function editDraft(attachment: RobotAttachment): RobotAttachmentInput {
+  const topic = attachmentInterface(attachment)
+  const translation = attachment.mount.translation_m ?? [0, 0, 0]
+  const rotation = attachment.mount.rotation_rpy_rad ?? [0, 0, 0]
+  return {
+    attachment_id: attachment.id,
+    display_name: attachment.display_name,
+    attachment_type: attachment.attachment_type,
+    capability: attachment.capability,
+    provider_package: attachment.provider.package,
+    provider_component: attachment.provider.component,
+    provider_adapter: attachment.provider.adapter || 'ros2',
+    topic: topic?.topic || '',
+    message_type: topic?.message_type || '',
+    parent_frame: attachment.parent_frame,
+    frame_id: attachment.frame_id,
+    x_m: Number(translation[0] || 0),
+    y_m: Number(translation[1] || 0),
+    z_m: Number(translation[2] || 0),
+    roll_rad: Number(rotation[0] || 0),
+    pitch_rad: Number(rotation[1] || 0),
+    yaw_rad: Number(rotation[2] || 0),
+    hardware_id: attachment.hardware_identity.id || '',
+    required: attachment.required,
+    enabled: attachment.enabled !== false,
+  }
+}
+
+function attachmentStatus(attachment: RobotAttachment) {
+  if (attachment.enabled === false) {
+    return { label: 'DISABLED', tone: 'disabled', message: 'This attachment is saved but excluded.' }
+  }
+  const check = attachment.last_check
+  if (!check) {
+    return { label: 'NOT CHECKED', tone: 'unchecked', message: 'Press Check ROS to inspect its live topic.' }
+  }
+  if (check.status === 'streaming') {
+    return { label: 'STREAMING', tone: 'healthy', message: check.message }
+  }
+  if (check.status === 'topic_present') {
+    return { label: 'TOPIC FOUND', tone: 'present', message: check.message }
+  }
+  return { label: 'ATTENTION', tone: 'attention', message: check.message }
+}
+
+export function RobotAttachmentsPanel({
+  robot,
+  onRobotUpdated,
+}: {
+  robot: HardwareDevice
+  onRobotUpdated: (robot: HardwareDevice) => void
+}) {
+  const attachments = robot.attachments ?? []
+  const [draft, setDraft] = useState<RobotAttachmentInput | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [busyId, setBusyId] = useState('')
+  const [error, setError] = useState('')
+
+  const beginAdd = () => {
+    setEditingId(null)
+    setDraft(emptyDraft())
+    setError('')
+  }
+
+  const beginEdit = (attachment: RobotAttachment) => {
+    setEditingId(attachment.id)
+    setDraft(editDraft(attachment))
+    setError('')
+  }
+
+  const save = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!draft) return
+    setBusyId(editingId || 'new')
+    setError('')
+    try {
+      const result = editingId
+        ? await api.updateRobotAttachment(robot.id, editingId, draft)
+        : await api.createRobotAttachment(robot.id, draft)
+      onRobotUpdated(result.device)
+      setDraft(null)
+      setEditingId(null)
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setBusyId('')
+    }
+  }
+
+  const remove = async (attachment: RobotAttachment) => {
+    if (!window.confirm(
+      `Remove “${attachment.display_name}” from ${robot.name}? This removes its saved attachment configuration; it does not uninstall system ROS 2 packages.`,
+    )) return
+    setBusyId(attachment.id)
+    setError('')
+    try {
+      const result = await api.deleteRobotAttachment(robot.id, attachment.id)
+      onRobotUpdated(result.device)
+      if (editingId === attachment.id) {
+        setDraft(null)
+        setEditingId(null)
+      }
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setBusyId('')
+    }
+  }
+
+  const check = async (attachment: RobotAttachment) => {
+    setBusyId(attachment.id)
+    setError('')
+    try {
+      const result = await api.checkRobotAttachment(robot.id, attachment.id)
+      onRobotUpdated(result.device)
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setBusyId('')
+    }
+  }
+
+  return (
+    <section className="bn-robot-attachments" aria-label={`Attachments for ${robot.name}`}>
+      <header className="bn-robot-attachments-head">
+        <div>
+          <strong>Attachments</strong>
+          <span>
+            Cameras and sensors mounted on this robot. Each attachment keeps its
+            ROS topic, frame, provider, and physical mounting transform. Register
+            the stream here after its ROS 2 driver is running.
+          </span>
+        </div>
+        {!draft && (
+          <button
+            type="button"
+            className="bn-device-action-button is-primary"
+            onClick={beginAdd}
+          >
+            Add attachment
+          </button>
+        )}
+      </header>
+
+      {error && <div className="bn-run-error-line bn-device-error" role="alert">{error}</div>}
+
+      {!draft && attachments.length === 0 && (
+        <div className="bn-robot-attachments-empty">
+          <strong>No attachments configured</strong>
+          <span>Add a camera, depth camera, LiDAR, IMU, GPS, microphone, or ROS 2 device.</span>
+          <button type="button" className="bn-device-action-button" onClick={beginAdd}>
+            Add the first attachment
+          </button>
+        </div>
+      )}
+
+      {!draft && attachments.length > 0 && (
+        <div className="bn-robot-attachment-list">
+          {attachments.map(attachment => {
+            const topic = attachmentInterface(attachment)
+            const status = attachmentStatus(attachment)
+            return (
+              <article className="bn-robot-attachment-card" key={attachment.id}>
+                <div className="bn-robot-attachment-card-head">
+                  <div>
+                    <span className="bn-robot-attachment-kind">
+                      {ATTACHMENT_TYPES.find(item => item.value === attachment.attachment_type)?.label
+                        || attachment.attachment_type}
+                    </span>
+                    <strong>{attachment.display_name}</strong>
+                  </div>
+                  <span
+                    className={`bn-robot-attachment-status is-${status.tone}`}
+                    title={status.message}
+                  >
+                    {status.label}
+                  </span>
+                </div>
+                <dl className="bn-robot-attachment-facts">
+                  <div>
+                    <dt>ROS topic</dt>
+                    <dd>{topic?.topic || 'Not configured'}</dd>
+                  </div>
+                  <div>
+                    <dt>Message</dt>
+                    <dd>{topic?.message_type || 'Not configured'}</dd>
+                  </div>
+                  <div>
+                    <dt>Frame</dt>
+                    <dd>{attachment.parent_frame} → {attachment.frame_id}</dd>
+                  </div>
+                  <div>
+                    <dt>Provider</dt>
+                    <dd>
+                      {attachment.provider.package}/{attachment.provider.component}
+                      {attachment.provider.adapter ? `@${attachment.provider.adapter}` : ''}
+                    </dd>
+                  </div>
+                </dl>
+                <p className="bn-robot-attachment-message">{status.message}</p>
+                <div className="bn-robot-attachment-actions">
+                  <button
+                    type="button"
+                    className="bn-device-action-button is-primary"
+                    disabled={Boolean(busyId)}
+                    onClick={() => void check(attachment)}
+                  >
+                    {busyId === attachment.id ? 'Checking…' : 'Check ROS'}
+                  </button>
+                  <button
+                    type="button"
+                    className="bn-device-action-button"
+                    disabled={Boolean(busyId)}
+                    onClick={() => beginEdit(attachment)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className="bn-device-action-button is-danger"
+                    disabled={Boolean(busyId)}
+                    onClick={() => void remove(attachment)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+
+      {draft && (
+        <form className="bn-robot-attachment-form" onSubmit={save}>
+          <div className="bn-robot-attachment-form-title">
+            <div>
+              <strong>{editingId ? 'Edit attachment' : 'Add attachment'}</strong>
+              <span>
+                Associate an existing ROS 2 stream with this robot, then use Check
+                ROS to verify its publisher.
+              </span>
+            </div>
+            <button
+              type="button"
+              className="bn-device-action-button"
+              disabled={Boolean(busyId)}
+              onClick={() => {
+                setDraft(null)
+                setEditingId(null)
+                setError('')
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+
+          <div className="bn-robot-attachment-form-grid">
+            <label>
+              <span>Attachment type</span>
+              <select
+                value={draft.attachment_type}
+                disabled={Boolean(editingId)}
+                onChange={event => {
+                  const type = event.target.value as RobotAttachmentType
+                  setDraft(emptyDraft(type))
+                }}
+              >
+                {ATTACHMENT_TYPES.map(item => (
+                  <option value={item.value} key={item.value}>{item.label}</option>
+                ))}
+              </select>
+            </label>
+            <label>
+              <span>Name</span>
+              <input
+                value={draft.display_name}
+                onChange={event => {
+                  const displayName = event.target.value
+                  setDraft(current => current && ({
+                    ...current,
+                    display_name: displayName,
+                    attachment_id: editingId
+                      ? current.attachment_id
+                      : attachmentId(displayName),
+                  }))
+                }}
+                required
+              />
+            </label>
+            <label>
+              <span>Stable attachment ID</span>
+              <input
+                value={draft.attachment_id}
+                disabled={Boolean(editingId)}
+                onChange={event => setDraft(current => current && ({
+                  ...current,
+                  attachment_id: attachmentId(event.target.value),
+                }))}
+                required
+              />
+            </label>
+            <label>
+              <span>Capability</span>
+              <input
+                value={draft.capability}
+                onChange={event => setDraft(current => current && ({
+                  ...current,
+                  capability: attachmentId(event.target.value),
+                }))}
+                required
+              />
+            </label>
+            <label className="is-wide">
+              <span>ROS 2 topic</span>
+              <input
+                value={draft.topic}
+                placeholder="/camera/image_raw"
+                onChange={event => setDraft(current => current && ({
+                  ...current,
+                  topic: event.target.value,
+                }))}
+                required
+              />
+            </label>
+            <label className="is-wide">
+              <span>ROS 2 message type</span>
+              <input
+                value={draft.message_type}
+                placeholder="sensor_msgs/msg/Image"
+                onChange={event => setDraft(current => current && ({
+                  ...current,
+                  message_type: event.target.value,
+                }))}
+                required
+              />
+            </label>
+            <label>
+              <span>Parent frame</span>
+              <input
+                value={draft.parent_frame}
+                onChange={event => setDraft(current => current && ({
+                  ...current,
+                  parent_frame: event.target.value,
+                }))}
+                required
+              />
+            </label>
+            <label>
+              <span>Attachment frame</span>
+              <input
+                value={draft.frame_id}
+                onChange={event => setDraft(current => current && ({
+                  ...current,
+                  frame_id: event.target.value,
+                }))}
+                required
+              />
+            </label>
+          </div>
+
+          <details className="bn-robot-attachment-advanced">
+            <summary>Mount position and provider</summary>
+            <div className="bn-robot-attachment-form-grid">
+              {([
+                ['x_m', 'X (m)'],
+                ['y_m', 'Y (m)'],
+                ['z_m', 'Z (m)'],
+                ['roll_rad', 'Roll (rad)'],
+                ['pitch_rad', 'Pitch (rad)'],
+                ['yaw_rad', 'Yaw (rad)'],
+              ] as const).map(([field, label]) => (
+                <label key={field}>
+                  <span>{label}</span>
+                  <input
+                    type="number"
+                    step="any"
+                    value={draft[field]}
+                    onChange={event => setDraft(current => current && ({
+                      ...current,
+                      [field]: Number(event.target.value || 0),
+                    }))}
+                  />
+                </label>
+              ))}
+              <label>
+                <span>Provider package</span>
+                <input
+                  value={draft.provider_package}
+                  onChange={event => setDraft(current => current && ({
+                    ...current,
+                    provider_package: event.target.value,
+                  }))}
+                  required
+                />
+              </label>
+              <label>
+                <span>Provider component</span>
+                <input
+                  value={draft.provider_component}
+                  onChange={event => setDraft(current => current && ({
+                    ...current,
+                    provider_component: event.target.value,
+                  }))}
+                  required
+                />
+              </label>
+              <label>
+                <span>Provider adapter</span>
+                <input
+                  value={draft.provider_adapter}
+                  onChange={event => setDraft(current => current && ({
+                    ...current,
+                    provider_adapter: event.target.value,
+                  }))}
+                />
+              </label>
+              <label>
+                <span>Physical hardware ID</span>
+                <input
+                  value={draft.hardware_id}
+                  placeholder="Serial number or stable path"
+                  onChange={event => setDraft(current => current && ({
+                    ...current,
+                    hardware_id: event.target.value,
+                  }))}
+                />
+              </label>
+            </div>
+          </details>
+
+          <div className="bn-robot-attachment-switches">
+            <label>
+              <input
+                type="checkbox"
+                checked={draft.enabled}
+                onChange={event => setDraft(current => current && ({
+                  ...current,
+                  enabled: event.target.checked,
+                }))}
+              />
+              Enabled for this robot
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={draft.required}
+                onChange={event => setDraft(current => current && ({
+                  ...current,
+                  required: event.target.checked,
+                }))}
+              />
+              Required for robot readiness
+            </label>
+          </div>
+
+          <div className="bn-robot-attachment-form-actions">
+            <button
+              type="submit"
+              className="bn-device-action-button is-primary"
+              disabled={Boolean(busyId)}
+            >
+              {busyId ? 'Saving…' : editingId ? 'Save changes' : 'Add attachment'}
+            </button>
+          </div>
+        </form>
+      )}
+    </section>
+  )
+}

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -89,6 +89,20 @@ class _HardwareService:
             "deployment_motion_control_v1",
             "ros2_diagnostics_v1",
         ]
+        self.ros2_diagnostics_payload = {
+            "ok": True,
+            "available": True,
+            "checked_at": "2026-07-27T00:00:00+00:00",
+            "summary": "Found 2 nodes, 2 topics, and 1 service.",
+            "nodes": ["/leader", "/follower"],
+            "topics": [
+                "/leader/joint_states [sensor_msgs/msg/JointState]",
+                "/follower/joint_states [sensor_msgs/msg/JointState]",
+            ],
+            "services": ["/leader/get_parameters"],
+            "topic_details": [],
+            "warnings": [],
+        }
         self.torque_readback_available = torque_readback_available
 
     def __call__(self, request, timeout=0):
@@ -176,20 +190,7 @@ class _HardwareService:
                 "messages": [],
             })
         if path == "/diagnostics/ros2":
-            return _JsonResponse({
-                "ok": True,
-                "available": True,
-                "checked_at": "2026-07-27T00:00:00+00:00",
-                "summary": "Found 2 nodes, 2 topics, and 1 service.",
-                "nodes": ["/leader", "/follower"],
-                "topics": [
-                    "/leader/joint_states [sensor_msgs/msg/JointState]",
-                    "/follower/joint_states [sensor_msgs/msg/JointState]",
-                ],
-                "services": ["/leader/get_parameters"],
-                "topic_details": [],
-                "warnings": [],
-            })
+            return _JsonResponse(self.ros2_diagnostics_payload)
         if path == "/deployments":
             if request.method == "GET":
                 return _JsonResponse({
@@ -2967,6 +2968,147 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertTrue(rpc_requests)
         self.assertEqual(rpc_requests[-1][3]["method"], "stop")
 
+    def test_robot_attachments_are_managed_in_ui_api_and_check_live_ros_topic(self):
+        hardware = _HardwareService()
+        attachment_payload = {
+            "attachment_id": "front_camera",
+            "display_name": "Front camera",
+            "attachment_type": "camera",
+            "capability": "camera",
+            "provider_package": "blacknode-perception",
+            "provider_component": "camera",
+            "provider_adapter": "ros2",
+            "topic": "/camera/image_raw",
+            "message_type": "sensor_msgs/msg/Image",
+            "parent_frame": "base_link",
+            "frame_id": "camera_link",
+            "x_m": 0.2,
+            "y_m": 0.0,
+            "z_m": 0.4,
+            "roll_rad": 0.0,
+            "pitch_rad": 0.1,
+            "yaw_rad": 0.0,
+            "hardware_id": "camera-serial-1",
+            "required": True,
+            "enabled": True,
+        }
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            created = self.client.post(
+                f"/devices/{paired['id']}/attachments",
+                json=attachment_payload,
+            )
+            listed = self.client.get(
+                f"/devices/{paired['id']}/attachments",
+            )
+            missing = self.client.post(
+                f"/devices/{paired['id']}/attachments/front_camera/check",
+            )
+
+            hardware.ros2_diagnostics_payload["topics"].append(
+                "/camera/image_raw [sensor_msgs/msg/Image]"
+            )
+            hardware.ros2_diagnostics_payload["topic_details"] = [{
+                "topic": "/camera/image_raw",
+                "ok": True,
+                "stdout": (
+                    "Type: sensor_msgs/msg/Image\n\n"
+                    "Publisher count: 1\n\nSubscription count: 0\n"
+                ),
+                "stderr": "",
+            }]
+            streaming = self.client.post(
+                f"/devices/{paired['id']}/attachments/front_camera/check",
+            )
+            updated = self.client.put(
+                f"/devices/{paired['id']}/attachments/front_camera",
+                json={
+                    **attachment_payload,
+                    "display_name": "Wrist camera",
+                },
+            )
+            re_paired = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            })
+            invalid_id_change = self.client.put(
+                f"/devices/{paired['id']}/attachments/front_camera",
+                json={
+                    **attachment_payload,
+                    "attachment_id": "different_camera",
+                },
+            )
+            deleted = self.client.delete(
+                f"/devices/{paired['id']}/attachments/front_camera",
+            )
+
+        self.assertEqual(created.status_code, 200)
+        attachment = created.json()["attachment"]
+        self.assertEqual(attachment["kind"], "blacknode.robot-attachment")
+        self.assertEqual(attachment["interfaces"][0]["topic"], "/camera/image_raw")
+        self.assertEqual(
+            attachment["mount"]["translation_m"],
+            [0.2, 0.0, 0.4],
+        )
+        self.assertEqual(
+            attachment["hardware_identity"]["id"],
+            "camera-serial-1",
+        )
+        self.assertEqual(len(listed.json()["attachments"]), 1)
+        self.assertEqual(missing.json()["check"]["status"], "missing")
+        self.assertFalse(missing.json()["check"]["ok"])
+        self.assertEqual(streaming.json()["check"]["status"], "streaming")
+        self.assertTrue(streaming.json()["check"]["ok"])
+        self.assertEqual(streaming.json()["check"]["publisher_count"], 1)
+        self.assertEqual(
+            updated.json()["attachment"]["display_name"],
+            "Wrist camera",
+        )
+        self.assertEqual(len(re_paired.json()["device"]["attachments"]), 1)
+        self.assertEqual(invalid_id_change.status_code, 400)
+        self.assertIn("stable", invalid_id_change.json()["detail"].lower())
+        self.assertEqual(deleted.status_code, 200)
+        self.assertEqual(deleted.json()["device"]["attachments"], [])
+        self.assertNotIn(hardware.token, created.text)
+        saved = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            saved["devices"][paired["id"]]["attachments"],
+            [],
+        )
+
+    def test_robot_attachment_rejects_invalid_ros_message_type(self):
+        hardware = _HardwareService()
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            paired = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]
+            response = self.client.post(
+                f"/devices/{paired['id']}/attachments",
+                json={
+                    "attachment_id": "front_camera",
+                    "display_name": "Front camera",
+                    "attachment_type": "camera",
+                    "capability": "camera",
+                    "provider_package": "blacknode-perception",
+                    "provider_component": "camera",
+                    "provider_adapter": "ros2",
+                    "topic": "/camera/image_raw",
+                    "message_type": "Image",
+                    "parent_frame": "base_link",
+                    "frame_id": "camera_link",
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("sensor_msgs/msg/image", response.json()["detail"].lower())
+
     def test_device_status_keeps_last_verified_hardware_version(self):
         hardware = _HardwareService(status_overrides={
             "software_version": "0.1.1",
@@ -4826,12 +4968,31 @@ class EditorDeviceApiTests(unittest.TestCase):
     def test_validated_graph_can_be_staged_and_started_on_runtime(self):
         hardware = _HardwareService()
         workflow = _workflow([])
+        attachment_payload = {
+            "attachment_id": "front_camera",
+            "display_name": "Front camera",
+            "attachment_type": "camera",
+            "capability": "camera",
+            "provider_package": "blacknode-perception",
+            "provider_component": "camera",
+            "provider_adapter": "ros2",
+            "topic": "/camera/image_raw",
+            "message_type": "sensor_msgs/msg/Image",
+            "parent_frame": "base_link",
+            "frame_id": "camera_link",
+            "required": True,
+            "enabled": True,
+        }
         with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
             device_id = self.client.post("/devices", json={
                 "name": "Workshop arm",
                 "base_url": "http://192.168.1.87:8765",
                 "token": hardware.token,
             }).json()["device"]["id"]
+            self.client.post(
+                f"/devices/{device_id}/attachments",
+                json=attachment_payload,
+            )
             with patch.object(server, "_workflow_payload", return_value=workflow):
                 preflight = self.client.post(
                     f"/devices/{device_id}/deployment-preflight",
@@ -4871,6 +5032,14 @@ class EditorDeviceApiTests(unittest.TestCase):
             stage_request[3]["manifest"]["target_device_id"],
             device_id,
         )
+        staged_attachments = stage_request[3]["manifest"]["robot_attachments"]
+        self.assertEqual(len(staged_attachments), 1)
+        self.assertEqual(staged_attachments[0]["id"], "front_camera")
+        self.assertEqual(
+            staged_attachments[0]["interfaces"][0]["topic"],
+            "/camera/image_raw",
+        )
+        self.assertNotIn("last_check", staged_attachments[0])
         self.assertFalse(stage_request[3]["manifest"]["telemetry_required"])
 
     def test_deployment_stream_reports_package_upload_and_start_progress(self):


### PR DESCRIPTION
## What changed

- adds robot-level attachment CRUD for cameras, depth cameras, LiDAR, IMU, GPS, microphones, and custom ROS 2 streams
- adds explicit live ROS topic/type/publisher checks with saved status
- adds an inline Attachments panel to each expanded robot card
- carries enabled attachment configuration in deployment manifests without adding workflow processes
- preserves attachments when a robot is paired again

## Why

Attachments belong to the physical robot and should be configured through the Devices UI, independently from workflow nodes. This provides a direct setup and debugging path while keeping one active workflow deployment per robot.

## Validation

- `python -m unittest discover -s tests` — 476 passed, 8 skipped
- `npm run build` — passed
- focused attachment/deployment API tests — passed
- restarted local editor/backend and verified attachment endpoints for both paired robots