### PR TITLE
Return Deployments to the previous panel

### DIFF
--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -99,13 +99,13 @@ const REMOTE_STATE_LABEL: Record<RemoteDeploymentState, string> = {
 interface DeploymentsPanelProps {
   onOpenTemplates: (query: string) => void
   targetDeviceId?: string
-  onBackToDevices?: () => void
+  onBack?: () => void
 }
 
 export default function DeploymentsPanel({
   onOpenTemplates,
   targetDeviceId = '',
-  onBackToDevices,
+  onBack,
 }: DeploymentsPanelProps) {
   const [deployments, setDeployments] = useState<Deployment[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -791,10 +791,10 @@ export default function DeploymentsPanel({
     <div className="bn-runs-panel bn-deploy-panel">
       {isRobotContext ? (
         <div className="bn-deploy-nav">
-          {onBackToDevices && (
-            <button type="button" className="bn-deploy-nav-button" onClick={onBackToDevices}>
+          {onBack && (
+            <button type="button" className="bn-deploy-nav-button" onClick={onBack}>
               <span aria-hidden="true">←</span>
-              <span>All devices</span>
+              <span>Back</span>
             </button>
           )}
           <button
@@ -814,6 +814,7 @@ export default function DeploymentsPanel({
             <div className="bn-runs-subtitle">Choose a robot for the current workflow</div>
           </div>
           <div className="bn-runs-actions">
+            {onBack && <button onClick={onBack} style={miniButton}>← Back</button>}
             <button onClick={refresh} style={miniButton}>Refresh</button>
             <button onClick={() => handleDeploy(false)} disabled={busy} style={miniButton} title="Save the runnable script on this computer without running it">Save local</button>
             <button onClick={() => handleDeploy(true)} disabled={busy} style={primaryButton} title="Stop the live graph, then run it on this computer">Run local</button>

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -163,6 +163,7 @@ export default function NodePalette() {
   const [showPackageWelcome, setShowPackageWelcome] = useState(false)
   const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_W)
   const [deploymentTargetId, setDeploymentTargetId] = useState('')
+  const [deploymentReturnTab, setDeploymentReturnTab] = useState<Tab>('devices')
   const [templateSearch, setTemplateSearch] = useState('')
   const [templateOpenInNewTab, setTemplateOpenInNewTab] = useState(false)
   const [openGroups, setOpenGroups] = useState<Set<string>>(() => new Set())
@@ -174,6 +175,9 @@ export default function NodePalette() {
   }
 
   const openPanel = (tab: Tab) => {
+    if (tab === 'deployments' && activeTab && activeTab !== 'deployments') {
+      setDeploymentReturnTab(activeTab)
+    }
     setActiveTab(tab)
     if (tab === 'templates') {
       setTemplateSearch('')
@@ -789,7 +793,7 @@ export default function NodePalette() {
               <DeploymentsPanel
                 onOpenTemplates={openTemplateGuide}
                 targetDeviceId={deploymentTargetId}
-                onBackToDevices={() => openPanel('devices')}
+                onBack={() => openPanel(deploymentReturnTab)}
               />
             )}
 

--- a/tests/test_editor_package_welcome.py
+++ b/tests/test_editor_package_welcome.py
@@ -27,3 +27,15 @@ def test_backend_failure_does_not_open_the_first_run_welcome():
     assert "setShowPackageWelcome(true)" not in failure_handler
     assert "setActiveTab('packages')" not in failure_handler
     assert "A backend outage is not first-run state." in failure_handler
+
+
+def test_deployments_back_returns_to_the_previous_panel():
+    palette = (ROOT / "editor" / "src" / "components" / "NodePalette.tsx").read_text(encoding="utf-8")
+    deployments = (ROOT / "editor" / "src" / "components" / "DeploymentsPanel.tsx").read_text(encoding="utf-8")
+
+    assert "deploymentReturnTab" in palette
+    assert "activeTab !== 'deployments'" in palette
+    assert "setDeploymentReturnTab(activeTab)" in palette
+    assert "onBack={() => openPanel(deploymentReturnTab)}" in palette
+    assert "onBackToDevices" not in deployments
+    assert "<span>Back</span>" in deployments


### PR DESCRIPTION
## Summary
- remember which sidebar panel opened Deployments
- replace the hard-coded All devices action with Back
- return to Devices, Projects, Templates, or the actual previous panel

## Verification
- python -m pytest tests/test_editor_package_welcome.py (3 passed)
- cd editor && npm run build