### PR TITLE
Support settled v1 package contracts

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -379,6 +379,26 @@ requires = [
 ]
 ```
 
+Set `internal = true` on an implementation component that participates in
+dependency resolution but should not appear as a user-selectable package
+feature. Public dependents declare it normally under `dependencies.requires`;
+enabling the public component activates the internal dependency automatically.
+
+Compatibility component names use `aliases` plus explicit deprecation
+metadata:
+
+```toml
+[components.arm]
+aliases = ["joint-control"]
+deprecated-aliases = {
+  joint-control = { replacement = "arm", removal-version = "1.0.0" }
+}
+```
+
+Selecting a deprecated alias emits a warning containing the replacement and
+planned removal version. New manifests, templates, and documentation use the
+canonical component name.
+
 Blacknode preflights the complete graph before changing activation state. It
 installs missing official packages, safely fast-forwards a clean behind-only
 checkout when that can satisfy a version requirement, enables dependencies

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -1,6 +1,6 @@
 """Blacknode editor backend — FastAPI server the React editor talks to."""
 from __future__ import annotations
-import asyncio, uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex, hashlib
+import asyncio, uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex, hashlib, math
 import urllib.error, urllib.parse, urllib.request
 from datetime import datetime
 from pathlib import Path
@@ -7617,6 +7617,57 @@ def _deployment_aware_device_status(device_id: str) -> dict[str, Any]:
     return status
 
 
+def _monitor_payload_from_device_state(payload: dict[str, Any]) -> dict[str, Any]:
+    """Convert canonical Blacknode robot state into the editor view model."""
+    if payload.get("kind") != "blacknode.device-state":
+        return payload
+    joint_state = payload.get("joint_state")
+    joint_state = joint_state if isinstance(joint_state, dict) else {}
+    positions = dict(joint_state.get("positions") or {})
+    velocities = dict(joint_state.get("velocities") or {})
+    limits = dict(joint_state.get("limits") or {})
+    position_unit = str(joint_state.get("position_unit") or "radian")
+    velocity_unit = str(joint_state.get("velocity_unit") or "radian/s")
+    to_display = math.degrees if position_unit == "radian" else float
+    velocity_to_display = (
+        math.degrees if velocity_unit == "radian/s" else float
+    )
+    joints = []
+    for name, raw_position in positions.items():
+        try:
+            position = to_display(float(raw_position))
+            velocity = velocity_to_display(float(velocities.get(name, 0.0)))
+        except (TypeError, ValueError):
+            continue
+        item = {
+            "name": str(name),
+            "position": position,
+            "velocity": velocity,
+        }
+        raw_limits = limits.get(name)
+        if isinstance(raw_limits, dict):
+            try:
+                item["lower_limit"] = to_display(float(raw_limits["lower"]))
+                item["upper_limit"] = to_display(float(raw_limits["upper"]))
+            except (KeyError, TypeError, ValueError):
+                pass
+        joints.append(item)
+    return {
+        "connected": bool(payload.get("connected")),
+        "armed": bool(payload.get("armed")),
+        "torque_enabled": payload.get("torque_enabled"),
+        "position_unit": "degree" if position_unit == "radian" else position_unit,
+        "velocity_unit": (
+            "degree/s" if velocity_unit == "radian/s" else velocity_unit
+        ),
+        "joints": joints,
+        "error": str(payload.get("error") or ""),
+        "faults": list(payload.get("faults") or []),
+        "temperatures_c": dict(payload.get("temperatures_c") or {}),
+        "voltage_v": payload.get("voltage_v"),
+    }
+
+
 def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
     """Return one normalized robot-state sample from the current bus owner."""
     device = _device_registry.get_public(device_id)
@@ -7661,6 +7712,11 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
             }
         payload = telemetry.get("payload")
         available = bool(telemetry.get("available") and isinstance(payload, dict))
+        monitor_payload = (
+            _monitor_payload_from_device_state(payload)
+            if available
+            else None
+        )
         return {
             "type": "robot_telemetry",
             "robot_id": device_id,
@@ -7674,7 +7730,7 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
             "sent_at": str(telemetry.get("sent_at") or ""),
             "received_at": str(telemetry.get("received_at") or now),
             "age_seconds": telemetry.get("age_seconds"),
-            "payload": payload if available else None,
+            "payload": monitor_payload,
             "message": str(
                 telemetry.get("message")
                 or (

--- a/editor/src/components/PackagesPanel.tsx
+++ b/editor/src/components/PackagesPanel.tsx
@@ -299,7 +299,8 @@ export default function PackagesPanel() {
         const installing = installingName === pkg.name
         const layer = packageLayer(pkg)
         const startsLayer = index === 0 || packageLayer(availablePackages[index - 1]) !== layer
-        const componentCount = Object.keys(pkg.components ?? {}).length
+        const componentCount = Object.values(pkg.components ?? {})
+          .filter(component => !component.internal).length
         const identity = packageIdentity(pkg)
         return (
           <Fragment key={pkg.name}>
@@ -366,6 +367,7 @@ export default function PackagesPanel() {
         const layer = packageLayer(pkg)
         const startsLayer = index === 0 || packageLayer(installedPackages[index - 1]) !== layer
         const componentEntries = Object.values(pkg.components ?? {})
+          .filter(component => !component.internal)
         const hasWarnings = (pkg.warnings?.length ?? 0) > 0
         const hasMissingNodes = (pkg.missing_node_types?.length ?? 0) > 0
         const prereqsMet = pkg.ok && !hasWarnings && !hasMissingNodes

--- a/editor/src/types.ts
+++ b/editor/src/types.ts
@@ -99,6 +99,12 @@ export interface BnPackageComponent {
   name: string
   description: string
   default: boolean
+  internal?: boolean
+  aliases?: string[]
+  deprecated_aliases?: Record<string, {
+    replacement: string
+    removal_version: string
+  }>
   capabilities: string[]
   node_types?: string[]
   node_paths?: string[]

--- a/python/blacknode/contracts.py
+++ b/python/blacknode/contracts.py
@@ -21,6 +21,7 @@ one to live yet.
 from __future__ import annotations
 
 import time
+import warnings
 from typing import Any
 
 # --- Part 1: already shipping elsewhere -------------------------------------
@@ -39,6 +40,9 @@ SHIPPING_KINDS: dict[str, str] = {
     "blacknode.replay-stream": "blacknode-dataset",
     "blacknode.sample-stream": "blacknode-ros2",
     "blacknode.latest-value-stream": "blacknode-perception",
+    "blacknode.joint-state": "blacknode-robot",
+    "blacknode.device-state": "blacknode-robot",
+    "blacknode.fault-state": "blacknode-robot",
     # Episodes / datasets
     "blacknode.episode": "blacknode-dataset",
     "blacknode.episode-journal": "blacknode-dataset",
@@ -94,7 +98,6 @@ NEW_KINDS: dict[str, str] = {
     "blacknode.point-cloud-stream": "point cloud handle",
     "blacknode.transform-stream": "frame-to-frame transform, static or dynamic",
     "blacknode.detection-stream": "a batch of detection2d/detection3d results",
-    "blacknode.robot-state-stream": "joint positions/velocities and armed state",
     # Planning / execution
     "blacknode.pose": "frame-qualified position and orientation",
     "blacknode.map": "map artifact, resolution, origin, frame, and provenance",
@@ -331,13 +334,48 @@ def detection_stream(frame: str, *, sequence: int = 0, detections: list[dict[str
 
 def robot_state_stream(
     *, sequence: int = 0, joint_positions: dict[str, float] | None = None,
-    joint_velocities: dict[str, float] | None = None, units: str = "radians", armed: bool = False,
+    joint_velocities: dict[str, float] | None = None, units: str = "radians",
+    armed: bool = False, device_id: str = "",
 ) -> dict[str, Any]:
+    """Compatibility adapter for the canonical blacknode-robot state model."""
+    warnings.warn(
+        "blacknode.contracts.robot_state_stream() is deprecated; construct "
+        "blacknode_robot.devices.DeviceState instead. Planned removal: 1.0.0.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    if units not in {"radians", "radian"}:
+        raise ValueError("canonical joint state uses radians")
+    now = time.time()
     return {
-        "kind": "blacknode.robot-state-stream", "schema_version": 1,
-        **_stream_fields("base_link", sequence),
-        "joint_positions": dict(joint_positions or {}), "joint_velocities": dict(joint_velocities or {}),
-        "units": units, "armed": armed,
+        "kind": "blacknode.device-state",
+        "schema_version": 1,
+        "device_id": device_id,
+        "connected": True,
+        "armed": armed,
+        "torque_enabled": None,
+        "capabilities": [],
+        "joint_state": {
+            "kind": "blacknode.joint-state",
+            "schema_version": 1,
+            "source_time": now,
+            "receive_time": now,
+            "frame_id": "base_link",
+            "position_unit": "radian",
+            "velocity_unit": "radian/s",
+            "effort_unit": "newton-metre",
+            "positions": dict(joint_positions or {}),
+            "velocities": dict(joint_velocities or {}),
+            "efforts": {},
+            "limits": {},
+            "sequence": sequence,
+        },
+        "faults": [],
+        "temperatures_c": {},
+        "voltage_v": None,
+        "values": {},
+        "error": "",
+        "updated_at": now,
     }
 
 

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -9,14 +9,14 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "name": "blacknode-runtime",
             "layer": "runtime",
             "components": {
-                "service": {
-                    "name": "service",
+                "deployment": {
+                    "name": "deployment",
                     "default": True,
                     "node_types": []
                 }
             },
             "git_url": "https://github.com/temiroff/blacknode-runtime.git",
-            "description": "Authenticated component loading, dependency resolution, workflow execution, supervision, configuration, logs, and rollback.",
+            "description": "Authenticated remote deployment, rollout, rollback, logs, and service supervision.",
             "node_types": []
         },
         "blacknode-skills": {
@@ -30,8 +30,23 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "follow": {
                     "name": "follow",
+                    "aliases": ["follow-person"],
                     "default": False,
                     "node_types": [],
+                    "dependencies": {
+                        "requires": [
+                            {
+                                "package": "blacknode-motion",
+                                "component": "arm",
+                                "version": ">=0.6.0,<1.0.0"
+                            },
+                            {
+                                "package": "blacknode-ros2",
+                                "component": "core",
+                                "version": ">=0.5.6,<1.0.0"
+                            }
+                        ]
+                    },
                     "adapters": {
                         "ros2": {
                             "name": "ros2",
@@ -82,6 +97,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "components": {
                 "executive": {
                     "name": "executive",
+                    "aliases": ["planner"],
                     "default": False,
                     "node_types": []
                 },
@@ -113,15 +129,29 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "components": {
                 "core": {
                     "name": "core",
-                    "default": False,
+                    "default": True,
+                    "internal": True,
                     "node_types": []
                 },
                 "arm": {
                     "name": "arm",
+                    "aliases": ["joint-control"],
                     "default": True,
                     "node_types": [
                         "JointMotionProfile"
                     ],
+                    "dependencies": {
+                        "requires": [
+                            {
+                                "component": "core",
+                                "version": ">=0.6.0,<1.0.0"
+                            },
+                            {
+                                "component": "safety",
+                                "version": ">=0.6.0,<1.0.0"
+                            }
+                        ]
+                    },
                     "adapters": {
                         "ros2": {
                             "name": "ros2",
@@ -147,8 +177,21 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "base": {
                     "name": "base",
+                    "aliases": ["mobile-base"],
                     "default": False,
                     "node_types": [],
+                    "dependencies": {
+                        "requires": [
+                            {
+                                "component": "core",
+                                "version": ">=0.6.0,<1.0.0"
+                            },
+                            {
+                                "component": "safety",
+                                "version": ">=0.6.0,<1.0.0"
+                            }
+                        ]
+                    },
                     "adapters": {
                         "ros2": {
                             "name": "ros2",
@@ -176,6 +219,18 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "name": "policy",
                     "default": True,
                     "node_types": [],
+                    "dependencies": {
+                        "requires": [
+                            {
+                                "component": "core",
+                                "version": ">=0.6.0,<1.0.0"
+                            },
+                            {
+                                "component": "safety",
+                                "version": ">=0.6.0,<1.0.0"
+                            }
+                        ]
+                    },
                     "adapters": {
                         "ros2": {
                             "name": "ros2",
@@ -198,8 +253,16 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "safety": {
                     "name": "safety",
-                    "default": False,
-                    "node_types": []
+                    "default": True,
+                    "node_types": [],
+                    "dependencies": {
+                        "requires": [
+                            {
+                                "component": "core",
+                                "version": ">=0.6.0,<1.0.0"
+                            }
+                        ]
+                    }
                 }
             },
             "git_url": "https://github.com/temiroff/blacknode-motion.git",
@@ -240,6 +303,11 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                             ],
                             "dependencies": {
                                 "requires": [
+                                    {
+                                        "package": "blacknode-robot",
+                                        "component": "contracts",
+                                        "version": ">=0.5.0,<1.0.0"
+                                    },
                                     {
                                         "package": "blacknode-ros2",
                                         "component": "rosbridge",

--- a/python/blacknode/packages.py
+++ b/python/blacknode/packages.py
@@ -29,6 +29,7 @@ import sys
 import tomllib
 import traceback
 import types
+import warnings as python_warnings
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -181,15 +182,37 @@ def _package_components(value: Any) -> dict[str, dict[str, Any]]:
         if isinstance(node_paths, str):
             node_paths = [node_paths]
         requirements, requirement_errors = _component_requirements(dependencies.get("requires", []))
+        aliases = [
+            alias
+            for alias in (_component_name(item) for item in config.get("aliases", []))
+            if alias and alias != name
+        ] if isinstance(config.get("aliases", []), list) else []
+        raw_deprecations = config.get("deprecated-aliases", {})
+        deprecated_aliases: dict[str, dict[str, str]] = {}
+        if isinstance(raw_deprecations, Mapping):
+            for raw_alias, raw_deprecation in raw_deprecations.items():
+                alias = _component_name(raw_alias)
+                if alias not in aliases or not isinstance(raw_deprecation, Mapping):
+                    continue
+                deprecated_aliases[alias] = {
+                    "replacement": _component_name(
+                        raw_deprecation.get("replacement")
+                    ) or name,
+                    "removal_version": str(
+                        raw_deprecation.get(
+                            "removal-version",
+                            raw_deprecation.get("removal_version", ""),
+                        )
+                        or ""
+                    ).strip(),
+                }
         components[name] = {
             "name": name,
-            "aliases": [
-                alias
-                for alias in (_component_name(item) for item in config.get("aliases", []))
-                if alias and alias != name
-            ] if isinstance(config.get("aliases", []), list) else [],
+            "aliases": aliases,
+            "deprecated_aliases": deprecated_aliases,
             "description": str(config.get("description") or ""),
             "default": bool(config.get("default", False)),
+            "internal": bool(config.get("internal", False)),
             "capabilities": sorted({
                 str(capability).strip()
                 for capability in capabilities
@@ -302,6 +325,32 @@ def _canonical_component_name(
         if requested in component.get("aliases", []):
             return name
     return requested
+
+
+def _warn_for_deprecated_component_alias(
+    info: PackageInfo,
+    component_name: str,
+    requested_name: str,
+) -> None:
+    """Surface an actionable warning when a compatibility alias is selected."""
+    if requested_name == component_name:
+        return
+    component = info.components.get(component_name, {})
+    deprecation = component.get("deprecated_aliases", {}).get(requested_name)
+    if not isinstance(deprecation, Mapping):
+        return
+    replacement = str(deprecation.get("replacement") or component_name)
+    removal = str(deprecation.get("removal_version") or "").strip()
+    message = (
+        f"Component '{info.name}/{requested_name}' is deprecated; "
+        f"use '{info.name}/{replacement}' instead"
+    )
+    if removal:
+        message += f". The alias is planned for removal in {removal}"
+    message += "."
+    if message not in info.warnings:
+        info.warnings.append(message)
+    python_warnings.warn(message, FutureWarning, stacklevel=3)
 
 
 def _component_state_keys(
@@ -897,7 +946,13 @@ def component_dependency_plan(package_name: str, component_name: str) -> dict[st
     target_component = _component_name(component_name)
     target_info = _PACKAGE_REGISTRY.get(target_package)
     if target_info is not None:
-        target_component = _canonical_component_name(target_info.components, target_component)
+        canonical = _canonical_component_name(
+            target_info.components, target_component
+        )
+        _warn_for_deprecated_component_alias(
+            target_info, canonical, target_component
+        )
+        target_component = canonical
     plan: list[dict[str, Any]] = []
     visited: set[tuple[str, str]] = set()
     visiting: list[tuple[str, str]] = []
@@ -990,7 +1045,13 @@ def component_dependency_install_plan(
     target_component = _component_name(component_name)
     target_info = _PACKAGE_REGISTRY.get(target_package)
     if target_info is not None:
-        target_component = _canonical_component_name(target_info.components, target_component)
+        canonical = _canonical_component_name(
+            target_info.components, target_component
+        )
+        _warn_for_deprecated_component_alias(
+            target_info, canonical, target_component
+        )
+        target_component = canonical
     actions: list[dict[str, Any]] = []
     conflicts: list[str] = []
     visited: set[tuple[str, str, str]] = set()
@@ -1361,13 +1422,15 @@ def _component_package_info(
         raise ValueError(f"No package named '{package_name}' is installed")
     if info.source != "folder" or not info.path:
         raise ValueError("Selective components currently require a folder package")
-    canonical_name = _canonical_component_name(info.components, component_name)
+    requested_name = _component_name(component_name)
+    canonical_name = _canonical_component_name(info.components, requested_name)
     if canonical_name not in info.components:
         raise ValueError(f"Package '{package_name}' has no component '{component_name}'")
     if not info.component_mode:
         raise ValueError(
             f"Package '{package_name}' only publishes component labels; its manifest has not enabled selective loading"
         )
+    _warn_for_deprecated_component_alias(info, canonical_name, requested_name)
     return info, canonical_name
 
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -61,7 +61,6 @@ def _constructors():
         "blacknode.point-cloud-stream": c.point_cloud_stream("camera_depth_frame"),
         "blacknode.transform-stream": c.transform_stream("base_link", "lidar_link"),
         "blacknode.detection-stream": c.detection_stream("camera_rgb_frame", detections=[]),
-        "blacknode.robot-state-stream": c.robot_state_stream(joint_positions={"shoulder": 0.1}),
         "blacknode.map": c.map_artifact("map1", resolution=0.05),
         "blacknode.navigation-goal": c.navigation_goal(target=p),
         "blacknode.navigation-status": c.navigation_status(),
@@ -117,3 +116,14 @@ def test_estop_state_only_timestamps_when_latched():
 def test_robot_capability_status_rejects_unknown_state():
     with pytest.raises(ValueError):
         c.robot_capability_status("camera", state="unknown")
+
+
+def test_legacy_robot_state_factory_adapts_to_canonical_robot_contract():
+    with pytest.warns(FutureWarning, match="Planned removal: 1.0.0"):
+        state = c.robot_state_stream(
+            device_id="arm-01",
+            joint_positions={"shoulder": 0.1},
+        )
+    assert state["kind"] == "blacknode.device-state"
+    assert state["joint_state"]["kind"] == "blacknode.joint-state"
+    assert state["joint_state"]["position_unit"] == "radian"

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -4426,15 +4426,23 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "age_seconds": 0.01,
                 "stale": False,
                 "payload": {
+                    "kind": "blacknode.device-state",
+                    "schema_version": 1,
+                    "device_id": "follower-arm",
                     "connected": True,
+                    "armed": True,
                     "torque_enabled": True,
-                    "position_unit": "degree",
-                    "velocity_unit": "degree/s",
-                    "joints": [{
-                        "name": "gripper",
-                        "position": 8.0,
-                        "velocity": 2.0,
-                    }],
+                    "joint_state": {
+                        "kind": "blacknode.joint-state",
+                        "schema_version": 1,
+                        "position_unit": "radian",
+                        "velocity_unit": "radian/s",
+                        "positions": {"gripper": 0.13962634015954636},
+                        "velocities": {"gripper": 0.03490658503988659},
+                        "efforts": {},
+                        "limits": {},
+                    },
+                    "faults": [],
                 },
             }
             response = self.client.get(f"/devices/{paired['id']}/monitor")

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -89,9 +89,31 @@ def test_core_index_maps_official_node_types_to_git_packages():
     motion = payload["packages"]["blacknode-motion"]
     assert motion["layer"] == "motion"
     assert set(motion["components"]) == {"core", "arm", "base", "policy", "safety"}
+    assert motion["components"]["core"]["default"] is True
+    assert motion["components"]["core"]["internal"] is True
     assert motion["components"]["arm"]["node_types"] == ["JointMotionProfile"]
-    assert motion["components"]["arm"].get("aliases", []) == []
-    assert motion["components"]["base"].get("aliases", []) == []
+    assert motion["components"]["arm"]["aliases"] == ["joint-control"]
+    assert motion["components"]["base"]["aliases"] == ["mobile-base"]
+    for component_name in {"arm", "base", "policy"}:
+        assert motion["components"][component_name]["dependencies"] == {
+            "requires": [
+                {
+                    "component": "core",
+                    "version": ">=0.6.0,<1.0.0",
+                },
+                {
+                    "component": "safety",
+                    "version": ">=0.6.0,<1.0.0",
+                },
+            ],
+        }
+    assert payload["packages"]["blacknode-agent"]["components"]["executive"]["aliases"] == [
+        "planner"
+    ]
+    assert payload["packages"]["blacknode-skills"]["components"]["follow"]["aliases"] == [
+        "follow-person"
+    ]
+    assert set(payload["packages"]["blacknode-runtime"]["components"]) == {"deployment"}
     assert "JointMotionProfile" not in motion["components"]["arm"]["adapters"]["ros2"]["node_types"]
     assert payload["packages"]["blacknode-dataset"]["layer"] == "learning"
     dataset = payload["packages"]["blacknode-dataset"]["components"]

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -310,6 +310,7 @@ def test_component_alias_supports_third_party_package_migrations(tmp_path):
         component_metadata='''
         [components.follow]
         aliases = ["legacy-follow"]
+        deprecated-aliases = { legacy-follow = { replacement = "follow", removal-version = "1.0.0" } }
         default = false
         nodes = ["components/follow/nodes"]
         ''',
@@ -328,6 +329,12 @@ def test_component_alias_supports_third_party_package_migrations(tmp_path):
 
     assert info.ok
     assert info.components["follow"]["aliases"] == ["legacy-follow"]
+    assert info.components["follow"]["deprecated_aliases"] == {
+        "legacy-follow": {
+            "replacement": "follow",
+            "removal_version": "1.0.0",
+        },
+    }
     assert info.enabled_components == ["follow"]
     assert "_PkgFollowAlias" in _NODE_REGISTRY
     assert "blacknode.pkg.bn_component_alias.follow" in sys.modules
@@ -335,18 +342,48 @@ def test_component_alias_supports_third_party_package_migrations(tmp_path):
         sys.modules["blacknode.pkg.bn_component_alias.legacy_follow"]
         is sys.modules["blacknode.pkg.bn_component_alias.follow"]
     )
-    assert component_dependency_plan(
-        "bn-component-alias", "legacy-follow"
-    )["target"]["component"] == "follow"
+    with pytest.warns(FutureWarning, match="planned for removal in 1.0.0"):
+        assert component_dependency_plan(
+            "bn-component-alias", "legacy-follow"
+        )["target"]["component"] == "follow"
 
-    disabled = set_component_enabled(
-        "bn-component-alias", "legacy-follow", False
-    )
+    with pytest.warns(FutureWarning, match="use 'bn-component-alias/follow'"):
+        disabled = set_component_enabled(
+            "bn-component-alias", "legacy-follow", False
+        )
     assert disabled.enabled_components == []
     state = json.loads(
         (tmp_path / ".blacknode-components.json").read_text(encoding="utf-8")
     )
     assert state["packages"]["bn-component-alias"]["follow"] is False
+
+
+def test_internal_component_loads_but_is_not_user_facing(tmp_path):
+    pkg = _write_package(
+        tmp_path,
+        name="bn-internal-component",
+        component_metadata='''
+        [components.core]
+        internal = true
+        default = true
+        nodes = ["components/core/nodes"]
+
+        [components.arm]
+        default = true
+
+        [components.arm.dependencies]
+        requires = [{ component = "core" }]
+        ''',
+    )
+    _write_component_node(pkg, "core", "_PkgInternalCore")
+
+    info = load_package(pkg)
+
+    assert info.ok
+    assert info.components["core"]["internal"] is True
+    assert info.components["arm"]["internal"] is False
+    assert info.enabled_components == ["core", "arm"]
+    assert "_PkgInternalCore" in _NODE_REGISTRY
 
 
 def test_component_reset_restores_manifest_default(tmp_path):


### PR DESCRIPTION
## What changed
- add internal component and versioned deprecated-alias metadata
- register canonical JointState, DeviceState, and FaultState contract kinds
- update the package catalog and editor package UI for the settled v1 packages
- adapt device monitoring to canonical state payloads

## Why
This makes the core package/runtime boundary consistent with the settled v1 robot, motion, driver, and deployment architecture.

## Validation
- `python -m pytest tests -q` (651 passed, 8 skipped, 48 subtests)
- `npm run build` in `editor`
- `cargo test`