### PR TITLE
Clarify device updates and harden managed installs

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -987,7 +987,7 @@ rm -rf -- "$target_private"
 mv -- "$temporary_private" "$target_private"
 (
   cd "$target"
-  BLACKNODE_HARDWARE_INSTANCE="" ./install-service.sh --all
+  BLACKNODE_HARDWARE_INSTANCE="" bash ./install-service.sh --all
 )
 for unit in "${legacy_units[@]}"; do
   directory="$(
@@ -1113,7 +1113,7 @@ fi
   echo "The organized Hardware package is missing or invalid: $target" >&2
   exit 4
 }
-[[ -x "$target/.venv/bin/python" && -x "$target/configure.sh" ]] || {
+[[ -x "$target/.venv/bin/python" && -f "$target/configure.sh" ]] || {
   echo "The organized Hardware environment is not set up: $target" >&2
   exit 4
 }
@@ -1158,7 +1158,7 @@ fi
   cd "$target"
   BLACKNODE_HARDWARE_INSTANCE="$service_instance" \
     BLACKNODE_RUNTIME_PORT="$runtime_port" \
-    ./configure.sh --all --install
+    bash ./configure.sh --all --install
 )
 
 for unit in "${orphan_units[@]}"; do
@@ -1353,7 +1353,7 @@ fi
 progress 50 "Setting up the Robot Hardware environment"
 (
   cd "$hardware_dir"
-  BLACKNODE_HARDWARE_INSTANCE="$service_instance" ./setup_ubuntu.sh
+  BLACKNODE_HARDWARE_INSTANCE="$service_instance" bash ./setup_ubuntu.sh
 )
 progress 88 "Recording the complete device stack"
 python3 - "$stack_root/install.json" "$instance" "$runtime_dir" "$hardware_dir" <<'PY'
@@ -1778,10 +1778,10 @@ progress 58 "Creating the Python environment"
 BLACKNODE_AUTH_TOKEN_FILE="$token_file" \
 BLACKNODE_RUNTIME_PORT="$runtime_port" \
 BLACKNODE_RUNTIME_INSTANCE="$service_instance" \
-./setup_ubuntu.sh
+bash ./setup_ubuntu.sh
 if [[ -n "$service_instance" ]]; then
   progress 78 "Configuring the independent instance"
-  BLACKNODE_RUNTIME_INSTANCE="$service_instance" ./configure.sh \
+  BLACKNODE_RUNTIME_INSTANCE="$service_instance" bash ./configure.sh \
     --device-id "$(hostname)-$service_instance"
 fi
 if [[ "$complete_stack" == true && ! -d "$hardware_dir" ]]; then
