### PR TITLE
Open Nodes panel on editor startup

### DIFF
--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -159,7 +159,7 @@ export default function NodePalette() {
     loadNodeTypes,
     learnedNodeHighlight,
   } = useStore()
-  const [activeTab, setActiveTab] = useState<Tab | null>('templates')
+  const [activeTab, setActiveTab] = useState<Tab | null>('nodes')
   const [showPackageWelcome, setShowPackageWelcome] = useState(false)
   const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_W)
   const [deploymentTargetId, setDeploymentTargetId] = useState('')

--- a/tests/test_editor_package_welcome.py
+++ b/tests/test_editor_package_welcome.py
@@ -4,7 +4,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_first_editor_visit_opens_packages_with_one_time_welcome():
+def test_editor_starts_in_nodes_and_first_visit_opens_packages_with_welcome():
     source = (ROOT / "editor" / "src" / "components" / "NodePalette.tsx").read_text(encoding="utf-8")
 
     assert "api.getOnboarding()" in source
@@ -15,7 +15,7 @@ def test_first_editor_visit_opens_packages_with_one_time_welcome():
     assert "Prepare your robotics workspace" in source
     assert "Explore essential packages" in source
     assert "Explore core templates" in source
-    assert "useState<Tab | null>('templates')" in source
+    assert "useState<Tab | null>('nodes')" in source
     assert "finishPackageWelcome('templates')" in source
 
 


### PR DESCRIPTION
## Summary
- open the Nodes panel on normal editor launches
- keep Templates available only when selected or requested by a guided action
- preserve the first-run Packages onboarding behavior

## Verification
- python -m pytest tests/test_editor_package_welcome.py tests/test_editor_template_groups.py (5 passed)
- cd editor && npm run build