### PR TITLE
Derive node mappings from package manifests

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -187,18 +187,22 @@ standalone scripts, but it should still be an export target, not a node.
 
 ## Missing-node resolution
 
-Blacknode ships a small core index that maps official extension node types to
-their package name and Git URL. The editor backend exposes it at:
+Blacknode combines its shipped official-package catalog with the `node-types`
+declared by every installed package manifest. The resulting live index maps
+extension node types to their package name and Git URL. The editor backend
+exposes it at:
 
 ```text
 GET /packages/index
 ```
 
 Template loading scans every root and nested node type before validation. When
-a type is unavailable, the loader combines the core index with the template's
-optional `metadata.required_packages` declaration. The Templates tab then
-shows the missing package, installs it through the existing package installer,
-refreshes node definitions, and retries the load.
+a type is unavailable, the loader combines the live manifest index with the
+template's optional `metadata.required_packages` declaration. A package update
+can therefore publish new nodes without waiting for a matching core catalog
+release. The Templates tab then shows the owning package, installs or reloads
+it through the existing package controls, refreshes node definitions, and
+retries the load.
 
 Indexed packages only need their name:
 

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -879,21 +879,100 @@ _NODE_PACKAGE_INDEX: dict[str, dict[str, str]] = {
 }
 
 
+def _manifest_node_types(info: Any) -> set[str]:
+    """Collect every node type declared by an installed package manifest."""
+    declared = {
+        str(node_type)
+        for node_type in getattr(info, "node_types", [])
+        if str(node_type)
+    }
+    components = getattr(info, "components", {})
+    if not isinstance(components, Mapping):
+        return declared
+    for component in components.values():
+        if not isinstance(component, Mapping):
+            continue
+        declared.update(
+            str(node_type)
+            for node_type in component.get("node_types", [])
+            if str(node_type)
+        )
+        adapters = component.get("adapters", {})
+        if not isinstance(adapters, Mapping):
+            continue
+        for adapter in adapters.values():
+            if not isinstance(adapter, Mapping):
+                continue
+            declared.update(
+                str(node_type)
+                for node_type in adapter.get("node_types", [])
+                if str(node_type)
+            )
+    return declared
+
+
+def _runtime_package_index() -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, str]]]:
+    """Merge installed self-describing manifests over the shipped catalog."""
+    packages = {
+        name: {
+            **package,
+            "node_types": list(package["node_types"]),
+        }
+        for name, package in _CORE_PACKAGES.items()
+    }
+    nodes = {
+        node_type: dict(resolution)
+        for node_type, resolution in _NODE_PACKAGE_INDEX.items()
+    }
+    try:
+        from .packages import installed_packages
+
+        installed = installed_packages()
+    except Exception:
+        installed = []
+
+    for info in installed:
+        name = str(getattr(info, "name", "") or "").strip()
+        if not name:
+            continue
+        declared = _manifest_node_types(info)
+        package = packages.get(name)
+        if package is None:
+            git_status = getattr(info, "git_status", {})
+            git_url = (
+                str(git_status.get("remote") or "")
+                if isinstance(git_status, Mapping)
+                else ""
+            )
+            package = {
+                "name": name,
+                "layer": str(getattr(info, "layer", "") or "extensions"),
+                "components": getattr(info, "components", {}),
+                "git_url": git_url,
+                "description": str(getattr(info, "description", "") or ""),
+                "node_types": [],
+            }
+            packages[name] = package
+        package["node_types"] = sorted({
+            *package.get("node_types", []),
+            *declared,
+        })
+        git_url = str(package.get("git_url") or "")
+        for node_type in declared:
+            nodes.setdefault(node_type, {
+                "package": name,
+                "git_url": git_url,
+            })
+    return packages, nodes
+
+
 def package_index_payload() -> dict[str, Any]:
-    """Return a JSON-safe copy of the package and node lookup index."""
+    """Return the shipped catalog enriched by installed package manifests."""
+    packages, nodes = _runtime_package_index()
     return {
         "schema_version": 2,
-        "packages": {
-            name: {
-                **package,
-                "node_types": list(package["node_types"]),
-            }
-            for name, package in _CORE_PACKAGES.items()
-        },
-        "nodes": {
-            node_type: dict(resolution)
-            for node_type, resolution in _NODE_PACKAGE_INDEX.items()
-        },
+        "packages": packages,
+        "nodes": nodes,
     }
 
 
