### PR TITLE
Support generic ROS 2 joint transport nodes

### DIFF
--- a/docs/so-arm101-leader-follower.md
+++ b/docs/so-arm101-leader-follower.md
@@ -21,10 +21,11 @@ from exchanging roles if operating-system discovery order changes.
 ## Start safely
 
 1. Support the leader arm and clear the follower workspace.
-2. Keep `ROS2LeaderFollower.armed=false` and press **Go live**.
+2. Keep `ROS2JointPublish.armed=false` and press **Go live**.
 3. Confirm leader torque is released and the dashboard shows live leader, safe
    target, and follower values. Moving the leader must not move the follower.
-4. Set `armed=true`. The live controller applies this immediately while limits,
+4. Set `ROS2JointPublish.armed=true`. The live publisher applies this
+   immediately while limits,
    bounded steps, deadband, and stale-message suppression remain active.
 5. Set `armed=false` or press **Stop all** before touching the follower.
 

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -833,7 +833,11 @@ def _push_live_node_param_update(meta: dict[str, Any], key: str, value: Any, old
         if not result.get("ok", True) and "not running" not in str(result.get("report") or ""):
             print(f"[blacknode] live joint-slider update for {run_id}.{key}: {result.get('report')}")
         return
-    if meta.get("type") in {"ROS2LeaderFollower", "ROS2FollowerJointPublisher"}:
+    if meta.get("type") in {
+        "ROS2LeaderFollower",
+        "ROS2FollowerJointPublisher",
+        "ROS2JointPublish",
+    }:
         update_fn = _runtime_callable("ros2_live", _RUNTIME_MODULES["ros2_live"], "update_leader_follower_config")
         if update_fn is None:
             return
@@ -1627,7 +1631,11 @@ def update_param(node_id: str, req: UpdateParamReq):
         invalidated_meta = _session.node_meta.get(invalidated_id)
         if invalidated_meta is not None:
             _clear_runtime_status(invalidated_meta)
-            if invalidated_meta.get("type") in {"ROS2LeaderFollower", "ROS2FollowerJointPublisher"} and invalidated_id != node_id:
+            if invalidated_meta.get("type") in {
+                "ROS2LeaderFollower",
+                "ROS2FollowerJointPublisher",
+                "ROS2JointPublish",
+            } and invalidated_id != node_id:
                 disarm_fn = _runtime_callable("ros2_live", _RUNTIME_MODULES["ros2_live"], "update_leader_follower_config")
                 if disarm_fn is not None:
                     run_id = str(invalidated_meta.get("params", {}).get("run_id") or "leader_follower").strip() or "leader_follower"
@@ -6018,6 +6026,8 @@ def _workflow_requires_deployment_telemetry(workflow: dict[str, Any]) -> bool:
         "RobotDriverLauncher",
         "ROS2JointSliders",
         "ROS2LeaderFollower",
+        "ROS2JointSubscribe",
+        "ROS2JointPublish",
         "ROS2FollowerJointPublisher",
         "ROS2LeaderJointSubscriber",
         "ROS2ManualMove",
@@ -6052,6 +6062,7 @@ def _workflow_motion_controls(workflow: dict[str, Any]) -> list[dict[str, str]]:
             not isinstance(meta, dict)
             or str(meta.get("type") or "") not in {
                 "ROS2LeaderFollower",
+                "ROS2JointPublish",
                 "ROS2FollowerJointPublisher",
             }
         ):
@@ -6081,6 +6092,7 @@ def _disarm_workflow_motion_controls(workflow: dict[str, Any]) -> list[str]:
         if isinstance(meta, dict)
         and str(meta.get("type") or "") in {
             "ROS2LeaderFollower",
+            "ROS2JointPublish",
             "ROS2FollowerJointPublisher",
         }
     }

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -41,6 +41,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                                 "RobotFollow",
                                 "ROS2FollowDetectionJoint",
                                 "ROS2LeaderFollower",
+                                "ROS2JointSubscribe",
+                                "ROS2JointPublish",
                                 "ROS2LeaderJointSubscriber",
                                 "ROS2FollowerJointPublisher",
                                 "ROS2NativeFollowDetectionJoint"
@@ -70,6 +72,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "RobotFollow",
                 "ROS2FollowDetectionJoint",
                 "ROS2LeaderFollower",
+                "ROS2JointSubscribe",
+                "ROS2JointPublish",
                 "ROS2LeaderJointSubscriber",
                 "ROS2FollowerJointPublisher",
                 "ROS2NativeFollowDetectionJoint"

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -5482,6 +5482,27 @@ class EditorDeviceApiTests(unittest.TestCase):
             "/blacknode/leader_follower/split_follower/control",
         )
 
+    def test_generic_joint_publisher_declares_one_remote_armed_gate(self):
+        workflow = _workflow([])
+        workflow["node_meta"]["publish"] = {
+            "id": "publish",
+            "type": "ROS2JointPublish",
+            "params": {
+                "run_id": "joint publisher",
+                "control_topic": "",
+                "armed": False,
+            },
+        }
+
+        controls = server._workflow_motion_controls(workflow)
+
+        self.assertEqual(len(controls), 1)
+        self.assertEqual(controls[0]["node_id"], "publish")
+        self.assertEqual(
+            controls[0]["topic"],
+            "/blacknode/leader_follower/joint_publisher/control",
+        )
+
     def test_remote_leader_follower_export_is_forced_disarmed(self):
         workflow = _workflow([])
         workflow["edges"] = [

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -100,6 +100,8 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["HDF5EpisodeExport"]["package"] == "blacknode-dataset"
     assert payload["nodes"]["StreamPublisher"]["package"] == "blacknode-dataset"
     assert payload["nodes"]["ROS2LeaderFollower"]["package"] == "blacknode-skills"
+    assert payload["nodes"]["ROS2JointSubscribe"]["package"] == "blacknode-skills"
+    assert payload["nodes"]["ROS2JointPublish"]["package"] == "blacknode-skills"
     assert payload["nodes"]["ROS2LeaderJointSubscriber"]["package"] == "blacknode-skills"
     assert payload["nodes"]["ROS2FollowerJointPublisher"]["package"] == "blacknode-skills"
     assert payload["nodes"]["PolicyRuntime"]["package"] == "blacknode-controllers"


### PR DESCRIPTION
## What changed

- Index `ROS2JointSubscribe` and `ROS2JointPublish` as `blacknode-skills` nodes.
- Recognize `ROS2JointPublish` as the safety-gated deployment motion control.
- Preserve forced-disarmed deployment export and live arm/disarm updates for the new publisher.
- Include the generic nodes in deployment telemetry detection.
- Update the leader/follower guide and add regression coverage.

## Why

The ROS 2 templates now expose role-neutral subscribe and publish nodes. Core deployment handling must recognize the new names while continuing to support saved graphs that use the compatibility aliases.

## Validation

- `PYTHONPATH=python python -m unittest discover -s tests` — 486 passed, 8 skipped
- `python -m pytest tests/test_package_index.py tests/test_editor_devices.py -q` — 122 passed
- Package templates validated independently in blacknode-skills PR #12