### PR TITLE
Keep template categories collapsed by default

### DIFF
--- a/editor/src/components/TemplateGallery.tsx
+++ b/editor/src/components/TemplateGallery.tsx
@@ -43,7 +43,6 @@ export default function TemplateGallery({
   const [error, setError] = useState<string | null>(null)
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set())
   const [query, setQuery] = useState(initialQuery)
-  const isUiTest = document.documentElement.dataset.uiTest === 'refined'
 
   useEffect(() => {
     setQuery(initialQuery)
@@ -77,13 +76,6 @@ export default function TemplateGallery({
       }))
       .filter(group => group.templates.length > 0)
   }, [query, templateGroups])
-
-  useEffect(() => {
-    if (!isUiTest || templateGroups.length === 0) return
-    setExpandedGroups(current => (
-      current.size > 0 ? current : new Set([templateGroups[0].name])
-    ))
-  }, [isUiTest, templateGroups])
 
   const toggleGroup = (name: string) => {
     setExpandedGroups(current => {

--- a/tests/test_editor_template_groups.py
+++ b/tests/test_editor_template_groups.py
@@ -10,6 +10,7 @@ def test_template_gallery_groups_are_collapsed_by_default():
     ).read_text(encoding="utf-8")
 
     assert "useState<Set<string>>(() => new Set())" in source
+    assert "new Set([templateGroups[0].name])" not in source
     assert "template.group || 'Core'" in source
     assert "aria-expanded={isExpanded}" in source
     assert "isExpanded && group.templates.map" in source


### PR DESCRIPTION
## Summary
- remove the refined-mode effect that automatically expanded the first template category
- keep all categories collapsed when Templates opens
- retain automatic expansion only for active search results

## Verification
- python -m pytest tests/test_editor_template_groups.py tests/test_editor_package_welcome.py (6 passed)
- cd editor && npm run build