### PR TITLE
Restore selected device after deployment

### DIFF
--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -470,7 +470,15 @@ function diagnoseDeviceMotion(
   return issues
 }
 
-export default function DevicesPanel() {
+interface DevicesPanelProps {
+  initialDeviceId?: string
+  onInitialDeviceRestored?: () => void
+}
+
+export default function DevicesPanel({
+  initialDeviceId = '',
+  onInitialDeviceRestored,
+}: DevicesPanelProps) {
   const isUiTest = document.documentElement.dataset.uiTest === 'refined'
   const activeProject = useStore(state => state.activeProject)
   const setActiveProject = useStore(state => state.setActiveProject)
@@ -483,7 +491,9 @@ export default function DevicesPanel() {
     Record<string, DeviceCheckIssue[]>
   >({})
   const [knownHardwareVersions, setKnownHardwareVersions] = useState<Record<string, string>>({})
-  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(
+    initialDeviceId || null,
+  )
   const [showDeviceForm, setShowDeviceForm] = useState(false)
   const [setupMode, setSetupMode] = useState<'local' | 'automatic' | 'manual'>('local')
   const [deviceName, setDeviceName] = useState('Local computer')
@@ -1073,6 +1083,10 @@ export default function DevicesPanel() {
 
   useEffect(() => {
     void refresh()
+  }, [])
+
+  useEffect(() => {
+    if (initialDeviceId) onInitialDeviceRestored?.()
   }, [])
 
   useEffect(() => {
@@ -4769,7 +4783,13 @@ export default function DevicesPanel() {
                 onRemove={() => removeRobot(robot)}
                 onDeploy={() => window.dispatchEvent(new CustomEvent(
                   'blacknode:open-panel',
-                  { detail: { tab: 'deployments', deviceId: robot.id } },
+                  {
+                    detail: {
+                      tab: 'deployments',
+                      deviceId: robot.id,
+                      returnDeviceId: selectedDevice.id,
+                    },
+                  },
                 ))}
                 onStopDeployment={deploymentId => stopDeployment(robot, deploymentId)}
                 onStartDeployment={(deploymentId, deploymentName) => (

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -164,6 +164,7 @@ export default function NodePalette() {
   const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_W)
   const [deploymentTargetId, setDeploymentTargetId] = useState('')
   const [deploymentReturnTab, setDeploymentReturnTab] = useState<Tab>('devices')
+  const [deploymentReturnDeviceId, setDeploymentReturnDeviceId] = useState('')
   const [templateSearch, setTemplateSearch] = useState('')
   const [templateOpenInNewTab, setTemplateOpenInNewTab] = useState(false)
   const [openGroups, setOpenGroups] = useState<Set<string>>(() => new Set())
@@ -221,11 +222,16 @@ export default function NodePalette() {
 
   useEffect(() => {
     const handleOpenPanel = (event: Event) => {
-      const detail = (event as CustomEvent<{ tab?: Tab; deviceId?: string }>).detail
+      const detail = (event as CustomEvent<{
+        tab?: Tab
+        deviceId?: string
+        returnDeviceId?: string
+      }>).detail
       const tab = detail?.tab
       if (!tab || (tab !== 'deployments' && !TABS.some(item => item.id === tab))) return
       if (tab === 'deployments') {
         setDeploymentTargetId(String(detail?.deviceId || ''))
+        setDeploymentReturnDeviceId(String(detail?.returnDeviceId || ''))
       }
       openPanel(tab)
     }
@@ -797,7 +803,12 @@ export default function NodePalette() {
               />
             )}
 
-            {activeTab === 'devices' && <DevicesPanel />}
+            {activeTab === 'devices' && (
+              <DevicesPanel
+                initialDeviceId={deploymentReturnDeviceId}
+                onInitialDeviceRestored={() => setDeploymentReturnDeviceId('')}
+              />
+            )}
 
             {/* ── RUNTIME ── */}
             {activeTab === 'runtime' && <RuntimePanel />}

--- a/tests/test_editor_package_welcome.py
+++ b/tests/test_editor_package_welcome.py
@@ -32,6 +32,7 @@ def test_backend_failure_does_not_open_the_first_run_welcome():
 def test_deployments_back_returns_to_the_previous_panel():
     palette = (ROOT / "editor" / "src" / "components" / "NodePalette.tsx").read_text(encoding="utf-8")
     deployments = (ROOT / "editor" / "src" / "components" / "DeploymentsPanel.tsx").read_text(encoding="utf-8")
+    devices = (ROOT / "editor" / "src" / "components" / "DevicesPanel.tsx").read_text(encoding="utf-8")
 
     assert "deploymentReturnTab" in palette
     assert "activeTab !== 'deployments'" in palette
@@ -39,3 +40,6 @@ def test_deployments_back_returns_to_the_previous_panel():
     assert "onBack={() => openPanel(deploymentReturnTab)}" in palette
     assert "onBackToDevices" not in deployments
     assert "<span>Back</span>" in deployments
+    assert "returnDeviceId: selectedDevice.id" in devices
+    assert "initialDeviceId={deploymentReturnDeviceId}" in palette
+    assert "onInitialDeviceRestored" in palette


### PR DESCRIPTION
## Summary
- carry the parent compute-device ID when a robot opens Deployments
- restore that device detail view when Back is pressed
- consume the return context once so later Devices visits behave normally

## Verification
- python -m pytest tests/test_editor_package_welcome.py (3 passed)
- cd editor && npm run build