### PR TITLE
Document UI-first device operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,20 @@ under `packages/` are separate Git repositories and carry their own `AGENTS.md`.
 - Keep physical motion disarmed by default. Retain stale-data, joint-limit, and
   shutdown safeguards in every transport path.
 
+## Operator workflow
+
+- Treat the Blacknode editor as the primary operator surface for managed
+  devices. Guide routine setup, package updates, service restarts, deployment,
+  and removal through the visible UI controls.
+- For a managed-device update, open **Devices**, select the device, press
+  **Software**, then press **Check updates**. Choose **Update all** or the
+  package card's **Update** action. Use the Runtime or Hardware card's
+  **Restart** button when a restart is required.
+- Do not lead with SSH, `git pull`, `service.sh`, systemd, or package-manager
+  commands when the editor exposes the requested action. Offer shell commands
+  only when the user explicitly requests them or when diagnosing or recovering
+  from an unavailable UI action, and identify them as the fallback path.
+
 ## Hardware modularity invariants
 
 - Base robot contracts, profiles, and capability inspection must load and work

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -41,6 +41,21 @@ When building a workflow:
 The canonical skill sources live in `skills/`; `.agents/skills/` is the
 repository-discoverable mirror. Keep both copies synchronized.
 
+### Managed-device operating workflow
+
+Use the editor for routine managed-device operations. Open **Devices**, select
+the device, and press **Software**. Enter the SSH password when the device is
+remote, press **Check updates**, then use **Update all** or the **Update**
+action on the Runtime or Hardware package card. Use the package card's
+**Restart** button when that service needs to restart.
+
+Agent instructions should point users to these controls for setup, package
+updates, restarts, deployment, and removal. SSH commands, `git pull`,
+`service.sh`, systemd, and direct package-manager commands are recovery,
+diagnostic, or package-development tools. Present them only when the user asks
+for a command-line path or the editor cannot complete the operation, and state
+why the fallback is needed.
+
 ## Current Contract
 
 Blacknode workflows are portable JSON graph files. They are meant to run outside the browser editor through the Python runtime and CLI.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -52,26 +52,32 @@ environment variable (separated by the platform path separator).
 
 ## Updating packages
 
+For a managed device, open **Devices**, select the device, and press
+**Software**. Enter the SSH password for a remote device, press
+**Check updates**, then choose **Update all** or the **Update** action on a
+package card. **Update all** refreshes Runtime, every extension package already
+installed in that Runtime, and Hardware. The package cards also provide
+**Restart** for restarting Runtime or Hardware individually.
+
+Blacknode stops active deployments, disarms attached robots, updates the
+selected services and clean package checkouts, reloads Runtime, and verifies
+the resulting package manifest. Deployments remain stopped and disarmed until
+the operator explicitly starts and arms them.
+
+For local package development and command-line diagnostics,
 `blacknode packages status` reports package load state, missing official nodes,
-and local git state for installed folder packages. Add `--fetch` when you want
-to contact remotes and see whether a package is behind upstream:
+and local git state for installed folder packages. Add `--fetch` to contact
+remotes and see whether a package is behind upstream:
 
 ```bash
 blacknode packages status --fetch
 ```
 
-Update clean package checkouts with:
+Update clean development checkouts with:
 
 ```bash
 blacknode packages update --all
 ```
-
-For a managed remote device, **Devices → Software packages → Update Runtime**
-and **Update all** also refresh every extension package already installed in
-that Runtime. Blacknode stops active deployments, disarms attached robots,
-updates the service and clean package checkouts, reloads Runtime, and verifies
-the resulting package manifest. Deployments remain stopped and disarmed until
-the operator explicitly starts and arms them.
 
 The update command is intentionally conservative: it fetches and fast-forwards
 only packages with no local edits and no local commits ahead of upstream. Dirty,

--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -68,6 +68,25 @@ Remote Hardware Run, Stop, and Restart control every exact
 active deployments and disarms each robot; Run and Restart return with motion
 disarmed.
 
+### Update or restart a managed device
+
+Routine device maintenance stays in the editor:
+
+1. Open **Devices** and select the managed computer.
+2. Press **Software** to open the Runtime and Hardware package cards.
+3. For a remote device, enter its SSH password in the field marked
+   **SSH password · never saved**.
+4. Press **Check updates**.
+5. Press **Update all** to update Runtime, every installed workflow package,
+   and Hardware together, or use **Update** on one package card.
+6. Use **Restart** on the Runtime or Hardware card when that individual service
+   needs to restart.
+
+The editor reports progress and verifies package state after the action.
+Update operations stop active deployments and leave attached robots disarmed.
+Command-line maintenance is reserved for package development, diagnostics, and
+recovery when an editor action is unavailable.
+
 For remote SSH setup, choose **Add device → Remote SSH** and enter the
 computer's IP address, username, and password. Blacknode first displays the
 SSH host-key fingerprint for confirmation. After confirmation it installs the

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -30,6 +30,24 @@ class AgentSkillTests(unittest.TestCase):
             "canonical and repository-local Blacknode skills must stay synchronized",
         )
 
+    def test_managed_device_operations_are_documented_as_ui_first(self):
+        agent_instructions = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        agent_guide = (ROOT / "docs" / "agent-guide.md").read_text(encoding="utf-8")
+        lifecycle = (ROOT / "docs" / "project-lifecycle.md").read_text(
+            encoding="utf-8",
+        )
+
+        for text in (agent_instructions, agent_guide, lifecycle):
+            with self.subTest(document=text[:40]):
+                self.assertIn("**Devices**", text)
+                self.assertIn("**Software**", text)
+                self.assertIn("**Check updates**", text)
+                self.assertIn("**Update all**", text)
+                self.assertIn("**Restart**", text)
+
+        self.assertIn("primary operator surface", agent_instructions)
+        self.assertIn("fallback path", agent_instructions)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- records the Blacknode editor as the primary operator surface for managed devices in `AGENTS.md`
- documents the exact Devices → Software → Check updates → Update all flow for operators and agents
- identifies shell commands as a recovery, diagnostic, or package-development fallback
- adds a focused regression test for the required UI button labels and agent guidance

## Why

Routine managed-device updates and restarts are performed through Blacknode's UI. The repository guidance previously allowed command-line update instructions to be presented first, which did not match the established operator workflow.

## Impact

Agents and contributors now guide users through the Devices panel for managed-device package updates and service restarts. Operator documentation leads with the same button-based flow.

## Validation

- `git diff --check`
- `python -m unittest discover -s tests -p test_agent_skill.py`