### PR TITLE
Fix launcher restart tracking and onboarding fallback

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -66,6 +66,10 @@ core graph** when you want to begin with built-in nodes. Blacknode records the
 choice in `.blacknode/onboarding.json`; Packages stays available in the left
 sidebar.
 
+The welcome message opens only after the backend confirms that onboarding has
+not been completed. A backend startup or connectivity error keeps the current
+canvas state and is reported through the service status instead.
+
 ## 3. Check the Local Setup
 
 Keep Blacknode running. In a second terminal, activate its environment once;

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -253,10 +253,8 @@ export default function NodePalette() {
         }
       })
       .catch(() => {
-        if (active) {
-          setActiveTab('packages')
-          setShowPackageWelcome(true)
-        }
+        // A backend outage is not first-run state. Connectivity errors are
+        // surfaced by the editor's service status instead of onboarding.
       })
     return () => { active = false }
   }, [])

--- a/start.ps1
+++ b/start.ps1
@@ -316,7 +316,11 @@ function Assert-ProcessRunning {
     param(
         [System.Diagnostics.Process] $Process,
         [string] $Name,
-        [string] $ErrorLog
+        [string] $ErrorLog,
+        [ValidateSet("backend", "frontend")]
+        [string] $Service,
+        [int] $Port,
+        [scriptblock] $ReadyProbe
     )
 
     $Process.Refresh()
@@ -326,6 +330,24 @@ function Assert-ProcessRunning {
 
     if (Test-LauncherReplaced) {
         return $false
+    }
+
+    if (& $ReadyProbe) {
+        $ReplacementIds = @(Get-PortProcessIds -Port $Port)
+        if ($ReplacementIds.Count -eq 1) {
+            try {
+                $Replacement = Get-Process -Id $ReplacementIds[0] -ErrorAction Stop
+                if ($Service -eq "backend") {
+                    $script:BackendProcess = $Replacement
+                } else {
+                    $script:FrontendProcess = $Replacement
+                }
+                Write-Step "$Name restarted; launcher adopted process $($Replacement.Id)."
+                return $true
+            } catch {
+                # The listener changed between the health probe and process lookup.
+            }
+        }
     }
 
     Write-Host ""
@@ -513,7 +535,13 @@ try {
         -ErrLog $ServerErr
 
     Start-Sleep -Seconds 3
-    if (-not (Assert-ProcessRunning -Process $script:BackendProcess -Name "Python server" -ErrorLog $ServerErr)) {
+    if (-not (Assert-ProcessRunning `
+        -Process $script:BackendProcess `
+        -Name "Python server" `
+        -ErrorLog $ServerErr `
+        -Service "backend" `
+        -Port $BackendPort `
+        -ReadyProbe { Test-BlacknodeBackendReady })) {
         Write-Step "Startup handed off to a newer Blacknode launcher."
         return
     }
@@ -542,7 +570,13 @@ try {
         -ErrLog $EditorErr
 
     Start-Sleep -Seconds 5
-    if (-not (Assert-ProcessRunning -Process $script:FrontendProcess -Name "Visual editor" -ErrorLog $EditorErr)) {
+    if (-not (Assert-ProcessRunning `
+        -Process $script:FrontendProcess `
+        -Name "Visual editor" `
+        -ErrorLog $EditorErr `
+        -Service "frontend" `
+        -Port $FrontendPort `
+        -ReadyProbe { Test-BlacknodeEditorReady })) {
         Write-Step "Startup handed off to a newer Blacknode launcher."
         return
     }
@@ -554,11 +588,23 @@ try {
     Write-Host ""
 
     while ($true) {
-        if (-not (Assert-ProcessRunning -Process $script:BackendProcess -Name "Python server" -ErrorLog $ServerErr)) {
+        if (-not (Assert-ProcessRunning `
+            -Process $script:BackendProcess `
+            -Name "Python server" `
+            -ErrorLog $ServerErr `
+            -Service "backend" `
+            -Port $BackendPort `
+            -ReadyProbe { Test-BlacknodeBackendReady })) {
             Write-Step "Blacknode was restarted by another launcher."
             return
         }
-        if (-not (Assert-ProcessRunning -Process $script:FrontendProcess -Name "Visual editor" -ErrorLog $EditorErr)) {
+        if (-not (Assert-ProcessRunning `
+            -Process $script:FrontendProcess `
+            -Name "Visual editor" `
+            -ErrorLog $EditorErr `
+            -Service "frontend" `
+            -Port $FrontendPort `
+            -ReadyProbe { Test-BlacknodeEditorReady })) {
             Write-Step "Blacknode was restarted by another launcher."
             return
         }

--- a/tests/test_editor_package_welcome.py
+++ b/tests/test_editor_package_welcome.py
@@ -17,3 +17,13 @@ def test_first_editor_visit_opens_packages_with_one_time_welcome():
     assert "Explore core templates" in source
     assert "useState<Tab | null>('templates')" in source
     assert "finishPackageWelcome('templates')" in source
+
+
+def test_backend_failure_does_not_open_the_first_run_welcome():
+    source = (ROOT / "editor" / "src" / "components" / "NodePalette.tsx").read_text(encoding="utf-8")
+    onboarding = source[source.index("api.getOnboarding()"):]
+    failure_handler = onboarding[onboarding.index(".catch(() => {"):onboarding.index("return () =>")]
+
+    assert "setShowPackageWelcome(true)" not in failure_handler
+    assert "setActiveTab('packages')" not in failure_handler
+    assert "A backend outage is not first-run state." in failure_handler

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -66,6 +66,20 @@ def test_windows_launcher_reuses_healthy_services_and_hands_off_cleanly():
     assert 'Write-Step "Blacknode was restarted by another launcher."' in powershell
 
 
+def test_windows_launcher_adopts_a_healthy_replacement_service():
+    powershell = (ROOT / "start.ps1").read_text(encoding="utf-8")
+
+    assert "if (& $ReadyProbe)" in powershell
+    assert "$ReplacementIds = @(Get-PortProcessIds -Port $Port)" in powershell
+    assert '$script:BackendProcess = $Replacement' in powershell
+    assert '$script:FrontendProcess = $Replacement' in powershell
+    assert 'Write-Step "$Name restarted; launcher adopted process $($Replacement.Id)."' in powershell
+    assert '-Service "backend"' in powershell
+    assert '-ReadyProbe { Test-BlacknodeBackendReady }' in powershell
+    assert '-Service "frontend"' in powershell
+    assert '-ReadyProbe { Test-BlacknodeEditorReady }' in powershell
+
+
 def test_windows_starter_always_restarts_running_services():
     batch = (ROOT / "start.bat").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## What changed

- adopt a healthy replacement backend or editor process instead of treating the original PID exit as a startup failure
- keep the package welcome closed when the onboarding request fails because the backend is unavailable
- document the onboarding/backend distinction and add launcher/UI regression coverage

## Root cause

The Windows launcher supervised only the PID it originally spawned. If a service was restarted independently, that PID exited even though a healthy Blacknode listener replaced it, so the launcher threw code 1. Separately, the editor interpreted any onboarding API failure as unseen onboarding and opened the Welcome dialog.

## Impact

Backend/editor reloads no longer produce a false launcher failure, and backend outages no longer appear as first-run onboarding.

## Validation

- `python -m pytest tests/test_launchers.py tests/test_editor_package_welcome.py -q`
- PowerShell parser validation for `start.ps1`
- `npm run build`
- `git diff --check`