### PR TITLE
Refresh package mappings on reload

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -26,13 +26,7 @@ from blacknode.learned import registry as learned_registry
 from blacknode.mcp import tools as mcp_tools
 from blacknode.node import _NODE_REGISTRY
 from blacknode.nodes import ai as ai_nodes
-from blacknode.package_index import (
-    package_index_payload,
-    resolve_workflow_dependencies,
-    template_adapter_requirements,
-    template_component_requirements,
-    workflow_node_types,
-)
+import blacknode.package_index as bn_package_index
 from blacknode.packages import MANIFEST_NAME as BN_MANIFEST_NAME
 from blacknode.packages import component_dependency_plan as bn_component_dependency_plan
 from blacknode.packages import adapter_dependency_plan as bn_adapter_dependency_plan
@@ -52,7 +46,6 @@ from blacknode.python_importer import import_workflow_python
 from blacknode.workflow import WorkflowRunError, export_workflow_python
 from blacknode.workflow import validate_graph as validate_bn_graph
 from blacknode.workflow import validate_workflow as validate_bn_workflow
-
 from device_installer import (
     adopt_legacy_hardware_services,
     configure_hardware_services,
@@ -89,6 +82,27 @@ from local_runtime import (
 from artifact_store import ArtifactStore, ArtifactStoreError
 from project_store import ProjectStore, ProjectStoreError
 from run_store import RunStore
+
+
+def package_index_payload(*args, **kwargs):
+    return bn_package_index.package_index_payload(*args, **kwargs)
+
+
+def resolve_workflow_dependencies(*args, **kwargs):
+    return bn_package_index.resolve_workflow_dependencies(*args, **kwargs)
+
+
+def template_adapter_requirements(*args, **kwargs):
+    return bn_package_index.template_adapter_requirements(*args, **kwargs)
+
+
+def template_component_requirements(*args, **kwargs):
+    return bn_package_index.template_component_requirements(*args, **kwargs)
+
+
+def workflow_node_types(*args, **kwargs):
+    return bn_package_index.workflow_node_types(*args, **kwargs)
+
 
 app = FastAPI(title="Blacknode Editor Server")
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
@@ -9434,7 +9448,8 @@ def get_package_index():
 @app.post("/packages/reload")
 def reload_packages():
     report = discover_bn_packages()
-    return {"ok": not report["failed"], **report}
+    importlib.reload(bn_package_index)
+    return {"ok": not report["failed"], "index_refreshed": True, **report}
 
 
 class InstallPackageReq(BaseModel):

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1208,7 +1208,7 @@ export const api = {
   // switching tabs or saving a script doesn't fire a burst of git commands.
   packages:  (withGit = false)               => req<{ packages: BnPackage[] }>('GET', withGit ? '/packages?git=true' : '/packages'),
   packageIndex: ()                           => req<BnPackageIndex>('GET', '/packages/index'),
-  reloadPackages: ()                         => req<{ ok: boolean }>('POST', '/packages/reload'),
+  reloadPackages: ()                         => req<{ ok: boolean; index_refreshed: boolean }>('POST', '/packages/reload'),
   installPackage: (url: string)              => req<{ ok: boolean; package: BnPackage | null; error: string; log: string[] }>('POST', '/packages/install', { url }),
   setupPackage: (name: string)               => req<{ ok: boolean; package: BnPackage | null; log: string[] }>('POST', `/packages/${encodeURIComponent(name)}/setup`),
   setPackageComponent: (name: string, component: string, enabled: boolean) =>

--- a/editor/src/components/PackagesPanel.tsx
+++ b/editor/src/components/PackagesPanel.tsx
@@ -129,6 +129,7 @@ export default function PackagesPanel() {
       await api.reloadPackages()
       await refresh()
       await loadNodeTypes()
+      window.dispatchEvent(new Event('blacknode:packages-reloaded'))
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {

--- a/editor/src/components/TemplateGallery.tsx
+++ b/editor/src/components/TemplateGallery.tsx
@@ -107,6 +107,12 @@ export default function TemplateGallery({
     refreshTemplates()
   }, [])
 
+  useEffect(() => {
+    const handlePackagesReloaded = () => setMissing({})
+    window.addEventListener('blacknode:packages-reloaded', handlePackagesReloaded)
+    return () => window.removeEventListener('blacknode:packages-reloaded', handlePackagesReloaded)
+  }, [])
+
   const loadTemplate = async (template: TemplateMeta) => {
     setLoading(template.slug)
     setLoaded(null)

--- a/tests/test_editor_template_packages.py
+++ b/tests/test_editor_template_packages.py
@@ -97,6 +97,25 @@ def test_component_dependency_plan_endpoint():
     resolver.assert_called_once_with("blacknode-adapter", "camera")
 
 
+def test_package_reload_refreshes_package_index():
+    report = {"loaded": [], "failed": []}
+    with (
+        patch.object(server, "discover_bn_packages", return_value=report) as discover,
+        patch.object(server.importlib, "reload", return_value=server.bn_package_index) as reload_module,
+    ):
+        response = TestClient(server.app).post("/packages/reload")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "index_refreshed": True,
+        "loaded": [],
+        "failed": [],
+    }
+    discover.assert_called_once_with()
+    reload_module.assert_called_once_with(server.bn_package_index)
+
+
 def test_nested_adapter_endpoints_preserve_component_ownership():
     plan = {
         "target": {"package": "blacknode-drivers", "component": "feetech", "adapter": "ros2"},


### PR DESCRIPTION
## What changed

- Reload the package index when the Packages panel reloads extension packages.
- Keep the editor server's package-index helpers live and backward-compatible.
- Clear stale template dependency errors after package reload.
- Add regression coverage for the reload contract.

## Why

The package loader could discover newly added node types while the editor server continued using an older in-memory node-to-package index. Templates then displayed `No package mapping` for valid package nodes and left the error card stuck after reload.

## User impact

Packages → Reload now refreshes both registered nodes and their package mappings. Template cards can be retried immediately from the UI, including `ROS2LeaderJointSubscriber` and `ROS2FollowerJointPublisher` from `blacknode-skills`.

## Validation

- `python -m pytest tests/test_editor_template_packages.py tests/test_package_index.py tests/test_editor_devices.py -q` — 126 passed
- `PYTHONPATH=python python -m unittest discover -s tests` — 485 passed, 8 skipped
- `cd editor && npm run build` — passed
- Package index maps both split ROS 2 nodes to `blacknode-skills`