### PR TITLE
Hide compatibility templates from gallery

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -393,6 +393,8 @@ sources, and enabled components.
 components and their enabled adapters. It also runs only the enabled units'
 declared `.py` or `.sh` `setup-hooks`; paths must remain inside the package.
 Enabled component and adapter `templates` paths are added to the Templates tab.
+Set `metadata.hidden: true` on compatibility templates that must remain
+loadable by slug but should not appear as a new-workflow choice.
 pip reuses already satisfied
 dependencies and checks declared version constraints. Component node modules use aliases such as
 `blacknode.pkg.blacknode_drivers.feetech.<module>`.

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -10555,6 +10555,13 @@ def list_templates():
                 continue
             try:
                 data = _read_workflow_file(os.path.join(templates_dir, fname))
+                metadata = (
+                    data.get("metadata")
+                    if isinstance(data.get("metadata"), dict)
+                    else {}
+                )
+                if bool(metadata.get("hidden", False)):
+                    continue
                 result.append(_workflow_summary(
                     slug,
                     data,

--- a/tests/test_editor_template_packages.py
+++ b/tests/test_editor_template_packages.py
@@ -158,6 +158,11 @@ def test_template_list_groups_core_and_package_templates(tmp_path: Path):
     (robot_dir / "motion-test.json").write_text(
         json.dumps(_template("Robot")), encoding="utf-8",
     )
+    hidden = _template("ROS2LeaderFollower")
+    hidden["metadata"]["hidden"] = True
+    (robot_dir / "legacy-motion.json").write_text(
+        json.dumps(hidden), encoding="utf-8",
+    )
     robot_package = SimpleNamespace(
         name="blacknode-robot",
         ok=True,
@@ -180,3 +185,4 @@ def test_template_list_groups_core_and_package_templates(tmp_path: Path):
     assert templates["motion-test"]["group"] == "Robot"
     assert templates["motion-test"]["group_color"] == "#14b8a6"
     assert templates["motion-test"]["required_packages"] == ["blacknode-cuda"]
+    assert "legacy-motion" not in templates


### PR DESCRIPTION
## What changed

- Exclude templates with `metadata.hidden: true` from the Templates gallery.
- Keep hidden templates loadable directly by slug for saved links and compatibility.
- Document the compatibility-template visibility contract.
- Add regression coverage proving hidden package templates are not listed.

## Why

Packages may retain older or hardware-specific templates for compatibility, but those files should not compete with the current recommended workflow pair in the new-workflow gallery.

## Validation

- `python -m pytest tests/test_editor_template_packages.py packages/blacknode-skills/tests -q` — 37 passed
- `PYTHONPATH=python python -m unittest discover -s tests` — 486 passed, 8 skipped
- All seven blacknode-skills ROS 2 templates validate with no errors or warnings