### PR TITLE
Support split ROS 2 follower nodes

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -819,7 +819,7 @@ def _push_live_node_param_update(meta: dict[str, Any], key: str, value: Any, old
         if not result.get("ok", True) and "not running" not in str(result.get("report") or ""):
             print(f"[blacknode] live joint-slider update for {run_id}.{key}: {result.get('report')}")
         return
-    if meta.get("type") == "ROS2LeaderFollower":
+    if meta.get("type") in {"ROS2LeaderFollower", "ROS2FollowerJointPublisher"}:
         update_fn = _runtime_callable("ros2_live", _RUNTIME_MODULES["ros2_live"], "update_leader_follower_config")
         if update_fn is None:
             return
@@ -1613,7 +1613,7 @@ def update_param(node_id: str, req: UpdateParamReq):
         invalidated_meta = _session.node_meta.get(invalidated_id)
         if invalidated_meta is not None:
             _clear_runtime_status(invalidated_meta)
-            if invalidated_meta.get("type") == "ROS2LeaderFollower" and invalidated_id != node_id:
+            if invalidated_meta.get("type") in {"ROS2LeaderFollower", "ROS2FollowerJointPublisher"} and invalidated_id != node_id:
                 disarm_fn = _runtime_callable("ros2_live", _RUNTIME_MODULES["ros2_live"], "update_leader_follower_config")
                 if disarm_fn is not None:
                     run_id = str(invalidated_meta.get("params", {}).get("run_id") or "leader_follower").strip() or "leader_follower"
@@ -6004,6 +6004,8 @@ def _workflow_requires_deployment_telemetry(workflow: dict[str, Any]) -> bool:
         "RobotDriverLauncher",
         "ROS2JointSliders",
         "ROS2LeaderFollower",
+        "ROS2FollowerJointPublisher",
+        "ROS2LeaderJointSubscriber",
         "ROS2ManualMove",
         "ROS2SetJoint",
     }
@@ -6034,7 +6036,10 @@ def _workflow_motion_controls(workflow: dict[str, Any]) -> list[dict[str, str]]:
     for node_id, meta in (workflow.get("node_meta") or {}).items():
         if (
             not isinstance(meta, dict)
-            or str(meta.get("type") or "") != "ROS2LeaderFollower"
+            or str(meta.get("type") or "") not in {
+                "ROS2LeaderFollower",
+                "ROS2FollowerJointPublisher",
+            }
         ):
             continue
         params = meta.get("params") if isinstance(meta.get("params"), dict) else {}
@@ -6059,7 +6064,11 @@ def _disarm_workflow_motion_controls(workflow: dict[str, Any]) -> list[str]:
     controlled_ids = {
         str(node_id)
         for node_id, meta in node_meta.items()
-        if isinstance(meta, dict) and str(meta.get("type") or "") == "ROS2LeaderFollower"
+        if isinstance(meta, dict)
+        and str(meta.get("type") or "") in {
+            "ROS2LeaderFollower",
+            "ROS2FollowerJointPublisher",
+        }
     }
     if not controlled_ids:
         return []

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1194,7 +1194,9 @@ export default function App() {
   )).length
   const managedRunCount = nodes.filter(n => n.data.type === 'ROS2Run' && n.data.portResults?.running === true).length
   const controllerNodes = nodes.filter(n => (
-    n.data.type === 'RobotFollow' || n.data.type === 'ROS2LeaderFollower'
+    n.data.type === 'RobotFollow'
+    || n.data.type === 'ROS2LeaderFollower'
+    || n.data.type === 'ROS2FollowerJointPublisher'
   ))
   const controllerRunningCount = controllerNodes.filter(n => n.data.portResults?.running === true).length
   const controllerCount = controllerNodes.filter(n => n.data.portResults?.live === true).length

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -25,6 +25,7 @@ const JOINT_MOTION_NODE_TYPES = new Set([
   'ROS2ManualMove',
   'ROS2JointSliders',
   'ROS2LeaderFollower',
+  'ROS2FollowerJointPublisher',
   'ROS2NativeFollowDetectionJoint',
   'ROS2FollowDetectionJoint',
   'RobotFollow',

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -657,7 +657,9 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
       },
     }
   }