@@ -1060,6 +1139,7 @@ def resolve_workflow_dependencies(
     missing_adapters: list[dict[str, Any]] = []
     component_plans: list[dict[str, Any]] = []
     unresolved_node_types: list[str] = []
+    _, runtime_node_index = _runtime_package_index()
 
     def installed_component(
         components: Any,
@@ -1184,14 +1264,18 @@ def resolve_workflow_dependencies(
             None,
         )
         if requirement is None:
-            resolution = _NODE_PACKAGE_INDEX.get(node_type)
+            resolution = runtime_node_index.get(node_type)
             if resolution is not None:
                 package_name = resolution["package"]
                 requirement = {
                     "name": package_name,
                     "git_url": explicit.get(package_name, {}).get("git_url", resolution["git_url"]),
                     "node_types": [node_type],
-                    "source": "core_index",
+                    "source": (
+                        "core_index"
+                        if node_type in _NODE_PACKAGE_INDEX
+                        else "package_manifest"
+                    ),
                 }
         if requirement is None:
             unresolved_node_types.append(node_type)

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from blacknode.package_index import (
     package_index_payload,
     resolve_workflow_dependencies,
@@ -120,6 +123,53 @@ def test_core_index_maps_official_node_types_to_git_packages():
         "git_url": "https://github.com/temiroff/blacknode-isaac.git",
     }
     assert payload["nodes"]["IsaacPolicyRuntime"]["package"] == "blacknode-isaac"
+
+
+def test_installed_package_manifest_maps_new_node_types_without_core_edit():
+    info = SimpleNamespace(
+        name="blacknode-skills",
+        layer="skills",
+        description="skills",
+        git_status={},
+        node_types=[],
+        components={
+            "follow": {
+                "node_types": [],
+                "adapters": {
+                    "ros2": {
+                        "node_types": ["ROS2FutureJointNode"],
+                    },
+                },
+            },
+        },
+    )
+    with patch("blacknode.packages.installed_packages", return_value=[info]):
+        payload = package_index_payload()
+        result = resolve_workflow_dependencies(
+            _workflow("ROS2FutureJointNode"),
+            available_node_types={"NestedNode"},
+            installed_packages={
+                "blacknode-skills": {
+                    "ok": True,
+                    "error": "",
+                },
+            },
+        )
+
+    assert payload["nodes"]["ROS2FutureJointNode"] == {
+        "package": "blacknode-skills",
+        "git_url": "https://github.com/temiroff/blacknode-skills.git",
+    }
+    assert "ROS2FutureJointNode" in payload["packages"]["blacknode-skills"]["node_types"]
+    assert result["unresolved_node_types"] == []
+    assert result["missing_packages"] == [{
+        "name": "blacknode-skills",
+        "git_url": "https://github.com/temiroff/blacknode-skills.git",
+        "node_types": ["ROS2FutureJointNode"],
+        "source": "package_manifest",
+        "installed": True,
+        "load_error": "",
+    }]
 
 
 def test_resolver_finds_nested_nodes_and_indexed_package():


### PR DESCRIPTION
## What changed

- Merge installed package manifest `node-types` into the live package/node index.
- Resolve workflow dependencies from that live manifest index rather than only the shipped static catalog.
- Preserve the official catalog as the authoritative release-drift check.
- Document package manifests as the runtime source of truth for newly published nodes.
- Add regression coverage for a package node that does not yet exist in core's static catalog.

## Root cause

A package could update and declare a new node while the running core catalog still lacked that node name. The editor then reported `No package mapping` even though the owning package was installed and self-described the node in `blacknode-package.toml`.

## User impact

Package reloads can recognize newly added nodes from blacknode-skills, perception, ROS 2, and other packages without waiting for a separate core mapping edit.

## Validation

- `python -m pytest tests/test_package_index.py tests/test_editor_template_packages.py -q` — 13 passed
- `PYTHONPATH=python python -m unittest discover -s tests` — 486 passed, 8 skipped