### PR TITLE
Recognize ready attachment capabilities

### DIFF
--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -156,6 +156,11 @@ runtime. Pairing and discovery keep physical motion disarmed.
 When a robot is added while a Project is active, Blacknode links that robot to
 the Project automatically.
 
+A successful attachment check makes that enabled attachment's stable
+capability, such as `camera`, available to deployment preflight. A stopped,
+missing, or unchecked attachment does not satisfy a workflow capability
+requirement.
+
 ## 3. Choose the workflow
 
 Return to the Project and select **Choose workflow**. Start with a tested

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -6768,6 +6768,21 @@ def _device_deployment_attachments(device_id: str) -> list[dict[str, Any]]:
     return attachments
 
 
+def _ready_attachment_capabilities(device: dict[str, Any]) -> set[str]:
+    """Return enabled attachment capabilities proven ready by their latest check."""
+    return {
+        str(item.get("capability") or "").strip()
+        for item in (device.get("attachments") or [])
+        if (
+            isinstance(item, dict)
+            and item.get("enabled") is not False
+            and isinstance(item.get("last_check"), dict)
+            and item["last_check"].get("ok") is True
+            and str(item.get("capability") or "").strip()
+        )
+    }
+
+
 @app.post("/devices/{device_id}/deployment-preflight")
 def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
     try:
@@ -6966,7 +6981,7 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
         str(item)
         for item in (remote_status.get("capabilities") or [])
         if isinstance(item, str)
-    })
+    } | _ready_attachment_capabilities(device))
     if required_capabilities:
         missing_capabilities = sorted(set(required_capabilities) - set(available_capabilities))
         checks.append(_preflight_check(

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -4638,6 +4638,63 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertFalse(report["ready"])
         self.assertNotIn(hardware.token, response.text)
 
+    def test_deployment_preflight_accepts_a_ready_attachment_capability(self):
+        hardware = _HardwareService()
+        hardware.ros2_diagnostics_payload["topics"].append(
+            "/camera/image_raw [sensor_msgs/msg/Image]"
+        )
+        hardware.ros2_diagnostics_payload["topic_details"] = [{
+            "topic": "/camera/image_raw",
+            "ok": True,
+            "stdout": (
+                "Type: sensor_msgs/msg/Image\n\n"
+                "Publisher count: 1\n\nSubscription count: 0\n"
+            ),
+            "stderr": "",
+        }]
+        attachment = {
+            "attachment_id": "front_camera",
+            "display_name": "Front camera",
+            "attachment_type": "camera",
+            "capability": "camera",
+            "provider_package": "blacknode-perception",
+            "provider_component": "camera",
+            "provider_adapter": "ros2",
+            "provider_profile": "existing_topics",
+            "topic": "/camera/image_raw",
+            "message_type": "sensor_msgs/msg/Image",
+            "parent_frame": "base_link",
+            "frame_id": "camera_link",
+            "required": True,
+            "enabled": True,
+        }
+
+        with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
+            device_id = self.client.post("/devices", json={
+                "name": "Workshop arm",
+                "base_url": "http://192.168.1.87:8765",
+                "token": hardware.token,
+            }).json()["device"]["id"]
+            self.client.post(
+                f"/devices/{device_id}/attachments",
+                json=attachment,
+            )
+            checked = self.client.post(
+                f"/devices/{device_id}/attachments/front_camera/check",
+            )
+            response = self.client.post(
+                f"/devices/{device_id}/deployment-preflight",
+                json={"workflow": _workflow(["camera"])},
+            )
+
+        self.assertEqual(checked.status_code, 200)
+        self.assertTrue(checked.json()["check"]["ok"])
+        self.assertEqual(response.status_code, 200)
+        checks = {item["id"]: item for item in response.json()["checks"]}
+        self.assertEqual(checks["capabilities"]["status"], "pass")
+        self.assertFalse(checks["capabilities"]["blocking"])
+        self.assertIn("camera", checks["capabilities"]["message"])
+
     def test_selected_calibration_can_be_activated_and_satisfies_preflight(self):
         hardware = _HardwareService(status_overrides={
             "connection": {


### PR DESCRIPTION
## What changed

- includes enabled, successfully checked robot attachments in deployment capability preflight
- keeps missing, stopped, disabled, and unchecked attachments from satisfying workflow requirements
- adds a regression test using a healthy ROS 2 front-camera attachment
- documents how attachment health feeds deployment preflight

## Why

Robot 2's front camera was healthy and publishing `/camera/image_raw`, but deployment preflight only considered capabilities reported by the robot driver. That incorrectly blocked a workflow requiring the stable `camera` capability.

## Impact

Validated workflows can consume healthy attached cameras and other attachment-backed capabilities while retaining the normal armed-state and calibration safety gates.

## Validation

- focused deployment-preflight tests: 2 passed
- `PYTHONPATH=python python -m unittest discover -s tests`: 484 passed, 8 skipped
- representative Follower + Front Camera workflow: 8 nodes, 8 edges, validation clean
- live Robot 2 preflight: camera capability passes; armed-state gate remains blocking