### PR TITLE
Fix managed camera attachment readiness

### DIFF
--- a/docs/managed-robot-attachments.md
+++ b/docs/managed-robot-attachments.md
@@ -72,26 +72,25 @@ published by another managed stack.
 
 ### Generic USB camera
 
-The provider starts `usb_cam` as a named managed ROS 2 process and verifies its
-RGB image and camera-info topics. Device selection and parameters remain in the
-provider configuration.
+The provider starts Blacknode's bundled `perception_camera usb_camera` process
+and verifies its RGB image and camera-info topics. Device selection and
+parameters remain in the provider configuration.
 
-### ROSOrin-Pro RGB-D
+### Blacknode RGB-D
 
-The ROSOrin-Pro `peripherals/depth_camera.launch.py` bring-up selects its depth
-camera from `DEPTH_CAMERA_TYPE` and publishes a normalized interface:
+The bundled `perception_camera rgbd_camera.launch.py` provider accepts explicit
+RGB and metric-depth video inputs and publishes a normalized interface:
 
 ```text
-/depth_cam/rgb0/image_raw
-/depth_cam/rgb0/camera_info
-/depth_cam/depth0/image_raw
-/depth_cam/depth0/camera_info
-/depth_cam/depth0/points
+/camera/rgb/image_raw
+/camera/rgb/camera_info
+/camera/depth/image_raw
+/camera/depth/camera_info
 ```
 
-The same stack starts `web_video_server` and rosbridge for remote tools.
-Blacknode treats those as optional presentation and bridge providers; native
-ROS 2 topics remain the source of truth.
+Blacknode accepts metric depth encoded as `16UC1` or `32FC1`. Calibrated
+downstream components may derive a point cloud when intrinsics and extrinsics
+are available. Native ROS 2 topics remain the sensor-data source of truth.
 
 ## Editor workflow
 

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -156,12 +156,12 @@ def _normalize_attachment(
     if provider_profile not in {
         "existing_topics",
         "usb_cam",
-        "rosorin_depth",
+        "blacknode_rgbd",
         "custom_launch",
     }:
         raise DeviceRegistryError(
             "Attachment provider profile must be existing topics, USB camera, "
-            "ROSOrin depth camera, or custom ROS 2 launch."
+            "Blacknode RGB-D, or custom ROS 2 launch."
         )
     topic = str(values.get("topic") or "").strip()
     if not topic.startswith("/") or any(character.isspace() for character in topic):
@@ -617,6 +617,19 @@ class RuntimeDeviceClient(HardwareDeviceClient):
     def get_service(self, service_id: str) -> dict[str, Any]:
         return self._request("GET", self._service_endpoint(service_id), timeout=30.0)
 
+    def service_logs(
+        self,
+        service_id: str,
+        *,
+        limit: int = 12000,
+    ) -> dict[str, Any]:
+        safe_limit = max(512, min(int(limit), 200000))
+        return self._request(
+            "GET",
+            f"{self._service_endpoint(service_id)}/logs?limit={safe_limit}",
+            timeout=30.0,
+        )
+
     def start_service(
         self,
         service_id: str,
@@ -626,7 +639,7 @@ class RuntimeDeviceClient(HardwareDeviceClient):
             "POST",
             f"{self._service_endpoint(service_id)}/start",
             payload=payload,
-            timeout=30.0,
+            timeout=60.0,
         )
 
     def stop_service(self, service_id: str) -> dict[str, Any]:

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -5249,21 +5249,55 @@ def _attachment_service_payload(
             ),
             "",
         )
-        arguments = ["--ros-args", "-r", f"image_raw:={topic}"]
+        arguments = list(service.get("launch_arguments") or [])
+        arguments.append(f"image_topic:={topic}")
         if info:
