### PR TITLE
Fix ROS 2 follower arm control mapping

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -6026,6 +6026,11 @@ def _workflow_requires_deployment_telemetry(workflow: dict[str, Any]) -> bool:
         "RobotDriverLauncher",
         "ROS2JointSliders",
         "ROS2LeaderFollower",
+        "ROS2PublishJointState",
+        "ROS2SubscribeJointState",
+        "ROS2JointController",
+        "ROS2JointStatePublish",
+        "ROS2JointReplicate",
         "ROS2JointSubscribe",
         "ROS2JointPublish",
         "ROS2FollowerJointPublisher",
@@ -6062,6 +6067,8 @@ def _workflow_motion_controls(workflow: dict[str, Any]) -> list[dict[str, str]]:
             not isinstance(meta, dict)
             or str(meta.get("type") or "") not in {
                 "ROS2LeaderFollower",
+                "ROS2JointController",
+                "ROS2JointReplicate",
                 "ROS2JointPublish",
                 "ROS2FollowerJointPublisher",
             }
@@ -6092,6 +6099,8 @@ def _disarm_workflow_motion_controls(workflow: dict[str, Any]) -> list[str]:
         if isinstance(meta, dict)
         and str(meta.get("type") or "") in {
             "ROS2LeaderFollower",
+            "ROS2JointController",
+            "ROS2JointReplicate",
             "ROS2JointPublish",
             "ROS2FollowerJointPublisher",
         }

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -2259,7 +2259,7 @@ export default function DevicesPanel() {
     }
     throw new Error(
       expected
-        ? 'Follower did not confirm physical torque within 8 seconds.'
+        ? 'Follower did not confirm physical torque within 8 seconds. Verify the leader publisher deployment is running with a fresh JointState stream, then check follower power and bus.'
         : 'Follower did not confirm torque release within 8 seconds.',
     )
   }

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -5503,6 +5503,27 @@ class EditorDeviceApiTests(unittest.TestCase):
             "/blacknode/leader_follower/joint_publisher/control",
         )
 
+    def test_joint_controller_declares_one_remote_armed_gate(self):
+        workflow = _workflow([])
+        workflow["node_meta"]["controller"] = {
+            "id": "controller",
+            "type": "ROS2JointController",
+            "params": {
+                "run_id": "joint controller",
+                "control_topic": "",
+                "armed": False,
+            },
+        }
+
+        controls = server._workflow_motion_controls(workflow)
+
+        self.assertEqual(len(controls), 1)
+        self.assertEqual(controls[0]["node_id"], "controller")
+        self.assertEqual(
+            controls[0]["topic"],
+            "/blacknode/leader_follower/joint_controller/control",
+        )
+
     def test_remote_leader_follower_export_is_forced_disarmed(self):
         workflow = _workflow([])
         workflow["edges"] = [
@@ -5547,6 +5568,21 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(
             workflow["metadata"]["deployment_motion_default"],
             "disarmed",
+        )
+
+    def test_joint_controller_export_is_forced_disarmed(self):
+        workflow = _workflow([])
+        workflow["node_meta"]["controller"] = {
+            "id": "controller",
+            "type": "ROS2JointController",
+            "params": {"armed": True},
+        }
+
+        controlled = server._disarm_workflow_motion_controls(workflow)
+
+        self.assertEqual(controlled, ["controller"])
+        self.assertFalse(
+            workflow["node_meta"]["controller"]["params"]["armed"]
         )
 
     def test_send_and_run_replaces_and_removes_older_target_deployments(self):
@@ -5616,6 +5652,16 @@ class EditorDeviceApiTests(unittest.TestCase):
         }
         self.assertTrue(
             server._workflow_requires_deployment_telemetry(robot_node_workflow)
+        )
+
+        controller_workflow = _workflow([])
+        controller_workflow["node_meta"]["controller"] = {
+            "id": "controller",
+            "type": "ROS2JointController",
+            "params": {},
+        }
+        self.assertTrue(
+            server._workflow_requires_deployment_telemetry(controller_workflow)
         )
 
     def test_project_owned_deployment_requires_linked_workflow_and_device(self):


### PR DESCRIPTION
## Summary
- recognize the visible ROS2JointController and compatibility aliases as deployment motion controls
- force the controller disarmed in staged deployment snapshots and require fresh robot telemetry
- make the torque timeout explain the required live leader JointState stream

## Verification
- python -m unittest discover -s tests (488 passed, 8 skipped)
- python -m pytest tests/test_editor_devices.py (117 passed)
- cd editor && npm run build