@@ -1796,7 +1796,7 @@ if [[ "$complete_stack" == true && ! -d "$hardware_dir" ]]; then
   fi
   (
     cd "$hardware_dir"
-    BLACKNODE_HARDWARE_INSTANCE="$service_instance" ./setup_ubuntu.sh
+    BLACKNODE_HARDWARE_INSTANCE="$service_instance" bash ./setup_ubuntu.sh
   )
 elif [[ "$complete_stack" == true ]]; then
   [[ -d "$hardware_dir/.git" && -f "$hardware_dir/pyproject.toml" ]] || {
@@ -1813,7 +1813,7 @@ rm -f -- "$port_file"
 port_file=""
 BLACKNODE_RUNTIME_PORT="$runtime_port" \
 BLACKNODE_RUNTIME_INSTANCE="$service_instance" \
-./install-service.sh
+bash ./install-service.sh
 if [[ "${#active_sibling_services[@]}" -gt 0 ]]; then
   progress 92 "Verifying existing runtimes and robot services"
   for sibling_service in "${active_sibling_services[@]}"; do
@@ -2205,7 +2205,7 @@ stop_verified_manual_hardware() {
 }
 
 install_persistent_hardware_services() {
-  [[ -x "$hardware_repo/install-service.sh" ]] || {
+  [[ -f "$hardware_repo/install-service.sh" ]] || {
     echo "Repair Hardware requires $hardware_repo/install-service.sh." >&2
     return 1
   }
@@ -2260,12 +2260,12 @@ PY
   if [[ -f "$hardware_repo/.blacknode-hardware/devices.json" ]]; then
     (
       cd "$hardware_repo"
-      ./install-service.sh --all
+      bash ./install-service.sh --all
     )
   elif [[ "${#hardware_ports[@]}" -eq 1 ]]; then
     (
       cd "$hardware_repo"
-      BLACKNODE_HARDWARE_PORT="${hardware_ports[0]}" ./install-service.sh
+      BLACKNODE_HARDWARE_PORT="${hardware_ports[0]}" bash ./install-service.sh
     )
   else
     echo "Multiple Hardware ports require a saved multi-robot configuration. Run ./configure.sh --all before Repair Hardware." >&2
@@ -2760,6 +2760,7 @@ def inspect(kind, repository, service, port, directory):
         "latest": {{"version": "unknown", "commit": ""}},
         "update_available": False,
         "can_update": False,
+        "migration_required": False,
         "dirty": False,
         "state": command(["systemctl", "is-active", service]).stdout.strip() or "unknown",
         "error": "",
@@ -2770,13 +2771,27 @@ def inspect(kind, repository, service, port, directory):
         origin = command(["git", "-C", str(directory), "remote", "get-url", "origin"])
         origin_url = origin.stdout.strip()
         normalized = origin_url.lower().removesuffix(".git").rstrip("/")
-        if not re.search(
+        trusted_origin = bool(re.search(
             rf"(?:github\.com[:/])temiroff/{{re.escape(repository)}}$",
             normalized,
-        ):
+        ))
+        legacy_hardware_origin = bool(
+            repository == "blacknode-robot"
+            and re.search(
+                r"(?:github\.com[:/])temiroff/blacknode-hardware$",
+                normalized,
+            )
+        )
+        if not trusted_origin and not legacy_hardware_origin:
             raise RuntimeError(
                 f"origin is not the trusted temiroff/{{repository}} repository"
             )
+        component["migration_required"] = legacy_hardware_origin
+        latest_origin_url = (
+            "https://github.com/temiroff/blacknode-robot.git"
+            if legacy_hardware_origin
+            else origin_url
+        )
         current = command(["git", "-C", str(directory), "rev-parse", "HEAD"])
         if current.returncode:
             raise RuntimeError(current.stderr.strip() or "could not read installed commit")
@@ -2785,24 +2800,48 @@ def inspect(kind, repository, service, port, directory):
             "git", "-C", str(directory), "status", "--porcelain", "--untracked-files=normal"
         ])
         component["dirty"] = bool(dirty.stdout.strip())
-        branch = command([
-            "git", "-C", str(directory), "rev-parse", "--abbrev-ref", "HEAD",
-        ]).stdout.strip()
-        upstream = command([
-            "git", "-C", str(directory), "config", "--get",
-            f"branch.{{branch}}.merge",
-        ])
-        upstream_ref = upstream.stdout.strip()
-        if not upstream_ref.startswith("refs/heads/"):
-            raise RuntimeError("the installed branch has no upstream configured")
-        latest = command(["git", "ls-remote", origin_url, upstream_ref], timeout=45)
+        if legacy_hardware_origin:
+            remote_head = command(
+                ["git", "ls-remote", "--symref", latest_origin_url, "HEAD"],
+                timeout=45,
+            )
+            upstream_ref = next(
+                (
+                    line.split()[1]
+                    for line in remote_head.stdout.splitlines()
+                    if line.startswith("ref:") and line.endswith("\tHEAD")
+                ),
+                "",
+            )
+            if remote_head.returncode or not upstream_ref.startswith("refs/heads/"):
+                raise RuntimeError(
+                    remote_head.stderr.strip()
+                    or "could not resolve the blacknode-robot default branch"
+                )
+        else:
+            branch = command([
+                "git", "-C", str(directory), "rev-parse", "--abbrev-ref", "HEAD",
+            ]).stdout.strip()
+            upstream = command([
+                "git", "-C", str(directory), "config", "--get",
+                f"branch.{{branch}}.merge",
+            ])
+            upstream_ref = upstream.stdout.strip()
+            if not upstream_ref.startswith("refs/heads/"):
+                raise RuntimeError("the installed branch has no upstream configured")
+        latest = command(
+            ["git", "ls-remote", latest_origin_url, upstream_ref],
+            timeout=45,
+        )
         if latest.returncode or not latest.stdout.strip():
             raise RuntimeError(
                 latest.stderr.strip() or "could not read the latest upstream commit"
             )
         latest_commit = latest.stdout.split()[0]
         component["latest"]["commit"] = latest_commit[:12]
-        component["update_available"] = current.stdout.strip() != latest_commit
+        component["update_available"] = (
+            legacy_hardware_origin or current.stdout.strip() != latest_commit
+        )
         if not component["update_available"]:
             component["latest"]["version"] = component["installed"]["version"]
         else:
@@ -2824,8 +2863,16 @@ def inspect(kind, repository, service, port, directory):
                         )
                 except Exception:
                     pass
