### PR TITLE
Adopt simplified package architecture

### DIFF
--- a/.agents/skills/blacknode-workflow/SKILL.md
+++ b/.agents/skills/blacknode-workflow/SKILL.md
@@ -128,8 +128,8 @@ or type error, inspect `get_node_schema` and fix the graph instead of guessing.
 
 - Prefer `Robot` for setup, then `ROS2Status`, `ROS2JointState`,
   `ROS2SetJoint`, and `ROS2ManualMove`. `ROS2Status` comes from
-  `blacknode-ros2`; the joint nodes come from the `blacknode-controllers`
-  joint-control ROS 2 adapter, so templates using them must require both
+  `blacknode-ros2`; the joint nodes come from the `blacknode-motion`
+  arm ROS 2 adapter, so templates using them must require both
   packages. Each node picks the transport itself via `transport=auto`.
 - Treat torque control and pose streaming as independent state:
   - `Release + live pose` disables torque and keeps joint feedback live. Support

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Build, run, inspect, and deploy robot behavior as typed visual workflows.**
 
-Blacknode connects robot hardware, perception, controllers, datasets, training,
+Blacknode connects robot hardware, perception, motion, datasets, training,
 simulation, and deployment on one visual canvas. Start with a tested robot
 template, inspect live state, authorize a bounded action, and follow every
 result through run history and replay.
@@ -35,7 +35,7 @@ Task skills and mission workflows
               │
        ┌──────┴──────┐
        ▼             ▼
-  Perception    Controllers + safety
+  Perception    Motion + safety
        │             │
        └──────┬──────┘
               ▼
@@ -52,12 +52,12 @@ Hardware drivers, cameras, buses, and the physical robot
 
 | Layer | What it owns | Packages |
 |---|---|---|