-  if (data.type === 'RobotFollow' || data.type === 'ROS2LeaderFollower') {
+  if (data.type === 'RobotFollow'
+    || data.type === 'ROS2LeaderFollower'
+    || data.type === 'ROS2FollowerJointPublisher') {
     return {
       ...base,
       portResults: {
@@ -3511,6 +3513,8 @@ export const useStore = create<Store>((set, get) => ({
           LIVE_STREAM_NODE_TYPES.has(n.data.type) ||
           n.data.type === 'RobotFollow' ||
           n.data.type === 'ROS2LeaderFollower' ||
+          n.data.type === 'ROS2FollowerJointPublisher' ||
+          n.data.type === 'ROS2LeaderJointSubscriber' ||
           n.data.type === 'ROS2ManualMove' ||
           n.data.type === 'ROS2MotionDashboard' ||
           n.data.type === 'Output' ||

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -41,6 +41,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                                 "RobotFollow",
                                 "ROS2FollowDetectionJoint",
                                 "ROS2LeaderFollower",
+                                "ROS2LeaderJointSubscriber",
+                                "ROS2FollowerJointPublisher",
                                 "ROS2NativeFollowDetectionJoint"
                             ]
                         }
@@ -68,6 +70,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "RobotFollow",
                 "ROS2FollowDetectionJoint",
                 "ROS2LeaderFollower",
+                "ROS2LeaderJointSubscriber",
+                "ROS2FollowerJointPublisher",
                 "ROS2NativeFollowDetectionJoint"
             ]
         },

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -5461,6 +5461,27 @@ class EditorDeviceApiTests(unittest.TestCase):
             }],
         )
 
+    def test_split_follower_publisher_declares_one_remote_armed_gate(self):
+        workflow = _workflow([])
+        workflow["node_meta"]["publisher"] = {
+            "id": "publisher",
+            "type": "ROS2FollowerJointPublisher",
+            "params": {
+                "run_id": "split follower",
+                "control_topic": "",
+                "armed": False,
+            },
+        }
+
+        controls = server._workflow_motion_controls(workflow)
+
+        self.assertEqual(len(controls), 1)
+        self.assertEqual(controls[0]["node_id"], "publisher")
+        self.assertEqual(
+            controls[0]["topic"],
+            "/blacknode/leader_follower/split_follower/control",
+        )
+
     def test_remote_leader_follower_export_is_forced_disarmed(self):
         workflow = _workflow([])
         workflow["edges"] = [

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -100,6 +100,8 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["HDF5EpisodeExport"]["package"] == "blacknode-dataset"
     assert payload["nodes"]["StreamPublisher"]["package"] == "blacknode-dataset"
     assert payload["nodes"]["ROS2LeaderFollower"]["package"] == "blacknode-skills"
+    assert payload["nodes"]["ROS2LeaderJointSubscriber"]["package"] == "blacknode-skills"
+    assert payload["nodes"]["ROS2FollowerJointPublisher"]["package"] == "blacknode-skills"
     assert payload["nodes"]["PolicyRuntime"]["package"] == "blacknode-controllers"
     assert payload["nodes"]["BaseSafetyGate"]["package"] == "blacknode-controllers"
     assert payload["nodes"]["Camera"]["package"] == "blacknode-perception"


### PR DESCRIPTION
## What changed

- recognize `ROS2LeaderJointSubscriber` and `ROS2FollowerJointPublisher` in package resolution and deployment telemetry
- treat the follower publisher as the remotely armable motion gate
- clear and count the split runtime nodes correctly in the editor
- add index and deployment-control regression tests

## Why

The follower deployment is being decomposed into a real managed ROS 2 subscription and a separate safety-gated command publisher. Core needs to understand those node contracts before the package template can use them.

## Impact

The editor can deploy, monitor, arm, disarm, and stop the split follower graph while legacy `ROS2LeaderFollower` workflows remain compatible.

## Validation

- `python -m unittest discover -s tests` — 485 passed, 8 skipped
- focused device/index suite — 120 passed
- `npm run build`
- `git diff --check`