### PR TITLE
Migrate retired camera attachment profiles

### DIFF
--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -31,6 +31,12 @@ _ATTACHMENT_TYPES = {
     "microphone",
     "custom",
 }
+_ATTACHMENT_PROVIDER_PROFILES = {
+    "existing_topics",
+    "usb_cam",
+    "blacknode_rgbd",
+    "custom_launch",
+}
 
 
 class DeviceRegistryError(RuntimeError):
@@ -153,12 +159,7 @@ def _normalize_attachment(
         or provider.get("profile")
         or "existing_topics"
     ).strip().lower()
-    if provider_profile not in {
-        "existing_topics",
-        "usb_cam",
-        "blacknode_rgbd",
-        "custom_launch",
-    }:
+    if provider_profile not in _ATTACHMENT_PROVIDER_PROFILES:
         raise DeviceRegistryError(
             "Attachment provider profile must be existing topics, USB camera, "
             "Blacknode RGB-D, or custom ROS 2 launch."
@@ -1396,15 +1397,47 @@ class DeviceRegistry:
         hosts = payload.get("hosts", {}) if isinstance(payload, dict) else {}
         if not isinstance(devices, dict) or not isinstance(hosts, dict):
             raise DeviceRegistryError("Local device registry has an invalid format.")
-        return ({
+        loaded_hosts = {
             str(host_id): dict(record)
             for host_id, record in hosts.items()
             if isinstance(record, dict)
-        }, {
+        }
+        loaded_devices = {
             str(device_id): dict(record)
             for device_id, record in devices.items()
             if isinstance(record, dict)
-        })
+        }
+        for record in loaded_devices.values():
+            for attachment in record.get("attachments") or []:
+                if not isinstance(attachment, dict):
+                    continue
+                provider = (
+                    attachment.get("provider")
+                    if isinstance(attachment.get("provider"), dict)
+                    else {}
+                )
+                service = (
+                    attachment.get("service")
+                    if isinstance(attachment.get("service"), dict)
+                    else {}
+                )
+                profile = str(
+                    provider.get("profile")
+                    or service.get("profile")
+                    or "existing_topics"
+                )
+                if (
+                    profile not in _ATTACHMENT_PROVIDER_PROFILES
+                    and str(attachment.get("attachment_type") or "")
+                    == "depth_camera"
+                    and str(provider.get("package") or "")
+                    == "blacknode-perception"
+                ):
+                    provider["profile"] = "blacknode_rgbd"
+                    service["profile"] = "blacknode_rgbd"
+                    attachment["provider"] = provider
+                    attachment["service"] = service
+        return loaded_hosts, loaded_devices
 
     def _load(self) -> dict[str, dict[str, Any]]:
         _hosts, devices = self._load_payload()

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -3316,6 +3316,47 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn("/camera/image_raw", check["message"])
         self.assertIn("Could not open camera device 0", check["message"])
 
+    def test_retired_depth_attachment_profile_migrates_to_blacknode_rgbd(self):
+        self.registry_path.parent.mkdir(parents=True, exist_ok=True)
+        self.registry_path.write_text(json.dumps({
+            "schema_version": 2,
+            "hosts": {},
+            "devices": {
+                "camera-robot": {
+                    "id": "camera-robot",
+                    "name": "Camera robot",
+                    "base_url": "http://127.0.0.1:8765",
+                    "token": "secret",
+                    "attachments": [{
+                        "id": "front_depth",
+                        "attachment_type": "depth_camera",
+                        "provider": {
+                            "package": "blacknode-perception",
+                            "component": "depth",
+                            "adapter": "ros2",
+                            "profile": "retired_depth_profile",
+                        },
+                        "service": {
+                            "id": "front-depth",
+                            "profile": "retired_depth_profile",
+                        },
+                    }],
+                },
+            },
+        }), encoding="utf-8")
+
+        attachment = server._device_registry.get_public(
+            "camera-robot"
+        )["attachments"][0]
+        self.assertEqual(
+            attachment["provider"]["profile"],
+            "blacknode_rgbd",
+        )
+        self.assertEqual(
+            attachment["service"]["profile"],
+            "blacknode_rgbd",
+        )
+
     def test_device_status_keeps_last_verified_hardware_version(self):
         hardware = _HardwareService(status_overrides={
             "software_version": "0.1.1",


### PR DESCRIPTION
## What changed
- migrate saved Blacknode perception depth attachments from retired provider profiles to `blacknode_rgbd` while loading the local registry
- keep current profiles unchanged
- add regression coverage for existing saved attachments

## Why
Existing users should receive the new managed provider after updating instead of deleting and recreating their camera attachment.

## Validation
- targeted editor device tests — 4 passed