-        component["can_update"] = not component["dirty"]
-        if component["dirty"]:
+        component["can_update"] = (
+            not component["dirty"] and not legacy_hardware_origin
+        )
+        if legacy_hardware_origin:
+            component["error"] = (
+                "Migration required: this service uses the legacy "
+                "temiroff/blacknode-hardware repository. Replace it with "
+                "temiroff/blacknode-robot before updating."
+            )
+        elif component["dirty"]:
             component["error"] = (
                 "Local source changes must be committed, stashed, or removed before update."
             )
@@ -2869,6 +2916,7 @@ for target in request["hardware_targets"]:
             "latest": {{"version": "unknown", "commit": ""}},
             "update_available": False,
             "can_update": False,
+            "migration_required": False,
             "dirty": False,
             "state": "unknown",
             "error": str(exc),

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -575,6 +575,7 @@ export interface ManagedServiceUpdateCheckResult {
       reported_version?: string
       update_available: boolean
       can_update: boolean
+      migration_required?: boolean
       dirty: boolean
       state: string
       error: string

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -863,6 +863,24 @@ export default function DevicesPanel({
   )
     ? `v${checkedHardwareInstallation.latest.version}`
     : null
+  const runtimeLatestVersionError = updateCheckReport
+    ? checkedRuntimeInstallation?.error
+      || (!runtimeLatestVersion && checkedRuntimeComponents.length === 0
+        ? 'The Runtime package was not included in the update check.'
+        : !runtimeLatestVersion
+          ? 'The Runtime repository was found, but its latest package version could not be read.'
+          : '')
+    : ''
+  const hardwareLatestVersionError = updateCheckReport
+    ? checkedHardwareInstallation?.error
+      || (!hardwareLatestVersion && checkedHardwareComponents.length === 0
+        ? selectedDevice?.robots.length
+          ? 'No attached Robot service was included in the update check.'
+          : 'Attach a robot service to this device before checking the Robot package.'
+        : !hardwareLatestVersion
+          ? 'The Robot repository was found, but its latest package version could not be read.'
+          : '')
+    : ''
   const remoteHardwareServices = selectedDevice?.robots
     .map(robot => `${robot.name}: ${robot.base_url}`)
     .join('\n') || ''
@@ -3544,6 +3562,11 @@ export default function DevicesPanel({
                   state={selectedRuntimePackageState}
                   currentVersion={runtimeCurrentVersion}
                   latestVersion={runtimeLatestVersion}
+                  latestChecked={Boolean(updateCheckReport)}
+                  latestError={runtimeLatestVersionError}
+                  migrationRequired={Boolean(
+                    checkedRuntimeInstallation?.migration_required,
+                  )}
                   installed={selectedDeviceState?.runtime?.installed !== false}
                   updateAvailable={checkedRuntimeComponents.some(
                     component => component.update_available,
@@ -3594,6 +3617,11 @@ export default function DevicesPanel({
                     state={selectedHardwarePackageState}
                     currentVersion={hardwareCurrentVersion}
                     latestVersion={hardwareLatestVersion}
+                    latestChecked={Boolean(updateCheckReport)}
+                    latestError={hardwareLatestVersionError}
+                    migrationRequired={Boolean(
+                      checkedHardwareInstallation?.migration_required,
+                    )}
                     installed={
                       selectedDeviceManagedLocally
                         ? selectedDeviceState?.runtime?.hardware?.installed !== false
@@ -4877,6 +4905,9 @@ function SoftwarePackageSummaryCard({
   state,
   currentVersion,
   latestVersion,
+  latestChecked,
+  latestError,
+  migrationRequired,
   installed,
   updateAvailable,
   busy,
@@ -4896,6 +4927,9 @@ function SoftwarePackageSummaryCard({
   state: string
   currentVersion: string
   latestVersion: string | null
+  latestChecked: boolean
+  latestError?: string
+  migrationRequired?: boolean
   installed: boolean
   updateAvailable: boolean
   busy: boolean
@@ -4944,9 +4978,24 @@ function SoftwarePackageSummaryCard({
               <small>Current</small>
               <b>{currentVersion}</b>
             </span>
-            <span className={latestVersion ? 'is-latest' : 'is-latest is-not-checked'}>
+            <span
+              className={`is-latest${
+                latestVersion
+                  ? migrationRequired
+                    ? ' is-migration-required'
+                    : updateAvailable
+                    ? ' is-update-available'
+                    : ' is-current-release'
+                  : latestChecked
+                    ? ' is-check-failed'
+                    : ' is-not-checked'
+              }`}
+              title={latestError || undefined}
+            >
               <small>Latest</small>
-              <b>{latestVersion ?? 'Not checked'}</b>
+              <b>
+                {latestVersion ?? (latestChecked ? 'Unavailable' : 'Not checked')}
+              </b>
             </span>
           </div>
         </div>
@@ -4958,7 +5007,23 @@ function SoftwarePackageSummaryCard({
       <code title={path}>{path}</code>
       {detail && <small>{detail}</small>}
       <div className="bn-local-package-version-action">
-        {!latestVersion ? (
+        {latestError ? (
+          <div className="bn-local-package-version-unavailable" role="alert">
+            <strong>
+              {migrationRequired ? 'Package migration required' : 'Latest version unavailable'}
+            </strong>
+            <span>{latestError}</span>
+            {!migrationRequired && (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onCheckLatest}
+              >
+                {busy ? 'Checking…' : 'Retry check'}
+              </button>
+            )}
+          </div>
+        ) : !latestVersion ? (
           <button
             type="button"
             className="bn-local-package-check-latest"

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -1251,6 +1251,26 @@ html[data-theme="light"] .bn-logo-image-light {
   color: var(--warn);
 }
 
+.bn-local-package-versions .is-latest.is-check-failed {
+  border-color: color-mix(in srgb, var(--err) 55%, var(--line2));
+  background: color-mix(in srgb, var(--err) 10%, transparent);
+  color: var(--err);
+}
+
+.bn-local-package-versions .is-latest.is-current-release {
+  color: var(--ok);
+}
+
+.bn-local-package-versions .is-latest.is-update-available {
+  color: var(--accent);
+}
+
+.bn-local-package-versions .is-latest.is-migration-required {
+  border-color: color-mix(in srgb, var(--warn) 55%, var(--line2));
+  background: color-mix(in srgb, var(--warn) 10%, transparent);
+  color: var(--warn);
+}
+
 .bn-local-package-version-action {
   display: flex;
   margin-top: auto;
@@ -1290,6 +1310,39 @@ html[data-theme="light"] .bn-logo-image-light {
   color: var(--ok);
   font-size: 11px;
   font-weight: 700;
+}
+
+.bn-local-package-version-unavailable {
+  display: grid;
+  width: 100%;
+  gap: 3px;
+  padding: 7px 8px;
+  border: 1px solid color-mix(in srgb, var(--err) 45%, var(--line2));
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--err) 8%, transparent);
+  color: var(--err);
+  font-size: 11px;
+}
+
+.bn-local-package-version-unavailable strong {
+  font-size: 11px;
+}
+
+.bn-local-package-version-unavailable span {
+  color: var(--tx2);
+  line-height: 1.35;
+}
+
+.bn-local-package-version-unavailable button {
+  justify-self: start;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--err);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  text-decoration: underline;
 }
 
 .bn-local-package-state {
@@ -6731,6 +6784,30 @@ html[data-ui-test="refined"] .bn-local-package-versions small {
   text-transform: none;
 }
 
+html[data-ui-test="refined"] .bn-local-package-versions > .is-current {
+  color: var(--ok);
+}
+
+html[data-ui-test="refined"] .bn-local-package-versions > .is-latest.is-current-release {
+  color: var(--ok);
+}
+
+html[data-ui-test="refined"] .bn-local-package-versions > .is-latest.is-update-available {
+  color: var(--accent);
+}
+
+html[data-ui-test="refined"] .bn-local-package-versions > .is-latest.is-migration-required {
+  color: var(--warn);
+}
+
+html[data-ui-test="refined"] .bn-local-package-versions > .is-latest.is-not-checked {
+  color: var(--warn);
+}
+
+html[data-ui-test="refined"] .bn-local-package-versions > .is-latest.is-check-failed {
+  color: var(--err);
+}
+
 html[data-ui-test="refined"] .bn-local-package-state {
   color: var(--tx3);
   font-family: var(--font-ui);
@@ -6746,7 +6823,8 @@ html[data-ui-test="refined"] .bn-local-package-version-action {
 
 html[data-ui-test="refined"] .bn-local-package-check-latest,
 html[data-ui-test="refined"] .bn-local-package-update-available,
-html[data-ui-test="refined"] .bn-local-package-version-current {
+html[data-ui-test="refined"] .bn-local-package-version-current,
+html[data-ui-test="refined"] .bn-local-package-version-unavailable {
   width: auto;
   border: 0;
   border-radius: 7px;

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -750,7 +750,7 @@ class EditorDeviceApiTests(unittest.TestCase):
             uploaded[0],
         )
         self.assertIn(
-            'BLACKNODE_HARDWARE_INSTANCE="$service_instance" ./setup_ubuntu.sh',
+            'BLACKNODE_HARDWARE_INSTANCE="$service_instance" bash ./setup_ubuntu.sh',
             uploaded[0],
         )
         remote_python = uploaded[0].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
@@ -813,7 +813,7 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn('legacy="$HOME/blacknode-hardware"', uploaded[0])
         self.assertIn('cp -a -- "$legacy_private" "$temporary_private"', uploaded[0])
         self.assertIn(
-            'BLACKNODE_HARDWARE_INSTANCE="" ./install-service.sh --all',
+            'BLACKNODE_HARDWARE_INSTANCE="" bash ./install-service.sh --all',
             uploaded[0],
         )
         self.assertIn(
@@ -1247,6 +1247,10 @@ class EditorDeviceApiTests(unittest.TestCase):
 
         self.assertTrue(result["components"][0]["update_available"])
         self.assertIn('"git", "ls-remote"', commands[0])
+        self.assertIn('"ls-remote", "--symref"', commands[0])
+        self.assertIn("temiroff/blacknode-hardware", commands[0])
+        self.assertIn('"migration_required": False', commands[0])
+        self.assertIn("Migration required:", commands[0])
         self.assertIn("raw.githubusercontent.com", commands[0])
         self.assertIn('"status", "--porcelain"', commands[0])
         self.assertNotIn('"fetch"', commands[0])


### PR DESCRIPTION
## What changed

- add clear Current/Latest color states in the Devices software cards
- distinguish unchecked, unavailable, current, update-available, and migration-required states
- resolve the target `blacknode-robot` release when a managed device still uses the trusted legacy `blacknode-hardware` repository
- invoke managed setup/configuration/service scripts through `bash` so installation does not depend solely on checkout executable bits
- surface actionable update-check errors and retry controls

## Why

The Devices panel hid why the Robot package latest version was unavailable. A fresh replacement then failed with Linux exit code 126 because `setup_ubuntu.sh` lacked executable permissions in the cloned package.

## Impact

Operators receive an accurate package comparison and migration diagnosis. Fresh or repaired device installs tolerate missing script mode bits while the package-side permissions are corrected.

## Validation

- `python tests/test_editor_devices.py` — 115 passed
- `cd editor && npm run build` — passed
- `python -m pytest packages/blacknode-robot/tests -q` — 101 passed, 2 skipped