-            arguments.extend(["-r", f"camera_info:={info}"])
-        command = {
-            "verb": "run",
-            "package": "usb_cam",
-            "target": "usb_cam_node_exe",
-            "arguments": arguments,
-        }
-    elif profile == "rosorin_depth":
+            arguments.append(f"camera_info_topic:={info}")
+        arguments.append(
+            f"frame_id:={str(primary.get('frame_id') or 'camera')}"
+        )
         command = {
             "verb": "launch",
-            "package": "peripherals",
-            "target": "depth_camera.launch.py",
-            "arguments": [],
+            "package": "perception_camera",
+            "target": "usb_camera.launch.py",
+            "arguments": arguments,
+        }
+    elif profile == "blacknode_rgbd":
+        primary = _attachment_primary_interface(attachment)
+        info = next(
+            (
+                str(item.get("topic") or "")
+                for item in (attachment.get("interfaces") or [])
+                if isinstance(item, dict)
+                and str(item.get("role") or "") == "camera_info"
+            ),
+            "",
+        )
+        depth = next(
+            (
+                str(item.get("topic") or "")
+                for item in (attachment.get("interfaces") or [])
+                if isinstance(item, dict)
+                and str(item.get("role") or "") == "depth"
+            ),
+            "",
+        )
+        arguments = (
+            list(service.get("launch_arguments") or [])
+            or ["rgb_device:=0", "depth_device:=1"]
+        )
+        arguments.extend([
+            f"rgb_topic:={str(primary.get('topic') or '/camera/rgb/image_raw')}",
+            f"rgb_info_topic:={info or '/camera/rgb/camera_info'}",
+            f"depth_topic:={depth or '/camera/depth/image_raw'}",
+            f"rgb_frame_id:={str(primary.get('frame_id') or 'camera_rgb')}",
+            f"depth_frame_id:={str(primary.get('frame_id') or 'camera_depth')}",
+        ])
+        command = {
+            "verb": "launch",
+            "package": "perception_camera",
+            "target": "rgbd_camera.launch.py",
+            "arguments": arguments,
         }
     elif profile == "custom_launch":
         command = {
@@ -5288,6 +5322,7 @@ def _attachment_service_payload(
         "name": str(attachment.get("display_name") or service_id),
         "command": command,
         "interfaces": interfaces,
+        "wait_seconds": 15.0,
     }
 
 
@@ -5417,6 +5452,8 @@ def _attachment_topic_check(
 def _attachment_service_check(
     attachment: dict[str, Any],
     service: dict[str, Any],
+    *,
+    provider_logs: str = "",
 ) -> dict[str, Any]:
     primary = _attachment_primary_interface(attachment)
     topic = str(primary.get("topic") or "")
@@ -5438,6 +5475,29 @@ def _attachment_service_check(
     missing = [str(value) for value in (diagnostics.get("missing") or [])]
     state = str(service.get("state") or "stopped")
     ok = state == "running" and bool(diagnostics.get("ok"))
+    message = (
+        f"{attachment.get('display_name') or topic} is running and all "
+        "required ROS 2 streams are publishing."
+        if ok
+        else (
+            "Provider is running, but required streams are not ready: "
+            + ", ".join(missing)
+            if state == "running" and missing
+            else str(
+                service.get("error")
+                or "Attachment provider is stopped."
+            )
+        )
+    )
+    clean_logs = re.sub(r"\x1b\[[0-9;]*m", "", provider_logs).strip()
+    if not ok and clean_logs:
+        log_tail = " | ".join(
+            line.strip()
+            for line in clean_logs.splitlines()[-8:]
+            if line.strip()
+        )
+        if log_tail:
+            message += f" Provider log: {log_tail[-1600:]}"
     return {
         "ok": ok,
         "status": (
@@ -5457,24 +5517,25 @@ def _attachment_service_check(
             diagnostics.get("checked_at")
             or datetime.now().astimezone().isoformat(timespec="seconds")
         ),
-        "message": (
-            f"{attachment.get('display_name') or topic} is running and all "
-            "required ROS 2 streams are publishing."
-            if ok
-            else (
-                "Provider is running, but required streams are not ready: "
-                + ", ".join(missing)
-                if state == "running" and missing
-                else str(
-                    service.get("error")
-                    or "Attachment provider is stopped."
-                )
-            )
-        ),
+        "message": message,
         "interfaces": interfaces,
         "missing": missing,
         "service_state": state,
     }
+
+
+def _attachment_provider_logs(
+    runtime_client: RuntimeDeviceClient,
+    service_id: str,
+    check: dict[str, Any],
+) -> str:
+    if check.get("ok"):
+        return ""
+    try:
+        result = runtime_client.service_logs(service_id, limit=12000)
+    except DeviceRegistryError:
+        return ""
+    return str(result.get("logs") or "")
 
 
 def _find_robot_attachment(
@@ -5572,6 +5633,15 @@ def check_robot_attachment(device_id: str, attachment_id: str):
                 service = {}
             if service:
                 check = _attachment_service_check(attachment, service)
+                check = _attachment_service_check(
+                    attachment,
+                    service,
+                    provider_logs=_attachment_provider_logs(
+                        runtime_client,
+                        service_id,
+                        check,
+                    ),
+                )
             else:
                 diagnostics = runtime_client.ros2_diagnostics()
                 check = _attachment_topic_check(attachment, diagnostics)
@@ -5610,11 +5680,21 @@ def start_robot_attachment(device_id: str, attachment_id: str):
                 "This attachment uses an existing ROS 2 topic. Start its external "
                 "driver, then press Check ROS.",
             )
-        service = _runtime_client_or_404(device_id).start_service(
+        runtime_client = _runtime_client_or_404(device_id)
+        service = runtime_client.start_service(
             service_id,
             payload,
         )
         check = _attachment_service_check(attachment, service)
+        check = _attachment_service_check(
+            attachment,
+            service,
+            provider_logs=_attachment_provider_logs(
+                runtime_client,
+                service_id,
+                check,
+            ),
+        )
         updated_device, updated_attachment = (
             _device_registry.remember_attachment_check(
                 device_id,

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -103,7 +103,7 @@ export type RobotAttachmentType =
 export type RobotAttachmentProviderProfile =
   | 'existing_topics'
   | 'usb_cam'
-  | 'rosorin_depth'
+  | 'blacknode_rgbd'
   | 'custom_launch'
 
 export interface RobotAttachmentCheck {

--- a/editor/src/components/RobotAttachmentsPanel.tsx
+++ b/editor/src/components/RobotAttachmentsPanel.tsx
@@ -47,7 +47,7 @@ const CAMERA_PROFILES: Array<{
   label: string
 }> = [
   { value: 'usb_cam', label: 'USB camera · Blacknode starts it' },
-  { value: 'rosorin_depth', label: 'ROSOrin RGB-D · Blacknode starts it' },
+  { value: 'blacknode_rgbd', label: 'Blacknode RGB-D · managed provider' },
   { value: 'existing_topics', label: 'Existing ROS 2 topics' },
   { value: 'custom_launch', label: 'Custom ROS 2 launch' },
 ]
@@ -66,6 +66,7 @@ const PRESETS: Record<RobotAttachmentType, AttachmentPreset> = {
     message_type: 'sensor_msgs/msg/Image',
     parent_frame: 'base_link',
     frame_id: 'camera_link',
+    launch_arguments: ['device:=0'],
   },
   depth_camera: {
     display_name: 'Front depth camera',
@@ -74,11 +75,12 @@ const PRESETS: Record<RobotAttachmentType, AttachmentPreset> = {
     provider_package: 'blacknode-perception',
     provider_component: 'depth',
     provider_adapter: 'ros2',
-    provider_profile: 'rosorin_depth',
-    topic: '/depth_cam/rgb0/image_raw',
-    camera_info_topic: '/depth_cam/rgb0/camera_info',
-    depth_topic: '/depth_cam/depth0/image_raw',
-    point_cloud_topic: '/depth_cam/depth0/points',
+    provider_profile: 'blacknode_rgbd',
+    topic: '/camera/rgb/image_raw',
+    camera_info_topic: '/camera/rgb/camera_info',
+    depth_topic: '/camera/depth/image_raw',
+    point_cloud_topic: '',
+    launch_arguments: ['rgb_device:=0', 'depth_device:=1'],
     message_type: 'sensor_msgs/msg/Image',
     parent_frame: 'base_link',
     frame_id: 'depth_camera_link',
@@ -573,11 +575,18 @@ export function RobotAttachmentsPanel({
                   setDraft(current => current && ({
                     ...current,
                     provider_profile: providerProfile,
-                    ...(providerProfile === 'rosorin_depth' ? {
-                      topic: '/depth_cam/rgb0/image_raw',
-                      camera_info_topic: '/depth_cam/rgb0/camera_info',
-                      depth_topic: '/depth_cam/depth0/image_raw',
-                      point_cloud_topic: '/depth_cam/depth0/points',
+                    ...(providerProfile === 'blacknode_rgbd' ? {
+                      topic: '/camera/rgb/image_raw',
+                      camera_info_topic: '/camera/rgb/camera_info',
+                      depth_topic: '/camera/depth/image_raw',
+                      point_cloud_topic: '',
+                      launch_arguments: ['rgb_device:=0', 'depth_device:=1'],
+                    } : providerProfile === 'usb_cam' ? {
+                      topic: '/camera/image_raw',
+                      camera_info_topic: '/camera/camera_info',
+                      depth_topic: '',
+                      point_cloud_topic: '',
+                      launch_arguments: ['device:=0'],
                     } : {}),
                   }))
                 }}
@@ -616,7 +625,7 @@ export function RobotAttachmentsPanel({
                   <span>Depth image topic · required for depth camera</span>
                   <input
                     value={draft.depth_topic}
-                    placeholder="/depth_cam/depth0/image_raw"
+                    placeholder="/camera/depth/image_raw"
                     onChange={event => setDraft(current => current && ({
                       ...current,
                       depth_topic: event.target.value,
@@ -628,7 +637,7 @@ export function RobotAttachmentsPanel({
                   <span>Point cloud topic · optional</span>
                   <input
                     value={draft.point_cloud_topic}
-                    placeholder="/depth_cam/depth0/points"
+                    placeholder="/camera/depth/points"
                     onChange={event => setDraft(current => current && ({
                       ...current,
                       point_cloud_topic: event.target.value,
@@ -637,33 +646,45 @@ export function RobotAttachmentsPanel({
                 </label>
               </>
             )}
-            {draft.provider_profile === 'custom_launch' && (
+            {(draft.provider_profile === 'custom_launch'
+              || draft.provider_profile === 'blacknode_rgbd'
+              || draft.provider_profile === 'usb_cam') && (
               <>
-                <label>
-                  <span>ROS 2 launch package</span>
-                  <input
-                    value={draft.launch_package}
-                    onChange={event => setDraft(current => current && ({
-                      ...current,
-                      launch_package: event.target.value,
-                    }))}
-                    required
-                  />
-                </label>
-                <label>
-                  <span>Launch file</span>
-                  <input
-                    value={draft.launch_target}
-                    placeholder="camera.launch.py"
-                    onChange={event => setDraft(current => current && ({
-                      ...current,
-                      launch_target: event.target.value,
-                    }))}
-                    required
-                  />
-                </label>
+                {draft.provider_profile === 'custom_launch' && (
+                  <>
+                    <label>
+                      <span>ROS 2 launch package</span>
+                      <input
+                        value={draft.launch_package}
+                        onChange={event => setDraft(current => current && ({
+                          ...current,
+                          launch_package: event.target.value,
+                        }))}
+                        required
+                      />
+                    </label>
+                    <label>
+                      <span>Launch file</span>
+                      <input
+                        value={draft.launch_target}
+                        placeholder="camera.launch.py"
+                        onChange={event => setDraft(current => current && ({
+                          ...current,
+                          launch_target: event.target.value,
+                        }))}
+                        required
+                      />
+                    </label>
+                  </>
+                )}
                 <label className="is-wide">
-                  <span>Launch arguments · one per line</span>
+                  <span>
+                    {draft.provider_profile === 'blacknode_rgbd'
+                      ? 'RGB and depth devices · one launch argument per line'
+                      : draft.provider_profile === 'usb_cam'
+                        ? 'Camera device · one launch argument per line'
+                      : 'Launch arguments · one per line'}
+                  </span>
                   <textarea
                     value={draft.launch_arguments.join('\n')}
                     onChange={event => setDraft(current => current && ({

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -198,6 +198,11 @@ class _HardwareService:
             service_id = parts[1]
             action = parts[2] if len(parts) > 2 else ""
             service = self.runtime_services.get(service_id)
+            if request.method == "GET" and action == "logs":
+                return _JsonResponse({
+                    "id": service_id,
+                    "logs": "managed camera provider output\n",
+                })
             if request.method == "GET" and not action:
                 if service is None:
                     raise urllib.error.HTTPError(
@@ -3170,7 +3175,7 @@ class EditorDeviceApiTests(unittest.TestCase):
                 response.json()["detail"].lower(),
             )
 
-    def test_managed_rosorin_rgbd_attachment_starts_outside_deployments(self):
+    def test_managed_blacknode_rgbd_attachment_starts_outside_deployments(self):
         hardware = _HardwareService()
         payload = {
             "attachment_id": "front_rgbd",
@@ -3180,12 +3185,13 @@ class EditorDeviceApiTests(unittest.TestCase):
             "provider_package": "blacknode-perception",
             "provider_component": "depth",
             "provider_adapter": "ros2",
-            "provider_profile": "rosorin_depth",
-            "topic": "/depth_cam/rgb0/image_raw",
+            "provider_profile": "blacknode_rgbd",
+            "topic": "/camera/rgb/image_raw",
             "message_type": "sensor_msgs/msg/Image",
-            "camera_info_topic": "/depth_cam/rgb0/camera_info",
-            "depth_topic": "/depth_cam/depth0/image_raw",
-            "point_cloud_topic": "/depth_cam/depth0/points",
+            "camera_info_topic": "/camera/rgb/camera_info",
+            "depth_topic": "/camera/depth/image_raw",
+            "point_cloud_topic": "",
+            "launch_arguments": ["rgb_device:=0", "depth_device:=1"],
             "parent_frame": "base_link",
             "frame_id": "depth_camera_link",
             "required": True,
@@ -3212,10 +3218,10 @@ class EditorDeviceApiTests(unittest.TestCase):
             )
 
         attachment = created.json()["attachment"]
-        self.assertEqual(len(attachment["interfaces"]), 4)
+        self.assertEqual(len(attachment["interfaces"]), 3)
         self.assertEqual(
             attachment["interfaces"][2]["topic"],
-            "/depth_cam/depth0/image_raw",
+            "/camera/depth/image_raw",
         )
         self.assertTrue(attachment["interfaces"][2]["required"])
         service = started.json()["service"]
@@ -3223,15 +3229,92 @@ class EditorDeviceApiTests(unittest.TestCase):
             service["command"],
             {
                 "verb": "launch",
-                "package": "peripherals",
-                "target": "depth_camera.launch.py",
-                "arguments": [],
+                "package": "perception_camera",
+                "target": "rgbd_camera.launch.py",
+                "arguments": [
+                    "rgb_device:=0",
+                    "depth_device:=1",
+                    "rgb_topic:=/camera/rgb/image_raw",
+                    "rgb_info_topic:=/camera/rgb/camera_info",
+                    "depth_topic:=/camera/depth/image_raw",
+                    "rgb_frame_id:=depth_camera_link",
+                    "depth_frame_id:=depth_camera_link",
+                ],
             },
         )
         self.assertEqual(started.json()["check"]["status"], "streaming")
         self.assertEqual(checked.json()["check"]["service_state"], "running")
         self.assertEqual(stopped.json()["service"]["state"], "stopped")
         self.assertEqual(hardware.runtime_deployments, {})
+
+    def test_managed_usb_attachment_uses_bundled_camera_provider(self):
+        service_id, payload = server._attachment_service_payload({
+            "id": "wrist_camera",
+            "display_name": "Wrist camera",
+            "service": {
+                "id": "wrist-camera",
+                "profile": "usb_cam",
+                "launch_arguments": ["device:=2"],
+            },
+            "interfaces": [
+                {
+                    "kind": "topic",
+                    "topic": "/wrist/image_raw",
+                    "message_type": "sensor_msgs/msg/Image",
+                    "frame_id": "wrist_camera_link",
+                },
+                {
+                    "kind": "topic",
+                    "role": "camera_info",
+                    "topic": "/wrist/camera_info",
+                    "message_type": "sensor_msgs/msg/CameraInfo",
+                    "required": False,
+                },
+            ],
+        })
+
+        self.assertEqual(service_id, "wrist-camera")
+        self.assertEqual(payload["command"], {
+            "verb": "launch",
+            "package": "perception_camera",
+            "target": "usb_camera.launch.py",
+            "arguments": [
+                "device:=2",
+                "image_topic:=/wrist/image_raw",
+                "camera_info_topic:=/wrist/camera_info",
+                "frame_id:=wrist_camera_link",
+            ],
+        })
+        self.assertEqual(payload["wait_seconds"], 15.0)
+
+    def test_attachment_check_surfaces_provider_log_for_missing_stream(self):
+        check = server._attachment_service_check(
+            {
+                "display_name": "Wrist camera",
+                "interfaces": [{
+                    "kind": "topic",
+                    "topic": "/camera/image_raw",
+                    "message_type": "sensor_msgs/msg/Image",
+                }],
+            },
+            {
+                "state": "running",
+                "error": "",
+                "diagnostics": {
+                    "ok": False,
+                    "missing": ["/camera/image_raw"],
+                    "interfaces": [],
+                },
+            },
+            provider_logs=(
+                "starting provider\n"
+                "RuntimeError: Could not open camera device 0\n"
+            ),
+        )
+
+        self.assertFalse(check["ok"])
+        self.assertIn("/camera/image_raw", check["message"])
+        self.assertIn("Could not open camera device 0", check["message"])
 
     def test_device_status_keeps_last_verified_hardware_version(self):
         hardware = _HardwareService(status_overrides={


### PR DESCRIPTION
## What changed
- route USB and RGB-D attachments to Blacknode's bundled perception camera providers
- add explicit device arguments in the attachment UI
- wait for required streams and show the managed provider log tail when startup fails
- replace hardcoded profile names and document the portable topic contract

## Why
A process being alive was treated as sufficient even when `/camera/image_raw` had no publisher, so the UI could only report a vague missing-stream warning.

## Validation
- core unit suite — 479 passed, 8 skipped
- editor device tests — 110 passed
- `npm run build`
- no stale hardcoded provider-name references remain