### PR TITLE
Preserve package state during workflow validation

### DIFF
--- a/python/blacknode/packages.py
+++ b/python/blacknode/packages.py
@@ -29,9 +29,10 @@ import sys
 import tomllib
 import traceback
 import types
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Iterator, Mapping
 
 from ._version import __version__ as _CORE_VERSION
 from .node import _NODE_REGISTRY
@@ -785,7 +786,7 @@ def load_workflow_requirements(workflow: Mapping[str, Any]) -> dict[str, Any]:
 
     loaded: list[dict[str, Any]] = []
     unavailable: list[dict[str, str]] = []
-    for package, overrides in overrides_by_package.items():
+    for package, required_overrides in overrides_by_package.items():
         info = _PACKAGE_REGISTRY.get(package)
         if info is None or info.source != "folder" or not info.path:
             unavailable.append({
@@ -793,6 +794,27 @@ def load_workflow_requirements(workflow: Mapping[str, Any]) -> dict[str, Any]:
                 "reason": "package is not installed as a folder package",
             })
             continue
+        requirements_satisfied = all(
+            (
+                f"{state_key.partition('@')[0]}/{state_key.partition('@')[2]}"
+                in info.enabled_adapters
+            )
+            if "@" in state_key
+            else state_key in info.enabled_components
+            for state_key in required_overrides
+        )
+        if requirements_satisfied:
+            loaded.append(info.to_dict())
+            continue
+        overrides = {
+            component: True
+            for component in info.enabled_components
+        }
+        for adapter_ref in info.enabled_adapters:
+            component, separator, adapter = adapter_ref.partition("/")
+            if separator:
+                overrides[_adapter_state_key(component, adapter)] = True
+        overrides.update(required_overrides)
         updated = load_package(info.path, component_overrides=overrides)
         if updated.ok:
             loaded.append(updated.to_dict())
@@ -803,6 +825,70 @@ def load_workflow_requirements(workflow: Mapping[str, Any]) -> dict[str, Any]:
             })
 
     return {"loaded": loaded, "unavailable": unavailable}
+
+
+@contextmanager
+def workflow_requirement_scope(
+    workflow: Mapping[str, Any],
+) -> Iterator[dict[str, Any]]:
+    """Temporarily load workflow requirements and restore package state."""
+    package_names = {
+        requirement["package"]
+        for requirement in (
+            *template_component_requirements(workflow),
+            *template_adapter_requirements(workflow),
+        )
+    }
+    if not package_names:
+        yield {"loaded": [], "unavailable": []}
+        return
+
+    node_snapshot = dict(_NODE_REGISTRY)
+    package_snapshot = {
+        package: _PACKAGE_REGISTRY.get(package)
+        for package in package_names
+    }
+    module_prefixes = tuple(
+        f"{_PKG_MODULE_ROOT}.{_safe_module_name(package)}"
+        for package in package_names
+    )
+    module_snapshot = {
+        name: module
+        for name, module in sys.modules.items()
+        if any(name == prefix or name.startswith(prefix + ".") for prefix in module_prefixes)
+    }
+    root = sys.modules.get(_PKG_MODULE_ROOT)
+    root_attributes = {
+        package: getattr(root, _safe_module_name(package), None) if root else None
+        for package in package_names
+    }
+
+    try:
+        yield load_workflow_requirements(workflow)
+    finally:
+        _NODE_REGISTRY.clear()
+        _NODE_REGISTRY.update(node_snapshot)
+        for package, previous in package_snapshot.items():
+            if previous is None:
+                _PACKAGE_REGISTRY.pop(package, None)
+            else:
+                _PACKAGE_REGISTRY[package] = previous
+        for name in [
+            name
+            for name in sys.modules
+            if any(name == prefix or name.startswith(prefix + ".") for prefix in module_prefixes)
+        ]:
+            del sys.modules[name]
+        sys.modules.update(module_snapshot)
+        root = sys.modules.get(_PKG_MODULE_ROOT)
+        if root is not None:
+            for package, previous in root_attributes.items():
+                attribute = _safe_module_name(package)
+                if previous is None:
+                    if hasattr(root, attribute):
+                        delattr(root, attribute)
+                else:
+                    setattr(root, attribute, previous)
 
 
 def component_dependency_plan(package_name: str, component_name: str) -> dict[str, Any]:
@@ -2316,6 +2402,7 @@ __all__ = [
     "package_statuses",
     "load_package",
     "load_workflow_requirements",
+    "workflow_requirement_scope",
     "package_category_colors",
     "package_template_dirs",
     "packages_root",

--- a/python/blacknode/workflow.py
+++ b/python/blacknode/workflow.py
@@ -175,9 +175,13 @@ def validate_graph(
 
 
 def validate_workflow(data: Mapping[str, Any]) -> ValidationReport:
-    from .packages import load_workflow_requirements
+    from .packages import workflow_requirement_scope
 
-    load_workflow_requirements(data)
+    with workflow_requirement_scope(data):
+        return _validate_workflow_loaded(data)
+
+
+def _validate_workflow_loaded(data: Mapping[str, Any]) -> ValidationReport:
     errors: list[ValidationIssue] = []
     warnings: list[ValidationIssue] = []
 
@@ -223,7 +227,9 @@ def load_workflow(path: str | Path) -> dict[str, Any]:
 
 def graph_from_workflow(data: Mapping[str, Any]):
     from .graph import Graph
+    from .packages import load_workflow_requirements
 
+    load_workflow_requirements(data)
     graph = Graph()
     node_meta = data.get("node_meta") or {}
     edges = data.get("edges") or []

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -118,13 +118,22 @@ def test_workflow_requirement_transiently_enables_optional_component(tmp_path):
         [components.optional]
         default = false
         nodes = ["components/optional/nodes"]
+
+        [components.already-enabled]
+        default = false
+        nodes = ["components/already-enabled/nodes"]
         ''',
     )
     _write_component_node(pkg, "optional", "_PkgWorkflowRequired")
-    info = load_package(pkg)
+    _write_component_node(pkg, "already-enabled", "_PkgAlreadyEnabled")
+    info = load_package(
+        pkg,
+        component_overrides={"already-enabled": True},
+    )
     assert info.ok
-    assert info.enabled_components == []
+    assert info.enabled_components == ["already-enabled"]
     assert "_PkgWorkflowRequired" not in _NODE_REGISTRY
+    assert "_PkgAlreadyEnabled" in _NODE_REGISTRY
 
     workflow = {
         "kind": "blacknode.workflow",
@@ -151,10 +160,21 @@ def test_workflow_requirement_transiently_enables_optional_component(tmp_path):
         "edges": [],
     }
 
+    already_enabled_node = _NODE_REGISTRY["_PkgAlreadyEnabled"]
+    assert validate_workflow(workflow).ok
+    assert "_PkgWorkflowRequired" not in _NODE_REGISTRY
+    assert _NODE_REGISTRY["_PkgAlreadyEnabled"] is already_enabled_node
+    assert _PACKAGE_REGISTRY["bn-workflow-required"].enabled_components == [
+        "already-enabled",
+    ]
+
     requirement_report = load_workflow_requirements(workflow)
     assert not requirement_report["unavailable"]
     assert "_PkgWorkflowRequired" in _NODE_REGISTRY
-    assert validate_workflow(workflow).ok
+    assert "_PkgAlreadyEnabled" in _NODE_REGISTRY
+    required_node = _NODE_REGISTRY["_PkgWorkflowRequired"]
+    assert not load_workflow_requirements(workflow)["unavailable"]
+    assert _NODE_REGISTRY["_PkgWorkflowRequired"] is required_node
     assert not (tmp_path / ".blacknode-components.json").exists()
 
 


### PR DESCRIPTION
## Summary

- Validate workflows inside a temporary package-requirement scope.
- Restore node, module, and package registries after validation.
- Keep explicit requirement loading persistent only when a workflow is built for execution.
- Preserve already-enabled components and avoid unnecessary package reloads.

## Root cause

The first optional-component validator fix reloaded entire packages and left the new module objects active. That invalidated existing runtime module references and could drop other transiently enabled components during package test collection.

## Impact

Validation can inspect opt-in component schemas without changing the active runtime package state. Workflow execution still activates declared requirements before building the graph.

## Validation

- 647 core tests passed, 8 skipped, 48 subtests passed
- 27 focused package-loader tests passed
- Motion: 57 passed
- Dataset: 53 passed
- Isaac: 5 passed
- Robot: 100 passed, 2 skipped
- Skills: 34 passed
- Training: 9 passed