-| Tasks and missions | Reusable robot skills, planning, confirmation, and orchestration | [`blacknode-skills`](https://github.com/temiroff/blacknode-skills), [`blacknode-agent`](https://github.com/temiroff/blacknode-agent) |
+| Tasks and missions | Reusable robot skills, persistent memory, and executive mission orchestration | [`blacknode-skills`](https://github.com/temiroff/blacknode-skills), [`blacknode-agent`](https://github.com/temiroff/blacknode-agent) |
 | Perception | Cameras, tracking, VLMs, and spatial observations | [`blacknode-perception`](https://github.com/temiroff/blacknode-perception) |
-| Control and safety | Joint control, mobile bases, manipulation, policies, arbitration, limits, freshness checks, and stop paths | [`blacknode-controllers`](https://github.com/temiroff/blacknode-controllers) |
-| Robot model | Robot profiles, capability contracts, calibration, discovery, and connection health | [`blacknode-robot`](https://github.com/temiroff/blacknode-robot) |
+| Motion and safety | Arm and base planning, trajectories, execution, policy, arbitration, and safety | [`blacknode-motion`](https://github.com/temiroff/blacknode-motion) |
+| Robot model and devices | Robot profiles, connected-device lifecycle, capability contracts, calibration, discovery, health, and normalized telemetry | [`blacknode-robot`](https://github.com/temiroff/blacknode-robot) |
 | Integration | ROS 2 graph, topics, services, processes, native transport, and rosbridge | [`blacknode-ros2`](https://github.com/temiroff/blacknode-ros2) |
-| Hardware deployment | Runtime device contracts, capability inspection, safe device control, replaceable adapters, physical drivers, and firmware protocols | [`blacknode-hardware`](https://github.com/temiroff/blacknode-hardware), [`blacknode-drivers`](https://github.com/temiroff/blacknode-drivers) |
+| Physical drivers | Concrete device drivers with internal serial, CAN, USB, and other protocol transports | [`blacknode-drivers`](https://github.com/temiroff/blacknode-drivers) |
 | Learning and deployment | Episode recording, policy training, remote runtime, simulation, and accelerated compute | [`blacknode-dataset`](https://github.com/temiroff/blacknode-dataset), [`blacknode-training`](https://github.com/temiroff/blacknode-training), [`blacknode-runtime`](https://github.com/temiroff/blacknode-runtime), [`blacknode-isaac`](https://github.com/temiroff/blacknode-isaac), [`blacknode-cuda`](https://github.com/temiroff/blacknode-cuda) |
 
 The workflow depends on stable capabilities such as a camera, joint controller,
@@ -104,9 +104,9 @@ Templates declare required packages and Blacknode resolves missing
 capabilities. See [Extension Packages](docs/packages.md).
 
 For deployment on physical hardware, use
-[`blacknode-hardware`](https://github.com/temiroff/blacknode-hardware) for
-runtime hardware contracts, capability checks, safe device control, and
-replaceable adapters. Add
+[`blacknode-robot`](https://github.com/temiroff/blacknode-robot) for connected
+device contracts, lifecycle, health, normalized telemetry, and safe provider
+interfaces. Add
 [`blacknode-drivers`](https://github.com/temiroff/blacknode-drivers) for the
 physical bus, firmware, or device protocol used by the robot.
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -173,7 +173,7 @@ Before creating a learned node:
 - set a useful `category` so the node lands in the right palette group instead
   of the default `Learned`
 - use the canonical [Blacknode family color](design-language.md) when the
-  category belongs to Core, Agent, Robot, Perception, ROS 2, CUDA, Controllers,
+  category belongs to Core, Agent, Robot, Perception, ROS 2, CUDA, Motion,
   Drivers, Output, or Values
 - generate only a `def run(...)` function and make sure its parameters match the
   declared input ports

--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -201,7 +201,7 @@ A platform update provider reports inventory and manages releases of:
 - the operating system and kernel;
 - Blacknode core;
 - `blacknode-runtime`;
-- `blacknode-hardware`;
+- `blacknode-robot` device and telemetry components;
 - device drivers and optional packages; and
 - service definitions and non-secret configuration.
 
@@ -257,7 +257,7 @@ responses, logs, or provider-neutral configuration.
 The editor registers the compute device and its shared runtime first. A device
 record owns the runtime URL on port `8766` and the server-side runtime pairing
 credential. Each child robot record uses the exact hardware service URL printed
-by `blacknode-hardware` pairing. On a multi-robot computer, hardware services
+by `blacknode-robot` device pairing. On a multi-robot computer, hardware services
 use `8765`, `8767`, `8768`, and subsequent assigned ports. The editor rejects
 `8766` as a robot hardware endpoint and binds every child robot to its parent
 device's runtime.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -13,7 +13,7 @@ status colors.
 | Perception | ![Green](images/swatches/swatch-22c55e.svg) Green | `#22c55e` |
 | ROS 2 | ![Blue](images/swatches/swatch-3b82f6.svg) Blue | `#3b82f6` |
 | CUDA | ![Lime](images/swatches/swatch-84cc16.svg) Lime | `#84cc16` |
-| Controllers | ![Orange](images/swatches/swatch-f97316.svg) Orange | `#f97316` |
+| Motion | ![Orange](images/swatches/swatch-f97316.svg) Orange | `#f97316` |
 | Drivers | ![Gray](images/swatches/swatch-64748b.svg) Gray | `#64748b` |
 | Output | ![Pink](images/swatches/swatch-ec4899.svg) Pink | `#ec4899` |
 | Values | ![Amber](images/swatches/swatch-f59e0b.svg) Amber | `#f59e0b` |

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -134,27 +134,34 @@ development:
 
 | Package | Role |
 |---|---|
-| `blacknode-runtime` | Authenticated remote deployment, target manifests, process supervision, logs, and rollback on Raspberry Pi, Jetson, and Linux targets. |
-| `blacknode-drivers` | Selectively enabled physical hardware drivers and firmware adapters; the first `feetech` component provides inert bus configuration, read-only probing, and torque-safe bus primitives. |
-| `blacknode-robot` | Generic USB robot discovery, serial permission help, driver descriptors, driver process launch, and the standard robot profile. |
-| `blacknode-controllers` | Joint-control, mobile-base, navigation, manipulation, policy, arbitration, and safety controllers with optional transport adapters. |
-| `blacknode-ros2` | ROS 2 graph discovery, topics, services, native/rosbridge transport, managed processes, and diagnostics. |
-| `blacknode-perception` | Camera, tracking, VLM, and spatial-perception components, organized as selectable components. |
-| `blacknode-dataset` | Blacknode-native episode journals, synchronized robot/camera recording, dataset validation, HDF5 and structured Parquet/MP4 export profiles, and explicit repository publishing. |
-| `blacknode-training` | PyTorch action-chunking training from Blacknode HDF5 episodes, managed jobs, resumable checkpoints, recorded-frame previews, and deployable policy artifacts. |
+| `blacknode-agent` | Persistent task memory and executive planning, mission execution, skill selection, confirmation, and review. |
+| `blacknode-motion` | Arm and base planning, trajectories, execution, learned policies, arbitration, and motion safety. |
+| `blacknode-cuda` | CUDA capability, image-processing, tensor-operation, and optional benchmark components backed by internal kernels. |
+| `blacknode-dataset` | Default recording, replay, and validation with optional evaluation, export, and repository publishing. |
+| `blacknode-drivers` | Selectively enabled concrete physical drivers; the `feetech` component provides inert bus configuration, read-only probing, and torque-safe bus primitives. |
 | `blacknode-isaac` | Direct closed-loop policy deployment using Isaac Sim articulation state, named RGB sensors, safety-gated targets, and runtime replay logs. |
+| `blacknode-perception` | Camera, tracking, VLM, and spatial-perception components, organized as selectable components. |
+| `blacknode-robot` | Robot contracts, profiles, calibration, connected-device discovery and lifecycle, normalized telemetry, driver descriptors, and driver process launch. |
+| `blacknode-ros2` | Native DDS graph, topic, service, and diagnostic integration with optional rosbridge and managed processes. |
+| `blacknode-runtime` | Authenticated remote deployment, target manifests, process supervision, logs, and rollback on Raspberry Pi, Jetson, and Linux targets. |
+| `blacknode-skills` | Task-level follow, pick-place, delivery, docking, and inspection behavior over stable capabilities. |
+| `blacknode-training` | Optional dataset checks, managed jobs, checkpoints, policy previews, and deployable policy artifacts for training workloads. |
 
-Keep the layers separate: `blacknode-robot` owns profiles, calibration, and the
-generic robot contract; `blacknode-drivers` owns physical protocol access and
-driver-boundary safeguards; and `blacknode-ros2` owns ROS graph and transport
-behavior. Optional adapters stay nested under the component they integrate.
+Keep the layers separate: `blacknode-robot` owns profiles, calibration,
+connected devices, normalized telemetry, and the generic robot contract;
+`blacknode-drivers` owns concrete physical drivers, their internal protocol
+access, and driver-boundary safeguards; and
+`blacknode-ros2` owns ROS graph and transport behavior. Optional adapters stay
+nested under the component they integrate. Serial, CAN, and USB helpers remain
+private implementation details of concrete drivers rather than selectable
+components.
 
 A node named `ROS2*` is not automatically a `blacknode-ros2` node. The
 integration layer owns only transport-agnostic ROS primitives; a node *about*
 a capability belongs to the capability's package as a ROS 2 adapter component
 that requires `blacknode-ros2/core`. That is why `CameraROS2Subscribe` lives in
 `blacknode-perception` (`camera/ros2`) and `ROS2SetJoint` in
-`blacknode-controllers` (`joint-control/ros2`). Dependencies point one way
+`blacknode-motion` (`arm/ros2`). Dependencies point one way
 only — capability adapters depend on the integration layer, never the reverse
 — so a second transport can be added as a sibling adapter later without
 reorganizing any capability package. Each capability package also ships its
@@ -325,11 +332,11 @@ requires = [
   { package = "blacknode-ros2", component = "core", version = ">=0.2.0,<1.0.0" }
 ]
 
-[components.stm32]
-description = "STM32 serial bridge."
-default = false
-nodes = ["components/stm32/nodes"]
 ```
+
+Manifests describe usable capabilities. Keep design notes for planned driver
+families in source control, then add a public component when its implementation,
+dependencies, safety behavior, unavailable state, and tests exist.
 
 The Packages UI groups installed and available packages by `layer`. Official
 catalog entries provide a layer for older manifests that do not declare one;
@@ -426,7 +433,7 @@ Lockfile reproduction and version selection across multiple compatible remote
 releases remain future resolver stages.
 
 The initial organizational layers are `skills`, `agent`, `robot`,
-`perception`, `controllers`, and `drivers`. `ros2` identifies the horizontal
+`perception`, `motion`, and `drivers`. `ros2` identifies the horizontal
 ROS graph and transport layer. `learning`, `compute`, and `simulation`
 identify supporting packages such as training, CUDA, and simulator adapters.
 

--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -64,7 +64,7 @@ Checking the device or package versions does not start a stopped service.
 Remote package actions use the verified SSH identity and one unsaved password
 field above the same two cards.
 Remote Hardware Run, Stop, and Restart control every exact
-`blacknode-hardware` service attached to that compute device. Stop first ends
+robot device service attached to that compute device. Stop first ends
 active deployments and disarms each robot; Run and Restart return with motion
 disarmed.
 
@@ -149,7 +149,7 @@ reads their private pairing credentials through the verified SSH connection.
 The token is paired server-side and is never displayed in the browser; the SSH
 password is used for that request and is not saved. Manual pairing remains
 available by entering the robot URL and token printed by
-`blacknode-hardware/pair.sh`. One device may contain several robots; each robot
+`blacknode-robot/pair.sh`. One device may contain several robots; each robot
 remains a distinct deployment target and uses its parent device's shared
 runtime. Pairing and discovery keep physical motion disarmed.
 

--- a/docs/so-arm101-leader-follower.md
+++ b/docs/so-arm101-leader-follower.md
@@ -21,10 +21,10 @@ from exchanging roles if operating-system discovery order changes.
 ## Start safely
 
 1. Support the leader arm and clear the follower workspace.
-2. Keep `ROS2JointPublish.armed=false` and press **Go live**.
+2. Keep `ROS2JointController.armed=false` and press **Go live**.
 3. Confirm leader torque is released and the dashboard shows live leader, safe
    target, and follower values. Moving the leader must not move the follower.
-4. Set `ROS2JointPublish.armed=true`. The live publisher applies this
+4. Set `ROS2JointController.armed=true`. The live controller applies this
    immediately while limits,
    bounded steps, deadband, and stale-message suppression remain active.
 5. Set `armed=false` or press **Stop all** before touching the follower.

--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -837,7 +837,7 @@ PY"""
                         256 * 1024,
                     )
                     if not re.search(
-                        r'(?m)^\s*name\s*=\s*["\']blacknode-hardware["\']\s*$',
+                        r'(?m)^\s*name\s*=\s*["\']blacknode-(?:robot|hardware)["\']\s*$',
                         manifest,
                     ):
                         raise ValueError(
@@ -1108,7 +1108,7 @@ if [[ "$instance" == "default" ]]; then
   legacy="$HOME/blacknode-hardware"
 fi
 [[ -d "$target/.git" && -f "$target/pyproject.toml" ]] \
-  && grep -Eq '^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']blacknode-hardware["'"'"'][[:space:]]*$' \
+  && grep -Eq '^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']blacknode-(robot|hardware)["'"'"'][[:space:]]*$' \
     "$target/pyproject.toml" || {
   echo "The organized Hardware package is missing or invalid: $target" >&2
   exit 4
@@ -1334,7 +1334,7 @@ if [[ -e "$hardware_dir" ]]; then
     exit 4
   }
   origin="$(git -C "$hardware_dir" remote get-url origin 2>/dev/null || true)"
-  [[ "$origin" =~ (github\.com[:/])temiroff/blacknode-hardware(\.git)?$ ]] || {
+  [[ "$origin" =~ (github\.com[:/])temiroff/blacknode-robot(\.git)?$ ]] || {
     echo "The existing Hardware checkout has an unrecognized Git origin."
     exit 4
   }
@@ -1342,7 +1342,7 @@ if [[ -e "$hardware_dir" ]]; then
 else
   progress 20 "Downloading the Robot Hardware package"
   mkdir -p "$(dirname -- "$hardware_dir")"
-  git clone https://github.com/temiroff/blacknode-hardware.git "$hardware_dir"
+  git clone https://github.com/temiroff/blacknode-robot.git "$hardware_dir"
   created=true
 fi
 if ! grep -q 'BLACKNODE_HARDWARE_INSTANCE' "$hardware_dir/install-service.sh" \
@@ -1788,7 +1788,7 @@ if [[ "$complete_stack" == true && ! -d "$hardware_dir" ]]; then
   progress 72 "Installing the Robot Hardware package"
   mkdir -p "$(dirname -- "$hardware_dir")"
   cleanup_hardware=true
-  git clone https://github.com/temiroff/blacknode-hardware.git "$hardware_dir"
+  git clone https://github.com/temiroff/blacknode-robot.git "$hardware_dir"
   if ! grep -q 'BLACKNODE_HARDWARE_INSTANCE' "$hardware_dir/install-service.sh" \
     || ! grep -q 'previous_working_directory' "$hardware_dir/install-service.sh"; then
     echo "The downloaded Blacknode Hardware release does not support isolated stacks yet."
@@ -2209,7 +2209,7 @@ install_persistent_hardware_services() {
     echo "Repair Hardware requires $hardware_repo/install-service.sh." >&2
     return 1
   }
-  validate_checkout "$hardware_repo" "blacknode-hardware"
+  validate_checkout "$hardware_repo" "blacknode-robot"
   if [[ -f "$hardware_repo/.blacknode-hardware/devices.json" ]]; then
     python3 - "$hardware_repo/.blacknode-hardware/devices.json" \
       "$hardware_targets_payload" <<'PY'
@@ -2334,7 +2334,7 @@ for directory in "${hardware_dirs[@]}"; do
     [[ "$existing" == "$directory" ]] && found=true
   done
   if [[ "$found" == false ]]; then
-    validate_checkout "$directory" "blacknode-hardware"
+    validate_checkout "$directory" "blacknode-robot"
     unique_hardware_dirs+=("$directory")
   fi
 done
@@ -2851,7 +2851,7 @@ for target in request["hardware_targets"]:
         )
         component = inspect(
             "hardware",
-            "blacknode-hardware",
+            "blacknode-robot",
             service,
             hardware_port,
             directory,

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -478,7 +478,7 @@ class HardwareDeviceClient:
             if exc.code == 404 and endpoint == "/calibration":
                 raise DeviceRegistryError(
                     "This device service does not support calibration activation yet. "
-                    "Update blacknode-hardware on the device, run "
+                    "Update blacknode-robot on the device, run "
                     "'./service.sh restart', then refresh the device in Blacknode."
                 ) from exc
             detail = ""

--- a/editor-server/local_runtime.py
+++ b/editor-server/local_runtime.py
@@ -19,7 +19,7 @@ from typing import Any, Callable
 
 
 _RUNTIME_REPOSITORY = "https://github.com/temiroff/blacknode-runtime.git"
-_HARDWARE_REPOSITORY = "https://github.com/temiroff/blacknode-hardware.git"
+_HARDWARE_REPOSITORY = "https://github.com/temiroff/blacknode-robot.git"
 
 
 class LocalRuntimeError(RuntimeError):
@@ -82,14 +82,14 @@ def _validate_hardware_checkout(hardware_dir: Path) -> None:
     service_script = hardware_dir / "scripts" / "hardware_service.py"
     if not pyproject.is_file() or not service_script.is_file():
         raise LocalRuntimeError(
-            f"{hardware_dir} is not an empty folder or a Blacknode Hardware checkout."
+            f"{hardware_dir} is not an empty folder or a Blacknode Robot checkout."
         )
     try:
         manifest = pyproject.read_text(encoding="utf-8")
     except OSError as exc:
         raise LocalRuntimeError(f"Could not inspect {pyproject}: {exc}") from exc
-    if 'name = "blacknode-hardware"' not in manifest:
-        raise LocalRuntimeError(f"{hardware_dir} is not a Blacknode Hardware checkout.")
+    if 'name = "blacknode-robot"' not in manifest:
+        raise LocalRuntimeError(f"{hardware_dir} is not a Blacknode Robot checkout.")
 
 
 def _resolve_install_dir(value: str, core_root: Path) -> Path:
@@ -519,7 +519,7 @@ def install_local_runtime(
         install_root = install_root.parent
     else:
         runtime_dir = install_root / "blacknode-runtime"
-    hardware_dir = install_root / "blacknode-hardware"
+    hardware_dir = install_root / "blacknode-robot"
     _report(progress, 4, "Checking the local robot stack folder")
 
     runtime_existed = runtime_dir.exists() and any(runtime_dir.iterdir())

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -617,7 +617,7 @@ def _stop_active_cook() -> None:
 _RUNTIME_MODULES = {
     "ros2": "blacknode.pkg.blacknode_ros2.ros2_runtime",
     "ros2_live": "blacknode.pkg.blacknode_skills.follow.leader_follower_runtime",
-    "joint_control": "blacknode.pkg.blacknode_controllers.joint_control.adapters.ros2.joint_motion",
+    "joint_control": "blacknode.pkg.blacknode_motion.arm.adapters.ros2.joint_motion",
     "vision": "blacknode.pkg.blacknode_perception.cv2_runtime",
     "cuda": "blacknode.pkg.blacknode_cuda.cuda_stream_runtime",
     "robot": "blacknode.pkg.blacknode_robot.robot",
@@ -835,8 +835,7 @@ def _push_live_node_param_update(meta: dict[str, Any], key: str, value: Any, old
         return
     if meta.get("type") in {
         "ROS2LeaderFollower",
-        "ROS2FollowerJointPublisher",
-        "ROS2JointPublish",
+        "ROS2JointController",
     }:
         update_fn = _runtime_callable("ros2_live", _RUNTIME_MODULES["ros2_live"], "update_leader_follower_config")
         if update_fn is None:
@@ -1633,8 +1632,7 @@ def update_param(node_id: str, req: UpdateParamReq):
             _clear_runtime_status(invalidated_meta)
             if invalidated_meta.get("type") in {
                 "ROS2LeaderFollower",
-                "ROS2FollowerJointPublisher",
-                "ROS2JointPublish",
+                "ROS2JointController",
             } and invalidated_id != node_id:
                 disarm_fn = _runtime_callable("ros2_live", _RUNTIME_MODULES["ros2_live"], "update_leader_follower_config")
                 if disarm_fn is not None:
@@ -4590,7 +4588,7 @@ def _control_robot_lifecycle_payload(
             raise HTTPException(
                 409,
                 "This robot's compute device was paired manually. Restart its "
-                "blacknode-hardware service on the device.",
+                "robot device service on the device.",
             )
         try:
             hardware_port = urllib.parse.urlsplit(
@@ -6029,12 +6027,6 @@ def _workflow_requires_deployment_telemetry(workflow: dict[str, Any]) -> bool:
         "ROS2PublishJointState",
         "ROS2SubscribeJointState",
         "ROS2JointController",
-        "ROS2JointStatePublish",
-        "ROS2JointReplicate",
-        "ROS2JointSubscribe",
-        "ROS2JointPublish",
-        "ROS2FollowerJointPublisher",
-        "ROS2LeaderJointSubscriber",
         "ROS2ManualMove",
         "ROS2SetJoint",
     }
@@ -6068,9 +6060,6 @@ def _workflow_motion_controls(workflow: dict[str, Any]) -> list[dict[str, str]]:
             or str(meta.get("type") or "") not in {
                 "ROS2LeaderFollower",
                 "ROS2JointController",
-                "ROS2JointReplicate",
-                "ROS2JointPublish",
-                "ROS2FollowerJointPublisher",
             }
         ):
             continue
@@ -6100,9 +6089,6 @@ def _disarm_workflow_motion_controls(workflow: dict[str, Any]) -> list[str]:
         and str(meta.get("type") or "") in {
             "ROS2LeaderFollower",
             "ROS2JointController",
-            "ROS2JointReplicate",
-            "ROS2JointPublish",
-            "ROS2FollowerJointPublisher",
         }
     }
     if not controlled_ids:
@@ -6437,7 +6423,7 @@ def _bind_robot_to_device(
     if str(connection.get("transport") or "").strip() != "serial" or not serial_port:
         raise ValueError(
             "The paired hardware service did not report its serial port. "
-            "Update blacknode-hardware and restart this robot service."
+            "Update blacknode-robot and restart this robot service."
         )
     calibration = (
         remote_status.get("calibration")
@@ -6567,7 +6553,7 @@ def _runtime_extension_update_specs(
             isinstance(item, dict)
             and str(item.get("name") or "").startswith("blacknode-")
             and str(item.get("name") or "")
-            not in {"blacknode-runtime", "blacknode-hardware"}
+            not in {"blacknode-runtime", "blacknode-robot", "blacknode-hardware"}
         )
     }
     local_packages = {

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1196,7 +1196,7 @@ export default function App() {
   const controllerNodes = nodes.filter(n => (
     n.data.type === 'RobotFollow'
     || n.data.type === 'ROS2LeaderFollower'
-    || n.data.type === 'ROS2FollowerJointPublisher'
+    || n.data.type === 'ROS2JointController'
   ))
   const controllerRunningCount = controllerNodes.filter(n => n.data.portResults?.running === true).length
   const controllerCount = controllerNodes.filter(n => n.data.portResults?.live === true).length

--- a/editor/src/categories.ts
+++ b/editor/src/categories.ts
@@ -62,6 +62,7 @@ export const FAMILY_COLORS: Record<string, string> = {
   AI: '#a855f7',
   Controllers: '#f97316',
   Controller: '#f97316',
+  Motion: '#f97316',
   Drivers: '#64748b',
   Driver: '#64748b',
   Output: '#ec4899',
@@ -71,11 +72,10 @@ export const FAMILY_COLORS: Record<string, string> = {
 
 export const PACKAGE_FAMILY_NAMES: Record<string, string> = {
   'blacknode-agent': 'Agent',
-  'blacknode-controllers': 'Controllers',
+  'blacknode-motion': 'Motion',
   'blacknode-cuda': 'CUDA',
   'blacknode-dataset': 'Dataset',
   'blacknode-drivers': 'Drivers',
-  'blacknode-hardware': 'Hardware',
   'blacknode-isaac': 'Isaac Sim',
   'blacknode-perception': 'Perception',
   'blacknode-robot': 'Robot',

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -25,7 +25,7 @@ const JOINT_MOTION_NODE_TYPES = new Set([
   'ROS2ManualMove',
   'ROS2JointSliders',
   'ROS2LeaderFollower',
-  'ROS2FollowerJointPublisher',
+  'ROS2JointController',
   'ROS2NativeFollowDetectionJoint',
   'ROS2FollowDetectionJoint',
   'RobotFollow',

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -658,7 +658,7 @@ export default function DevicesPanel({
     selectedDeviceState?.runtime?.manifest?.packages ?? []
   ).filter(item => (
     item.name.startsWith('blacknode-')
-    && !['blacknode-runtime', 'blacknode-hardware'].includes(item.name)
+    && !['blacknode-runtime', 'blacknode-robot', 'blacknode-hardware'].includes(item.name)
   ))
   const selectedHardwareVersion = (
     selectedDeviceState?.runtime?.hardware?.status?.software_version
@@ -5574,7 +5574,7 @@ function RobotRow({
               }}
               disabled={busy || state?.loading || !canRestartService}
               title={canRestartService
-                ? 'Restart the exact remote blacknode-hardware systemd service for this port'
+                ? 'Restart the exact remote robot device systemd service for this port'
                 : 'Open the compute device and choose Enable SSH controls first'}
               className="bn-device-action-button"
             >

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -659,7 +659,7 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
   }
   if (data.type === 'RobotFollow'
     || data.type === 'ROS2LeaderFollower'
-    || data.type === 'ROS2FollowerJointPublisher') {
+    || data.type === 'ROS2JointController') {
     return {
       ...base,
       portResults: {
@@ -3513,8 +3513,8 @@ export const useStore = create<Store>((set, get) => ({
           LIVE_STREAM_NODE_TYPES.has(n.data.type) ||
           n.data.type === 'RobotFollow' ||
           n.data.type === 'ROS2LeaderFollower' ||
-          n.data.type === 'ROS2FollowerJointPublisher' ||
-          n.data.type === 'ROS2LeaderJointSubscriber' ||
+          n.data.type === 'ROS2JointController' ||
+          n.data.type === 'ROS2SubscribeJointState' ||
           n.data.type === 'ROS2ManualMove' ||
           n.data.type === 'ROS2MotionDashboard' ||
           n.data.type === 'Output' ||

--- a/packages/README.md
+++ b/packages/README.md
@@ -21,10 +21,12 @@ and how to write your own package.
 
 Every package folder here is gitignored — each is its own repository. Official
 robotics packages are split by responsibility: `blacknode-robot` owns robot
-profiles and calibration, `blacknode-drivers` owns physical hardware protocols,
-`blacknode-ros2` owns ROS 2 graph/transport behavior, and `blacknode-perception`
-provides camera/CV2/VLM perception. `blacknode-cuda` remains the smallest flat
-package reference; `blacknode-drivers` is the selective-component reference.
+profiles, calibration, connected-device lifecycle, health, and normalized
+telemetry; `blacknode-drivers` owns physical hardware protocols;
+`blacknode-ros2` owns ROS 2 graph/transport behavior; and
+`blacknode-perception` provides camera/CV2/VLM perception. `blacknode-cuda`
+remains the smallest flat package reference; `blacknode-drivers` is the
+selective-component reference.
 
 Maintained packages should include a scoped `AGENTS.md` with ownership,
 dependency, safety, and verification rules. Agents use the core

--- a/python/blacknode/contracts.py
+++ b/python/blacknode/contracts.py
@@ -63,8 +63,8 @@ SHIPPING_KINDS: dict[str, str] = {
     "blacknode.policy-replay": "blacknode-training",
     "blacknode.policy-replay-frame": "blacknode-training",
     "blacknode.policy-replay-metrics": "blacknode-training",
-    "blacknode.policy-runtime": "blacknode-controllers",
-    "blacknode.policy-safety-gate": "blacknode-controllers",
+    "blacknode.policy-runtime": "blacknode-motion",
+    "blacknode.policy-safety-gate": "blacknode-motion",
     # Simulation
     "blacknode.isaac-command": "blacknode-isaac",
     "blacknode.isaac-observation": "blacknode-isaac",

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -16,7 +16,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 }
             },
             "git_url": "https://github.com/temiroff/blacknode-runtime.git",
-            "description": "Authenticated remote deployment, runtime inspection, supervision, logs, and rollback.",
+            "description": "Authenticated component loading, dependency resolution, workflow execution, supervision, configuration, logs, and rollback.",
             "node_types": []
         },
         "blacknode-skills": {
@@ -30,7 +30,6 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "follow": {
                     "name": "follow",
-                    "aliases": ["follow-person"],
                     "default": False,
                     "node_types": [],
                     "adapters": {
@@ -44,12 +43,6 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                                 "ROS2PublishJointState",
                                 "ROS2SubscribeJointState",
                                 "ROS2JointController",
-                                "ROS2JointStatePublish",
-                                "ROS2JointSubscribe",
-                                "ROS2JointReplicate",
-                                "ROS2JointPublish",
-                                "ROS2LeaderJointSubscriber",
-                                "ROS2FollowerJointPublisher",
                                 "ROS2NativeFollowDetectionJoint"
                             ]
                         }
@@ -80,12 +73,6 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "ROS2PublishJointState",
                 "ROS2SubscribeJointState",
                 "ROS2JointController",
-                "ROS2JointStatePublish",
-                "ROS2JointSubscribe",
-                "ROS2JointReplicate",
-                "ROS2JointPublish",
-                "ROS2LeaderJointSubscriber",
-                "ROS2FollowerJointPublisher",
                 "ROS2NativeFollowDetectionJoint"
             ]
         },
@@ -93,23 +80,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "name": "blacknode-agent",
             "layer": "agent",
             "components": {
-                "planner": {
-                    "name": "planner",
-                    "default": False,
-                    "node_types": []
-                },
-                "skill-registry": {
-                    "name": "skill-registry",
-                    "default": False,
-                    "node_types": []
-                },
-                "mission-review": {
-                    "name": "mission-review",
-                    "default": False,
-                    "node_types": []
-                },
-                "confirmation": {
-                    "name": "confirmation",
+                "executive": {
+                    "name": "executive",
                     "default": False,
                     "node_types": []
                 },
@@ -126,7 +98,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 }
             },
             "git_url": "https://github.com/temiroff/blacknode-agent.git",
-            "description": "Planning, memory, review, confirmation, and skill orchestration.",
+            "description": "Persistent memory and executive mission orchestration.",
             "node_types": [
                 "AdaptationRecommendation",
                 "EpisodeMemoryIngest",
@@ -135,31 +107,46 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "TaskEvaluationRecord"
             ]
         },
-        "blacknode-controllers": {
-            "name": "blacknode-controllers",
-            "layer": "controllers",
+        "blacknode-motion": {
+            "name": "blacknode-motion",
+            "layer": "motion",
             "components": {
-                "joint-control": {
-                    "name": "joint-control",
+                "core": {
+                    "name": "core",
+                    "default": False,
+                    "node_types": []
+                },
+                "arm": {
+                    "name": "arm",
                     "default": True,
-                    "node_types": [],
+                    "node_types": [
+                        "JointMotionProfile"
+                    ],
                     "adapters": {
                         "ros2": {
                             "name": "ros2",
                             "default": True,
                             "node_types": [
-                                "JointMotionProfile",
                                 "ROS2JointSliders",
                                 "ROS2JointState",
                                 "ROS2ManualMove",
                                 "ROS2MotionDashboard",
                                 "ROS2SetJoint"
-                            ]
+                            ],
+                            "dependencies": {
+                                "requires": [
+                                    {
+                                        "package": "blacknode-ros2",
+                                        "component": "core",
+                                        "version": ">=0.5.6,<1.0.0"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
-                "mobile-base": {
-                    "name": "mobile-base",
+                "base": {
+                    "name": "base",
                     "default": False,
                     "node_types": [],
                     "adapters": {
@@ -172,19 +159,18 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                                 "ROS2BaseStop",
                                 "ROS2LaserScanCheck",
                                 "ROS2OdomState"
-                            ]
+                            ],
+                            "dependencies": {
+                                "requires": [
+                                    {
+                                        "package": "blacknode-ros2",
+                                        "component": "rosbridge",
+                                        "version": ">=0.5.8,<1.0.0"
+                                    }
+                                ]
+                            }
                         }
                     }
-                },
-                "nav2": {
-                    "name": "nav2",
-                    "default": False,
-                    "node_types": []
-                },
-                "manipulation": {
-                    "name": "manipulation",
-                    "default": False,
-                    "node_types": []
                 },
                 "policy": {
                     "name": "policy",
@@ -197,23 +183,27 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                             "node_types": [
                                 "PolicyRuntime",
                                 "PolicySafetyGate"
-                            ]
+                            ],
+                            "dependencies": {
+                                "requires": [
+                                    {
+                                        "package": "blacknode-ros2",
+                                        "component": "rosbridge",
+                                        "version": ">=0.5.8,<1.0.0"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
-                "command-arbitration": {
-                    "name": "command-arbitration",
-                    "default": False,
-                    "node_types": []
-                },
-                "safety-supervisors": {
-                    "name": "safety-supervisors",
+                "safety": {
+                    "name": "safety",
                     "default": False,
                     "node_types": []
                 }
             },
-            "git_url": "https://github.com/temiroff/blacknode-controllers.git",
-            "description": "Generic motion, manipulation, policy, arbitration, and safety controllers.",
+            "git_url": "https://github.com/temiroff/blacknode-motion.git",
+            "description": "Arm and base planning, trajectory generation, execution, policy, arbitration, and motion safety.",
             "node_types": [
                 "BaseSafetyGate",
                 "JointMotionProfile",
@@ -252,48 +242,13 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                                 "requires": [
                                     {
                                         "package": "blacknode-ros2",
-                                        "component": "core",
-                                        "version": ">=0.2.0,<1.0.0"
+                                        "component": "rosbridge",
+                                        "version": ">=0.5.8,<1.0.0"
                                     }
                                 ]
                             }
                         }
                     }
-                },
-                "stm32": {
-                    "name": "stm32",
-                    "default": False,
-                    "node_types": []
-                },
-                "serial": {
-                    "name": "serial",
-                    "default": False,
-                    "node_types": []
-                },
-                "can": {
-                    "name": "can",
-                    "default": False,
-                    "node_types": []
-                },
-                "usb": {
-                    "name": "usb",
-                    "default": False,
-                    "node_types": []
-                },
-                "motor-controllers": {
-                    "name": "motor-controllers",
-                    "default": False,
-                    "node_types": []
-                },
-                "sensor-drivers": {
-                    "name": "sensor-drivers",
-                    "default": False,
-                    "node_types": []
-                },
-                "vendor-adapters": {
-                    "name": "vendor-adapters",
-                    "default": False,
-                    "node_types": []
                 }
             },
             "git_url": "https://github.com/temiroff/blacknode-drivers.git",
@@ -316,14 +271,6 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                         "GPURequirement"
                     ]
                 },
-                "kernels": {
-                    "name": "kernels",
-                    "default": True,
-                    "node_types": [
-                        "CUDACustomKernel",
-                        "CUDAKernelLab"
-                    ]
-                },
                 "image-processing": {
                     "name": "image-processing",
                     "default": True,
@@ -342,19 +289,17 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "benchmarks": {
                     "name": "benchmarks",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "CUTLASSGemm"
                     ]
                 }
             },
             "git_url": "https://github.com/temiroff/blacknode-cuda.git",
-            "description": "Real GPU compute nodes: CUDA kernel lab, custom NVRTC kernels, GPU image filters, Tensor Core GEMM, and CUTLASS.",
+            "description": "GPU capability checks, image processing, tensor operations, and optional benchmarks.",
             "node_types": [
-                "CUDACustomKernel",
                 "CUDAImageFilter",
                 "CUDAImageFilterStream",
-                "CUDAKernelLab",
                 "CUTLASS",
                 "CUTLASSGemm",
                 "GPUCapability",
@@ -373,7 +318,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "rosbridge": {
                     "name": "rosbridge",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "ROS2BridgeEcho",
                         "ROS2BridgePublish",
@@ -410,7 +355,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "processes": {
                     "name": "processes",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "ROS2Launch",
                         "ROS2PackageExecutables",
@@ -520,6 +465,25 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                         "RobotUSBDiscovery"
                     ]
                 },
+                "devices": {
+                    "name": "devices",
+                    "default": True,
+                    "node_types": [
+                        "HardwareCapabilities"
+                    ]
+                },
+                "telemetry": {
+                    "name": "telemetry",
+                    "default": True,
+                    "node_types": [],
+                    "adapters": {
+                        "mqtt": {
+                            "name": "mqtt",
+                            "default": False,
+                            "node_types": []
+                        }
+                    }
+                },
                 "authorization": {
                     "name": "authorization",
                     "default": False,
@@ -527,8 +491,9 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 }
             },
             "git_url": "https://github.com/temiroff/blacknode-robot.git",
-            "description": "Generic robot setup: USB discovery, serial permission diagnostics, driver launch, and standard robot profiles.",
+            "description": "Robot contracts, connected-device lifecycle, normalized telemetry, profiles, and driver launch.",
             "node_types": [
+                "HardwareCapabilities",
                 "Robot",
                 "RobotAttachment",
                 "RobotAttachmentList",
@@ -713,14 +678,14 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "evaluation": {
                     "name": "evaluation",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "EpisodeEvaluator"
                     ]
                 },
                 "export": {
                     "name": "export",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "HDF5EpisodeExport",
                         "LeRobotV3Export"
@@ -728,7 +693,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "publishing": {
                     "name": "publishing",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "BlacknodeHubExport",
                         "HuggingFaceDatasetUpload",
@@ -762,28 +727,28 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "components": {
                 "dataset-check": {
                     "name": "dataset-check",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "TrainingDatasetCheck"
                     ]
                 },
                 "training-jobs": {
                     "name": "training-jobs",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "ACTTraining"
                     ]
                 },
                 "checkpoints": {
                     "name": "checkpoints",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "ACTCheckpointInspect"
                     ]
                 },
                 "policy-preview": {
                     "name": "policy-preview",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "ACTPolicyPreview",
                         "ACTPolicyReplay"
@@ -791,7 +756,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "policy-artifacts": {
                     "name": "policy-artifacts",
-                    "default": True,
+                    "default": False,
                     "node_types": [
                         "ACTPolicyExport",
                         "PolicyArtifactLoad"
@@ -821,7 +786,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "dependencies": {
                         "requires": [
                             {
-                                "package": "blacknode-controllers",
+                                "package": "blacknode-motion",
                                 "component": "policy",
                                 "version": ">=0.1.0,<1.0.0"
                             }

--- a/python/blacknode/packages.py
+++ b/python/blacknode/packages.py
@@ -674,6 +674,18 @@ def load_package(pkg_dir: str | Path) -> PackageInfo:
     try:
         if info.component_mode:
             _prepare_component_package(snake_name, pkg_path)
+            tagged_root_nodes = (
+                (pkg_path / "nodes").is_dir()
+                and not any(
+                    component["node_paths"]
+                    for component in info.components.values()
+                )
+            )
+            if tagged_root_nodes:
+                nodes_dir = pkg_path / "nodes"
+                before = dict(_NODE_REGISTRY)
+                _import_nodes_package(snake_name, nodes_dir, clear=False)
+                _tag_new_package_nodes(before, info.name, nodes_dir)
             for component_name in info.enabled_components:
                 component = info.components[component_name]
                 for index, nodes_dir in enumerate(_component_node_dirs(pkg_path, component_name, component)):
@@ -714,6 +726,7 @@ def load_package(pkg_dir: str | Path) -> PackageInfo:
                     component_name,
                     component.get("aliases", []),
                 )
+            _filter_package_component_nodes(info)
         else:
             nodes_dir = pkg_path / "nodes"
             if not nodes_dir.is_dir():
@@ -1478,6 +1491,34 @@ def _deregister_package_nodes(package_name: str) -> None:
     for node_name, fn in list(_NODE_REGISTRY.items()):
         if getattr(fn, "_bn_package", "") == package_name:
             del _NODE_REGISTRY[node_name]
+
+
+def _filter_package_component_nodes(info: PackageInfo) -> None:
+    """Keep only nodes owned by enabled, declared components and adapters."""
+    enabled_components = set(info.enabled_components)
+    ignored_components: set[str] = set()
+    for node_name, fn in list(_NODE_REGISTRY.items()):
+        if getattr(fn, "_bn_package", "") != info.name:
+            continue
+        component_name = _component_name(getattr(fn, "_bn_component", ""))
+        if not component_name or component_name not in info.components:
+            del _NODE_REGISTRY[node_name]
+            ignored_components.add(component_name or "(undeclared)")
+            continue
+        if component_name not in enabled_components:
+            del _NODE_REGISTRY[node_name]
+            continue
+        adapter_name = _component_name(getattr(fn, "_bn_adapter", ""))
+        if not adapter_name:
+            continue
+        adapter = info.components[component_name].get("adapters", {}).get(adapter_name)
+        if not isinstance(adapter, Mapping) or not adapter.get("enabled"):
+            del _NODE_REGISTRY[node_name]
+    if ignored_components:
+        info.warnings.append(
+            "Ignored nodes assigned to unpublished components: "
+            + ", ".join(sorted(ignored_components))
+        )
 
 
 def _check_indexed_nodes(info: PackageInfo) -> None:

--- a/python/blacknode/packages.py
+++ b/python/blacknode/packages.py
@@ -35,7 +35,11 @@ from typing import Any, Callable, Mapping
 
 from ._version import __version__ as _CORE_VERSION
 from .node import _NODE_REGISTRY
-from .package_index import indexed_package
+from .package_index import (
+    indexed_package,
+    template_adapter_requirements,
+    template_component_requirements,
+)
 
 MANIFEST_NAME = "blacknode-package.toml"
 ENTRY_POINT_GROUP = "blacknode.packages"
@@ -545,7 +549,11 @@ def _audit_enabled_component_dependencies(infos: list[PackageInfo]) -> None:
         )
 
 
-def load_package(pkg_dir: str | Path) -> PackageInfo:
+def load_package(
+    pkg_dir: str | Path,
+    *,
+    component_overrides: Mapping[str, bool] | None = None,
+) -> PackageInfo:
     pkg_path = Path(pkg_dir).expanduser().resolve()
     info = PackageInfo(name=pkg_path.name, path=str(pkg_path))
     try:
@@ -577,6 +585,12 @@ def load_package(pkg_dir: str | Path) -> PackageInfo:
         overrides, state_warning = _read_component_overrides(pkg_path, info.name)
         if state_warning:
             info.warnings.append(state_warning)
+        if component_overrides:
+            overrides.update({
+                str(name): enabled
+                for name, enabled in component_overrides.items()
+                if isinstance(enabled, bool)
+            })
     for component_name, component in info.components.items():
         component["enabled"] = (
             _component_override_value(
@@ -747,6 +761,48 @@ def load_package(pkg_dir: str | Path) -> PackageInfo:
     _check_indexed_nodes(info)
     _PACKAGE_REGISTRY[info.name] = info
     return info
+
+
+def load_workflow_requirements(workflow: Mapping[str, Any]) -> dict[str, Any]:
+    """Activate explicitly required workflow components for this process.
+
+    Workflow validation and execution need the node schemas owned by optional
+    components. These overrides affect only the in-memory package load and do
+    not modify the operator's persisted component selections.
+    """
+    overrides_by_package: dict[str, dict[str, bool]] = {}
+    for requirement in template_component_requirements(workflow):
+        package = requirement["package"]
+        component = requirement["component"]
+        overrides_by_package.setdefault(package, {})[component] = True
+    for requirement in template_adapter_requirements(workflow):
+        package = requirement["package"]
+        component = requirement["component"]
+        adapter = requirement["adapter"]
+        package_overrides = overrides_by_package.setdefault(package, {})
+        package_overrides[component] = True
+        package_overrides[_adapter_state_key(component, adapter)] = True
+
+    loaded: list[dict[str, Any]] = []
+    unavailable: list[dict[str, str]] = []
+    for package, overrides in overrides_by_package.items():
+        info = _PACKAGE_REGISTRY.get(package)
+        if info is None or info.source != "folder" or not info.path:
+            unavailable.append({
+                "package": package,
+                "reason": "package is not installed as a folder package",
+            })
+            continue
+        updated = load_package(info.path, component_overrides=overrides)
+        if updated.ok:
+            loaded.append(updated.to_dict())
+        else:
+            unavailable.append({
+                "package": package,
+                "reason": updated.error.strip() or "package could not be loaded",
+            })
+
+    return {"loaded": loaded, "unavailable": unavailable}
 
 
 def component_dependency_plan(package_name: str, component_name: str) -> dict[str, Any]:
@@ -2259,6 +2315,7 @@ __all__ = [
     "package_git_status",
     "package_statuses",
     "load_package",
+    "load_workflow_requirements",
     "package_category_colors",
     "package_template_dirs",
     "packages_root",

--- a/python/blacknode/workflow.py
+++ b/python/blacknode/workflow.py
@@ -175,6 +175,9 @@ def validate_graph(
 
 
 def validate_workflow(data: Mapping[str, Any]) -> ValidationReport:
+    from .packages import load_workflow_requirements
+
+    load_workflow_requirements(data)
     errors: list[ValidationIssue] = []
     warnings: list[ValidationIssue] = []
 

--- a/python/blacknode/workflow.py
+++ b/python/blacknode/workflow.py
@@ -439,7 +439,7 @@ def export_workflow_python(data: Mapping[str, Any], *, style: str = "flat") -> s
         "        return",
         "    _blacknode_live_runtime_stopped = True",
         "    for module_name in (",
-        "        'blacknode.pkg.blacknode_controllers.joint_control.adapters.ros2.joint_motion',",
+        "        'blacknode.pkg.blacknode_motion.arm.adapters.ros2.joint_motion',",
         "        'blacknode.pkg.blacknode_robot.robot',",
         "        'blacknode.pkg.blacknode_ros2.ros2_runtime',",
         "        'blacknode.pkg.blacknode_perception.cv2_runtime',",

--- a/skills/blacknode-workflow/SKILL.md
+++ b/skills/blacknode-workflow/SKILL.md
@@ -128,8 +128,8 @@ or type error, inspect `get_node_schema` and fix the graph instead of guessing.
 
 - Prefer `Robot` for setup, then `ROS2Status`, `ROS2JointState`,
   `ROS2SetJoint`, and `ROS2ManualMove`. `ROS2Status` comes from
-  `blacknode-ros2`; the joint nodes come from the `blacknode-controllers`
-  joint-control ROS 2 adapter, so templates using them must require both
+  `blacknode-ros2`; the joint nodes come from the `blacknode-motion`
+  arm ROS 2 adapter, so templates using them must require both
   packages. Each node picks the transport itself via `transport=auto`.
 - Treat torque control and pose streaming as independent state:
   - `Release + live pose` disables torque and keeps joint feedback live. Support

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -29,20 +29,20 @@ def _constructors():
         "blacknode.robot-profile": c.robot_profile(
             "r1",
             capabilities=["mobile-base"],
-            capability_bindings={"mobile-base": {"provider": {"package": "blacknode-controllers"}}},
+            capability_bindings={"mobile-base": {"provider": {"package": "blacknode-motion"}}},
             hardware_identity={"id": "robot-1"},
             driver={"hardware_id": "x"},
         ),
         "blacknode.robot-capability-binding": c.robot_capability_binding(
             "mobile-base",
-            provider_package="blacknode-controllers",
-            provider_component="mobile-base",
+            provider_package="blacknode-motion",
+            provider_component="base",
             provider_adapter="ros2",
         ),
         "blacknode.robot-capability-status": c.robot_capability_status(
             "mobile-base",
             state="unavailable",
-            provider={"package": "blacknode-controllers", "component": "mobile-base"},
+            provider={"package": "blacknode-motion", "component": "base"},
             reason="provider is not installed",
         ),
         "blacknode.mobile-base": c.mobile_base(

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -742,6 +742,14 @@ class EditorDeviceApiTests(unittest.TestCase):
             uploaded[0],
         )
         self.assertIn(
+            "git clone https://github.com/temiroff/blacknode-robot.git",
+            uploaded[0],
+        )
+        self.assertNotIn(
+            "github.com/temiroff/blacknode-hardware.git",
+            uploaded[0],
+        )
+        self.assertIn(
             'BLACKNODE_HARDWARE_INSTANCE="$service_instance" ./setup_ubuntu.sh',
             uploaded[0],
         )
@@ -1807,14 +1815,14 @@ class EditorDeviceApiTests(unittest.TestCase):
             "service_name": "blacknode-runtime-local-process",
             "instance_id": "local",
             "stack_mode": "runtime_only",
-            "hardware_dir": r"E:\Blacknode\blacknode-hardware",
+            "hardware_dir": r"E:\Blacknode\blacknode-robot",
             "hardware_port": 8765,
             "hardware_service_name": "blacknode-hardware-local-awaiting-device",
             "hardware_state": "awaiting_device",
             "hardware_configured": False,
-            "hardware_pid_file": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\hardware.pid",
-            "hardware_token_file": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\auth.token",
-            "hardware_log_path": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\hardware.log",
+            "hardware_pid_file": r"E:\Blacknode\blacknode-robot\.blacknode-hardware\hardware.pid",
+            "hardware_token_file": r"E:\Blacknode\blacknode-robot\.blacknode-hardware\auth.token",
+            "hardware_log_path": r"E:\Blacknode\blacknode-robot\.blacknode-hardware\hardware.log",
             "hardware_owned_install": True,
             "management_mode": "local",
             "config_path": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.json",
@@ -1857,7 +1865,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         )
         self.assertEqual(
             device["managed_runtime"]["hardware_dir"],
-            r"E:\Blacknode\blacknode-hardware",
+            r"E:\Blacknode\blacknode-robot",
         )
         self.assertEqual(device["managed_runtime"]["hardware_port"], 8765)
         self.assertEqual(
@@ -1902,7 +1910,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             stack = Path(temporary)
             runtime_dir = stack / "blacknode-runtime"
-            hardware_dir = stack / "blacknode-hardware"
+            hardware_dir = stack / "blacknode-robot"
             (runtime_dir / "scripts").mkdir(parents=True)
             (hardware_dir / "scripts").mkdir(parents=True)
             (runtime_dir / "scripts" / "runtime_service.py").write_text(
@@ -1918,7 +1926,7 @@ class EditorDeviceApiTests(unittest.TestCase):
                 encoding="utf-8",
             )
             (hardware_dir / "pyproject.toml").write_text(
-                '[project]\nname = "blacknode-hardware"\nversion = "0.1.1"\n',
+                '[project]\nname = "blacknode-robot"\nversion = "0.4.0"\n',
                 encoding="utf-8",
             )
             runtime_state = runtime_dir / ".blacknode-runtime"
@@ -1945,7 +1953,7 @@ class EditorDeviceApiTests(unittest.TestCase):
             self.assertEqual(runtime_report["state"], "stopped")
             self.assertEqual(runtime_report["installed_version"], "0.3.9")
             self.assertEqual(hardware_report["state"], "stopped")
-            self.assertEqual(hardware_report["installed_version"], "0.1.1")
+            self.assertEqual(hardware_report["installed_version"], "0.4.0")
             spawn_runtime.assert_not_called()
             spawn_hardware.assert_not_called()
 
@@ -1967,14 +1975,14 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "service_name": "blacknode-runtime-local-process",
                 "runtime_dir": r"E:\Blacknode\blacknode-runtime",
                 "stack_mode": "runtime_only",
-                "hardware_dir": r"E:\Blacknode\blacknode-hardware",
+                "hardware_dir": r"E:\Blacknode\blacknode-robot",
                 "hardware_port": 8765,
                 "hardware_service_name": "blacknode-hardware-local-awaiting-device",
                 "hardware_state": "awaiting_device",
                 "hardware_configured": False,
-                "hardware_pid_file": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\hardware.pid",
-                "hardware_token_file": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\auth.token",
-                "hardware_log_path": r"E:\Blacknode\blacknode-hardware\.blacknode-hardware\hardware.log",
+                "hardware_pid_file": r"E:\Blacknode\blacknode-robot\.blacknode-hardware\hardware.pid",
+                "hardware_token_file": r"E:\Blacknode\blacknode-robot\.blacknode-hardware\auth.token",
+                "hardware_log_path": r"E:\Blacknode\blacknode-robot\.blacknode-hardware\hardware.log",
                 "hardware_owned_install": True,
                 "config_path": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.json",
                 "pid_file": r"E:\Blacknode\blacknode-runtime\.blacknode-runtime\runtime.pid",
@@ -2046,7 +2054,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         managed = {
             "management_mode": "local",
             "runtime_dir": r"E:\Blacknode\blacknode-runtime",
-            "hardware_dir": r"E:\Blacknode\blacknode-hardware",
+            "hardware_dir": r"E:\Blacknode\blacknode-robot",
         }
         host = {
             "id": "local-computer",
@@ -2098,7 +2106,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             stack = Path(temporary)
             runtime_dir = stack / "blacknode-runtime"
-            hardware_dir = stack / "blacknode-hardware"
+            hardware_dir = stack / "blacknode-robot"
             (runtime_dir / "scripts").mkdir(parents=True)
             (hardware_dir / "scripts").mkdir(parents=True)
             (runtime_dir / "scripts" / "runtime_service.py").write_text(
@@ -2114,7 +2122,7 @@ class EditorDeviceApiTests(unittest.TestCase):
                 encoding="utf-8",
             )
             (hardware_dir / "pyproject.toml").write_text(
-                '[project]\nname = "blacknode-hardware"\nversion = "0.1.1"\n',
+                '[project]\nname = "blacknode-robot"\nversion = "0.4.0"\n',
                 encoding="utf-8",
             )
             managed = {
@@ -2183,7 +2191,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         managed = {
             "management_mode": "local",
             "runtime_dir": r"E:\Blacknode\blacknode-runtime",
-            "hardware_dir": r"E:\Blacknode\blacknode-hardware",
+            "hardware_dir": r"E:\Blacknode\blacknode-robot",
         }
         host = {
             "id": "local-computer",
@@ -4974,7 +4982,7 @@ class EditorDeviceApiTests(unittest.TestCase):
             patch("device_registry.urllib.request.urlopen", side_effect=error),
             self.assertRaisesRegex(
                 device_registry.DeviceRegistryError,
-                r"Update blacknode-hardware.*service\.sh restart",
+                r"Update blacknode-robot.*service\.sh restart",
             ),
         ):
             client.activate_calibration({}, {})
@@ -5102,8 +5110,8 @@ class EditorDeviceApiTests(unittest.TestCase):
             "name": "blacknode-skills",
             "git_url": "https://github.com/temiroff/blacknode-skills.git",
             "version": "0.1.0",
-            "components": ["follow-person"],
-            "adapters": [{"component": "follow-person", "adapter": "ros2"}],
+            "components": ["follow"],
+            "adapters": [{"component": "follow", "adapter": "ros2"}],
         }]
         package_index = {
             "packages": {},
@@ -5459,48 +5467,6 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "run_id": "so-arm follower",
                 "topic": "/blacknode/leader_follower/so_arm_follower/control",
             }],
-        )
-
-    def test_split_follower_publisher_declares_one_remote_armed_gate(self):
-        workflow = _workflow([])
-        workflow["node_meta"]["publisher"] = {
-            "id": "publisher",
-            "type": "ROS2FollowerJointPublisher",
-            "params": {
-                "run_id": "split follower",
-                "control_topic": "",
-                "armed": False,
-            },
-        }
-
-        controls = server._workflow_motion_controls(workflow)
-
-        self.assertEqual(len(controls), 1)
-        self.assertEqual(controls[0]["node_id"], "publisher")
-        self.assertEqual(
-            controls[0]["topic"],
-            "/blacknode/leader_follower/split_follower/control",
-        )
-
-    def test_generic_joint_publisher_declares_one_remote_armed_gate(self):
-        workflow = _workflow([])
-        workflow["node_meta"]["publish"] = {
-            "id": "publish",
-            "type": "ROS2JointPublish",
-            "params": {
-                "run_id": "joint publisher",
-                "control_topic": "",
-                "armed": False,
-            },
-        }
-
-        controls = server._workflow_motion_controls(workflow)
-
-        self.assertEqual(len(controls), 1)
-        self.assertEqual(controls[0]["node_id"], "publish")
-        self.assertEqual(
-            controls[0]["topic"],
-            "/blacknode/leader_follower/joint_publisher/control",
         )
 
     def test_joint_controller_declares_one_remote_armed_gate(self):

--- a/tests/test_editor_family_colors.py
+++ b/tests/test_editor_family_colors.py
@@ -14,7 +14,7 @@ def test_canonical_family_colors_are_stable():
         "Perception": "#22c55e",
         "ROS2": "#3b82f6",
         "CUDA": "#84cc16",
-        "Controllers": "#f97316",
+        "Motion": "#f97316",
         "Drivers": "#64748b",
         "Output": "#ec4899",
         "Values": "#f59e0b",

--- a/tests/test_editor_template_packages.py
+++ b/tests/test_editor_template_packages.py
@@ -50,8 +50,8 @@ def _template(node_type: str) -> dict:
 
 def test_template_load_returns_installable_missing_package(tmp_path):
     path = tmp_path / "missing-cuda.json"
-    path.write_text(json.dumps(_template("CUDAKernelLab")), encoding="utf-8")
-    registered = _NODE_REGISTRY.pop("CUDAKernelLab", None)
+    path.write_text(json.dumps(_template("CUDAImageFilter")), encoding="utf-8")
+    registered = _NODE_REGISTRY.pop("CUDAImageFilter", None)
     try:
         with (
             patch.object(server, "_TEMPLATES_DIR", str(tmp_path)),
@@ -60,16 +60,16 @@ def test_template_load_returns_installable_missing_package(tmp_path):
             response = TestClient(server.app).post("/templates/missing-cuda/load")
     finally:
         if registered is not None:
-            _NODE_REGISTRY["CUDAKernelLab"] = registered
+            _NODE_REGISTRY["CUDAImageFilter"] = registered
 
     assert response.status_code == 409
     detail = response.json()["detail"]
     assert detail["code"] == "missing_packages"
-    assert detail["missing_node_types"] == ["CUDAKernelLab"]
+    assert detail["missing_node_types"] == ["CUDAImageFilter"]
     assert detail["missing_packages"] == [{
         "name": "blacknode-cuda",
         "git_url": "https://github.com/temiroff/blacknode-cuda.git",
-        "node_types": ["CUDAKernelLab"],
+        "node_types": ["CUDAImageFilter"],
         "source": "template",
         "installed": False,
         "load_error": "",

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -40,10 +40,30 @@ def test_core_index_maps_official_node_types_to_git_packages():
     payload = package_index_payload()
 
     assert payload["schema_version"] == 2
+    assert set(payload["packages"]) == {
+        "blacknode-agent",
+        "blacknode-motion",
+        "blacknode-cuda",
+        "blacknode-dataset",
+        "blacknode-drivers",
+        "blacknode-isaac",
+        "blacknode-perception",
+        "blacknode-robot",
+        "blacknode-ros2",
+        "blacknode-runtime",
+        "blacknode-skills",
+        "blacknode-training",
+    }
     assert payload["packages"]["blacknode-robot"]["layer"] == "robot"
+    robot = payload["packages"]["blacknode-robot"]
+    assert {"devices", "telemetry"}.issubset(robot["components"])
+    assert robot["components"]["devices"]["node_types"] == ["HardwareCapabilities"]
+    assert robot["components"]["telemetry"]["adapters"]["mqtt"]["default"] is False
     assert payload["packages"]["blacknode-perception"]["layer"] == "perception"
     assert payload["packages"]["blacknode-ros2"]["layer"] == "ros2"
     assert payload["packages"]["blacknode-ros2"]["components"]["core"]["default"] is True
+    assert payload["packages"]["blacknode-ros2"]["components"]["rosbridge"]["default"] is False
+    assert payload["packages"]["blacknode-ros2"]["components"]["processes"]["default"] is False
     assert set(payload["packages"]["blacknode-ros2"]["components"]) == {
         "core",
         "diagnostics",
@@ -63,9 +83,23 @@ def test_core_index_maps_official_node_types_to_git_packages():
             "requires": [{"component": "core"}],
         }
     assert payload["packages"]["blacknode-skills"]["layer"] == "skills"
-    assert payload["packages"]["blacknode-agent"]["layer"] == "agent"
-    assert payload["packages"]["blacknode-controllers"]["layer"] == "controllers"
+    agent = payload["packages"]["blacknode-agent"]
+    assert agent["layer"] == "agent"
+    assert set(agent["components"]) == {"memory", "executive"}
+    motion = payload["packages"]["blacknode-motion"]
+    assert motion["layer"] == "motion"
+    assert set(motion["components"]) == {"core", "arm", "base", "policy", "safety"}
+    assert motion["components"]["arm"]["node_types"] == ["JointMotionProfile"]
+    assert motion["components"]["arm"].get("aliases", []) == []
+    assert motion["components"]["base"].get("aliases", []) == []
+    assert "JointMotionProfile" not in motion["components"]["arm"]["adapters"]["ros2"]["node_types"]
     assert payload["packages"]["blacknode-dataset"]["layer"] == "learning"
+    dataset = payload["packages"]["blacknode-dataset"]["components"]
+    assert all(dataset[name]["default"] for name in {"recording", "replay", "validation"})
+    assert not any(dataset[name]["default"] for name in {"evaluation", "export", "publishing"})
+    cuda = payload["packages"]["blacknode-cuda"]["components"]
+    assert set(cuda) == {"capability", "image-processing", "tensor-operations", "benchmarks"}
+    assert cuda["benchmarks"]["default"] is False
     drivers = payload["packages"]["blacknode-drivers"]
     assert drivers["layer"] == "drivers"
     assert drivers["components"]["feetech"]["default"] is True
@@ -73,27 +107,19 @@ def test_core_index_maps_official_node_types_to_git_packages():
         "FeetechBusConfig",
         "FeetechBusProbe",
     ]
-    # Roadmap components are declared ahead of implementation, so assert the
-    # one that ships nodes rather than pinning the whole set.
-    assert "feetech" in drivers["components"]
-    assert all(
-        not component["node_types"]
-        for name, component in drivers["components"].items()
-        if name != "feetech"
-    )
+    assert set(drivers["components"]) == {"feetech"}
     assert drivers["components"]["feetech"]["adapters"]["ros2"]["default"] is False
     assert payload["nodes"]["FeetechROS2Adapter"]["package"] == "blacknode-drivers"
     assert payload["nodes"]["FeetechBusProbe"]["package"] == "blacknode-drivers"
-    assert payload["nodes"]["CUDAKernelLab"] == {
-        "package": "blacknode-cuda",
-        "git_url": "https://github.com/temiroff/blacknode-cuda.git",
-    }
+    assert "CUDAKernelLab" not in payload["nodes"]
+    assert "CUDACustomKernel" not in payload["nodes"]
     assert payload["nodes"]["ROS2TopicList"]["package"] == "blacknode-ros2"
     assert payload["nodes"]["ROS2TopicPublisher"]["package"] == "blacknode-ros2"
     assert "ROS2DemoPublisher" not in payload["nodes"]
     assert payload["nodes"]["RobotDiscovery"]["package"] == "blacknode-robot"
     assert payload["nodes"]["RobotMonitor"]["package"] == "blacknode-robot"
     assert payload["nodes"]["RobotCapabilityInspect"]["package"] == "blacknode-robot"
+    assert payload["nodes"]["HardwareCapabilities"]["package"] == "blacknode-robot"
     assert payload["nodes"]["EpisodeRecorder"] == {
         "package": "blacknode-dataset",
         "git_url": "https://github.com/temiroff/blacknode-dataset.git",
@@ -106,14 +132,17 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["ROS2PublishJointState"]["package"] == "blacknode-skills"
     assert payload["nodes"]["ROS2SubscribeJointState"]["package"] == "blacknode-skills"
     assert payload["nodes"]["ROS2JointController"]["package"] == "blacknode-skills"
-    assert payload["nodes"]["ROS2JointStatePublish"]["package"] == "blacknode-skills"
-    assert payload["nodes"]["ROS2JointSubscribe"]["package"] == "blacknode-skills"
-    assert payload["nodes"]["ROS2JointReplicate"]["package"] == "blacknode-skills"
-    assert payload["nodes"]["ROS2JointPublish"]["package"] == "blacknode-skills"
-    assert payload["nodes"]["ROS2LeaderJointSubscriber"]["package"] == "blacknode-skills"
-    assert payload["nodes"]["ROS2FollowerJointPublisher"]["package"] == "blacknode-skills"
-    assert payload["nodes"]["PolicyRuntime"]["package"] == "blacknode-controllers"
-    assert payload["nodes"]["BaseSafetyGate"]["package"] == "blacknode-controllers"
+    for legacy_name in {
+        "ROS2JointStatePublish",
+        "ROS2JointSubscribe",
+        "ROS2JointReplicate",
+        "ROS2JointPublish",
+        "ROS2LeaderJointSubscriber",
+        "ROS2FollowerJointPublisher",
+    }:
+        assert legacy_name not in payload["nodes"]
+    assert payload["nodes"]["PolicyRuntime"]["package"] == "blacknode-motion"
+    assert payload["nodes"]["BaseSafetyGate"]["package"] == "blacknode-motion"
     assert payload["nodes"]["Camera"]["package"] == "blacknode-perception"
     assert payload["nodes"]["CameraStream"]["package"] == "blacknode-perception"
     assert payload["nodes"]["ACTTraining"] == {
@@ -123,6 +152,10 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["ACTPolicyExport"]["package"] == "blacknode-training"
     assert payload["nodes"]["ACTPolicyReplay"]["package"] == "blacknode-training"
     assert payload["nodes"]["PolicyArtifactLoad"]["package"] == "blacknode-training"
+    assert not any(
+        component["default"]
+        for component in payload["packages"]["blacknode-training"]["components"].values()
+    )
     assert payload["nodes"]["IsaacPolicyBridge"] == {
         "package": "blacknode-isaac",
         "git_url": "https://github.com/temiroff/blacknode-isaac.git",
@@ -178,9 +211,9 @@ def test_installed_package_manifest_maps_new_node_types_without_core_edit():
 
 
 def test_resolver_finds_nested_nodes_and_indexed_package():
-    workflow = _workflow("CUDAKernelLab")
+    workflow = _workflow("CUDAImageFilter")
 
-    assert workflow_node_types(workflow) == {"CUDAKernelLab", "NestedNode"}
+    assert workflow_node_types(workflow) == {"CUDAImageFilter", "NestedNode"}
     result = resolve_workflow_dependencies(
         workflow,
         available_node_types={"Output"},
@@ -189,7 +222,7 @@ def test_resolver_finds_nested_nodes_and_indexed_package():
 
     assert not result["ok"]
     assert result["missing_packages"][0]["name"] == "blacknode-cuda"
-    assert result["missing_packages"][0]["node_types"] == ["CUDAKernelLab"]
+    assert result["missing_packages"][0]["node_types"] == ["CUDAImageFilter"]
     assert result["unresolved_node_types"] == ["NestedNode"]
 
 
@@ -282,36 +315,3 @@ def test_workflow_adapter_requirement_adds_missing_official_package():
     assert result["code"] == "missing_packages"
     assert result["missing_packages"][0]["name"] == "blacknode-drivers"
     assert result["missing_adapters"][0]["reason"] == "package is not installed"
-
-
-def test_legacy_component_alias_resolves_against_renamed_installed_component():
-    workflow = _workflow("ROS2LeaderFollower")
-    workflow["metadata"]["required_components"] = [
-        "blacknode-skills/follow-person"
-    ]
-    workflow["metadata"]["required_adapters"] = [
-        "blacknode-skills/follow-person@ros2"
-    ]
-    installed = {
-        "blacknode-skills": {
-            "ok": True,
-            "version": "0.2.0",
-            "components": {
-                "follow": {
-                    "aliases": ["follow-person"],
-                    "enabled": True,
-                    "adapters": {"ros2": {"enabled": True}},
-                },
-            },
-        },
-    }
-
-    result = resolve_workflow_dependencies(
-        workflow,
-        available_node_types={"ROS2LeaderFollower", "NestedNode"},
-        installed_packages=installed,
-    )
-
-    assert result["ok"]
-    assert result["missing_components"] == []
-    assert result["missing_adapters"] == []

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -20,6 +20,7 @@ from blacknode.packages import (
     install_from_git,
     install_prerequisites,
     load_package,
+    load_workflow_requirements,
     package_template_dirs,
     remove_package,
     reset_component,
@@ -28,6 +29,7 @@ from blacknode.packages import (
     validate_package_catalog,
     write_package_lock,
 )
+from blacknode.workflow import validate_workflow
 
 
 def _write_package(
@@ -104,6 +106,56 @@ def test_folder_package_exposes_layer_and_component_catalog(tmp_path):
     assert component["node_paths"] == []
     assert info.component_mode is False
     assert "_PkgDriverLayer" in info.node_types
+
+
+def test_workflow_requirement_transiently_enables_optional_component(tmp_path):
+    pkg = _write_package(
+        tmp_path,
+        name="bn-workflow-required",
+        node_name="_PkgWorkflowRequiredRoot",
+        package_metadata="component-mode = true",
+        component_metadata='''
+        [components.optional]
+        default = false
+        nodes = ["components/optional/nodes"]
+        ''',
+    )
+    _write_component_node(pkg, "optional", "_PkgWorkflowRequired")
+    info = load_package(pkg)
+    assert info.ok
+    assert info.enabled_components == []
+    assert "_PkgWorkflowRequired" not in _NODE_REGISTRY
+
+    workflow = {
+        "kind": "blacknode.workflow",
+        "schema_version": 1,
+        "name": "Required optional component",
+        "entrypoint": {"node_id": "probe", "port": "out"},
+        "metadata": {
+            "required_packages": ["bn-workflow-required"],
+            "required_components": ["bn-workflow-required/optional"],
+        },
+        "node_meta": {
+            "probe": {
+                "id": "probe",
+                "type": "_PkgWorkflowRequired",
+                "params": {"text": "hello"},
+                "pos": [0, 0],
+                "inputs": ["text"],
+                "outputs": ["out"],
+                "input_types": {"text": "Text"},
+                "output_types": {"out": "Text"},
+                "input_defaults": {},
+            },
+        },
+        "edges": [],
+    }
+
+    requirement_report = load_workflow_requirements(workflow)
+    assert not requirement_report["unavailable"]
+    assert "_PkgWorkflowRequired" in _NODE_REGISTRY
+    assert validate_workflow(workflow).ok
+    assert not (tmp_path / ".blacknode-components.json").exists()
 
 
 def _write_component_node(pkg, component, node_name):

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -184,7 +184,52 @@ def test_component_package_loads_only_enabled_nodes_and_dependencies(tmp_path):
     assert "_PkgComponentCore" in _NODE_REGISTRY
 
 
-def test_component_alias_preserves_saved_state_cli_and_import_paths(tmp_path):
+def test_tagged_root_component_package_filters_nodes_by_enabled_component(tmp_path):
+    pkg = _write_package(
+        tmp_path,
+        name="bn-tagged-components",
+        node_name="_PkgTaggedCore",
+        package_metadata='component-mode = true',
+        component_metadata='''
+        [components.core]
+        default = true
+
+        [components.optional]
+        default = false
+        ''',
+    )
+    probe = pkg / "nodes" / "probe.py"
+    probe.write_text(
+        probe.read_text(encoding="utf-8").replace(
+            'name="_PkgTaggedCore",',
+            'name="_PkgTaggedCore", component="core",',
+        ),
+        encoding="utf-8",
+    )
+    (pkg / "nodes" / "optional.py").write_text(textwrap.dedent("""
+        from blacknode.node import Text, node
+
+
+        @node(name="_PkgTaggedOptional", component="optional", inputs={"text": Text}, outputs={"out": Text})
+        def optional(text: str) -> str:
+            return text
+    """), encoding="utf-8")
+
+    info = load_package(pkg)
+
+    assert info.ok
+    assert info.component_mode is True
+    assert info.enabled_components == ["core"]
+    assert "_PkgTaggedCore" in _NODE_REGISTRY
+    assert "_PkgTaggedOptional" not in _NODE_REGISTRY
+
+    enabled = set_component_enabled("bn-tagged-components", "optional", True)
+    assert enabled.enabled_components == ["core", "optional"]
+    assert "_PkgTaggedCore" in _NODE_REGISTRY
+    assert "_PkgTaggedOptional" in _NODE_REGISTRY
+
+
+def test_component_alias_supports_third_party_package_migrations(tmp_path):
     pkg = _write_package(
         tmp_path,
         name="bn-component-alias",
@@ -192,7 +237,7 @@ def test_component_alias_preserves_saved_state_cli_and_import_paths(tmp_path):
         package_metadata='layer = "Skills"',
         component_metadata='''
         [components.follow]
-        aliases = ["follow-person"]
+        aliases = ["legacy-follow"]
         default = false
         nodes = ["components/follow/nodes"]
         ''',
@@ -202,7 +247,7 @@ def test_component_alias_preserves_saved_state_cli_and_import_paths(tmp_path):
         "schema_version": 1,
         "packages": {
             "bn-component-alias": {
-                "follow-person": True,
+                "legacy-follow": True,
             },
         },
     }), encoding="utf-8")
@@ -210,20 +255,20 @@ def test_component_alias_preserves_saved_state_cli_and_import_paths(tmp_path):
     info = load_package(pkg)
 
     assert info.ok
-    assert info.components["follow"]["aliases"] == ["follow-person"]
+    assert info.components["follow"]["aliases"] == ["legacy-follow"]
     assert info.enabled_components == ["follow"]
     assert "_PkgFollowAlias" in _NODE_REGISTRY
     assert "blacknode.pkg.bn_component_alias.follow" in sys.modules
     assert (
-        sys.modules["blacknode.pkg.bn_component_alias.follow_person"]
+        sys.modules["blacknode.pkg.bn_component_alias.legacy_follow"]
         is sys.modules["blacknode.pkg.bn_component_alias.follow"]
     )
     assert component_dependency_plan(
-        "bn-component-alias", "follow-person"
+        "bn-component-alias", "legacy-follow"
     )["target"]["component"] == "follow"
 
     disabled = set_component_enabled(
-        "bn-component-alias", "follow-person", False
+        "bn-component-alias", "legacy-follow", False
     )
     assert disabled.enabled_components == []
     state = json.loads(
@@ -787,8 +832,12 @@ def test_remove_unknown_package_is_structured_error():
 def test_blacknode_cuda_loads_as_package():
     if "blacknode-cuda" not in _PACKAGE_REGISTRY:
         pytest.skip("blacknode-cuda not installed (it lives in its own repo)")
-    assert "CUDAKernelLab" in _NODE_REGISTRY
-    assert getattr(_NODE_REGISTRY["CUDAKernelLab"], "_bn_package", "") == "blacknode-cuda"
+    assert "GPUCapability" in _NODE_REGISTRY
+    assert "CUDAImageFilter" in _NODE_REGISTRY
+    assert "CUDAKernelLab" not in _NODE_REGISTRY
+    assert "CUDACustomKernel" not in _NODE_REGISTRY
+    assert "CUTLASSGemm" not in _NODE_REGISTRY
+    assert getattr(_NODE_REGISTRY["GPUCapability"], "_bn_package", "") == "blacknode-cuda"
     info = _PACKAGE_REGISTRY["blacknode-cuda"]
     assert info.ok
     assert info.categories.get("NVIDIA CUDA")

--- a/tests/test_python_roundtrip.py
+++ b/tests/test_python_roundtrip.py
@@ -155,7 +155,7 @@ class PythonRoundTripTests(unittest.TestCase):
             script,
         )
         self.assertIn(
-            "blacknode.pkg.blacknode_controllers.joint_control.adapters.ros2.joint_motion",
+            "blacknode.pkg.blacknode_motion.arm.adapters.ros2.joint_motion",
             script,
         )
         self.assertIn("signal.signal(signal.SIGTERM, _raise_blacknode_stop)", script)


### PR DESCRIPTION
## Summary

- Rename the controller package architecture to blacknode-motion across the catalog, runtime, editor, workflows, and documentation.
- Apply the settled public-component boundaries and default activation rules for agent, drivers, CUDA, dataset, ROS 2, runtime, skills, and training.
- Remove official package, component, and node compatibility aliases.
- Load workflow-declared optional components in memory before validation without changing persisted operator settings.

## Why

Blacknode is still under active construction, so the package surface can move directly to canonical names and concrete capability boundaries. Package CI also requires the core catalog and loader to land before extension checks can validate the coordinated release.

## Impact

Workflows use blacknode-motion and explicit required components. Native DDS remains the normal ROS 2 path, optional workloads stay opt-in, and validation can resolve schemas from those opt-in components.

## Validation

- 486 core Python tests passed, 8 skipped
- 27 focused package-loader tests passed
- All ROS 2 templates validated through the CLI
- Editor production build passed
- Rust workspace tests passed