### PR TITLE
Fix robot hardware discovery and recovery

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -932,17 +932,23 @@ target_private="$target/.blacknode-hardware"
 legacy_private="$legacy/.blacknode-hardware"
 marker="__BLACKNODE_HARDWARE_ADOPTION__="
 
-valid_hardware_checkout() {
+valid_target_checkout() {
+  [[ -d "$1/.git" && -f "$1/pyproject.toml" ]] \
+    && grep -Eq '^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']blacknode-robot["'"'"'][[:space:]]*$' \
+      "$1/pyproject.toml"
+}
+
+valid_legacy_checkout() {
   [[ -d "$1/.git" && -f "$1/pyproject.toml" ]] \
     && grep -Eq '^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']blacknode-hardware["'"'"'][[:space:]]*$' \
       "$1/pyproject.toml"
 }
 
-valid_hardware_checkout "$target" || {
+valid_target_checkout "$target" || {
   echo "The organized Hardware package is missing or invalid: $target" >&2
   exit 4
 }
-valid_hardware_checkout "$legacy" || {
+valid_legacy_checkout "$legacy" || {
   printf '%s{"adopted":0}\n' "$marker"
   exit 0
 }
@@ -2584,13 +2590,19 @@ request = json.loads(base64.urlsafe_b64decode(sys.argv[1]).decode("utf-8"))
 home = Path.home()
 instance = request["instance_id"]
 organized_runtime = home / "Blacknode" / "devices" / instance / "runtime"
+organized_hardware = home / "Blacknode" / "devices" / instance / "hardware"
 if instance == "default":
     legacy_runtime = home / "blacknode-runtime"
+    legacy_hardware = home / "blacknode-hardware"
     runtime_service = "blacknode-runtime.service"
 else:
     legacy_runtime = home / "blacknode-runtimes" / instance
+    legacy_hardware = home / "blacknode-hardware-instances" / instance
     runtime_service = f"blacknode-runtime-{{instance}}.service"
 runtime_dir = organized_runtime if organized_runtime.is_dir() else legacy_runtime
+hardware_dir = (
+    organized_hardware if organized_hardware.is_dir() else legacy_hardware
+)
 
 def command(args, timeout=30):
     try:
@@ -2751,10 +2763,10 @@ def resolve_hardware(port, expected_device_id):
         raise RuntimeError(f"{{unit}} does not report its repository WorkingDirectory.")
     return unit, Path(directory), resolution_error
 
-def inspect(kind, repository, service, port, directory):
+def inspect(kind, repository, service, port, directory, state_override=""):
     component = {{
         "kind": kind,
-        "service_name": service,
+        "service_name": service or "blacknode-hardware-awaiting-device",
         "port": int(port),
         "installed": {{"version": package_version(directory), "commit": ""}},
         "latest": {{"version": "unknown", "commit": ""}},
@@ -2762,7 +2774,11 @@ def inspect(kind, repository, service, port, directory):
         "can_update": False,
         "migration_required": False,
         "dirty": False,
-        "state": command(["systemctl", "is-active", service]).stdout.strip() or "unknown",
+        "state": (
+            state_override
+            or command(["systemctl", "is-active", service]).stdout.strip()
+            or "unknown"
+        ),
         "error": "",
     }}
     try:
@@ -2889,6 +2905,17 @@ components = [
         runtime_dir,
     )
 ]
+if not request["hardware_targets"] and hardware_dir.is_dir():
+    components.append(
+        inspect(
+            "hardware",
+            "blacknode-robot",
+            "",
+            0,
+            hardware_dir,
+            "configured",
+        )
+    )
 for target in request["hardware_targets"]:
     hardware_port = int(target["port"])
     try:

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -3611,9 +3611,11 @@ export default function DevicesPanel({
                     }
                     detail={selectedDeviceManagedLocally
                       ? `Port ${selectedDevice.managed_runtime.hardware_port || 8765}`
-                      : `${selectedDevice.robots.length} Hardware service${
-                          selectedDevice.robots.length === 1 ? '' : 's'
-                        } on ${runtimeHostname(selectedDevice.runtime_url)}`}
+                      : selectedDevice.robots.length
+                        ? `${selectedDevice.robots.length} Hardware service${
+                            selectedDevice.robots.length === 1 ? '' : 's'
+                          } on ${runtimeHostname(selectedDevice.runtime_url)}`
+                        : 'Robot package installed · no robot service configured yet'}
                     state={selectedHardwarePackageState}
                     currentVersion={hardwareCurrentVersion}
                     latestVersion={hardwareLatestVersion}
@@ -4698,6 +4700,18 @@ export default function DevicesPanel({
                         ? 'Find and attach robots'
                         : 'Install Hardware package'}
                   </button>
+                  {selectedDevice.managed_runtime.hardware_dir
+                    && selectedDevice.robots.length === 0 && (
+                    <button
+                      type="button"
+                      className="bn-device-action-button"
+                      disabled={busy || !robotDiscoveryPassword}
+                      onClick={() => void installDeviceHardware()}
+                      title="Set up the saved Robot Hardware checkout again, or download it when the managed checkout is missing"
+                    >
+                      Repair Hardware package
+                    </button>
+                  )}
                 </div>
               )}
               {selectedDevice.managed_runtime && !selectedDeviceManagedLocally && (
@@ -4944,11 +4958,13 @@ function SoftwarePackageSummaryCard({
   onDelete: () => void
 }) {
   const normalizedState = String(state || 'unchecked').toLowerCase()
-  const running = ['running', 'unreachable', 'awaiting_device', 'configured'].includes(
-    normalizedState,
-  )
+  const running = ['running', 'unreachable'].includes(normalizedState)
   const statusLabel = normalizedState === 'checking'
     ? 'CHECKING'
+    : normalizedState === 'configured'
+      ? 'INSTALLED'
+      : normalizedState === 'awaiting_device'
+        ? 'AWAITING ROBOT'
     : running && normalizedState !== 'unreachable'
       ? 'RUNNING'
       : normalizedState === 'stopped'
@@ -4960,6 +4976,8 @@ function SoftwarePackageSummaryCard({
             : 'NOT CHECKED'
   const statusTone = normalizedState === 'checking'
     ? 'checking'
+    : normalizedState === 'configured' || normalizedState === 'awaiting_device'
+      ? 'configured'
     : running && normalizedState !== 'unreachable'
       ? 'running'
       : normalizedState === 'stopped'

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -1369,6 +1369,10 @@ html[data-theme="light"] .bn-logo-image-light {
   color: var(--ok);
 }
 
+.bn-local-package-state.is-configured {
+  color: var(--accent);
+}
+
 .bn-local-package-state.is-stopped,
 .bn-local-package-state.is-missing {
   color: var(--tx3);

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -811,6 +811,10 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertNotIn("ssh-password", uploaded[0])
         self.assertIn('target="$HOME/Blacknode/devices/default/hardware"', uploaded[0])
         self.assertIn('legacy="$HOME/blacknode-hardware"', uploaded[0])
+        self.assertIn("valid_target_checkout", uploaded[0])
+        self.assertIn("valid_legacy_checkout", uploaded[0])
+        self.assertIn("blacknode-robot", uploaded[0])
+        self.assertIn("blacknode-hardware", uploaded[0])
         self.assertIn('cp -a -- "$legacy_private" "$temporary_private"', uploaded[0])
         self.assertIn(
             'BLACKNODE_HARDWARE_INSTANCE="" bash ./install-service.sh --all',
@@ -1251,6 +1255,11 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn("temiroff/blacknode-hardware", commands[0])
         self.assertIn('"migration_required": False', commands[0])
         self.assertIn("Migration required:", commands[0])
+        self.assertIn(
+            'if not request["hardware_targets"] and hardware_dir.is_dir():',
+            commands[0],
+        )
+        self.assertIn('"configured"', commands[0])
         self.assertIn("raw.githubusercontent.com", commands[0])
         self.assertIn('"status", "--porcelain"', commands[0])
         self.assertNotIn('"fetch"', commands[0])


### PR DESCRIPTION
## What changed

- validate the organized Hardware checkout as `blacknode-robot` while retaining the legacy `blacknode-hardware` validator for migration
- report the installed Robot package even when no Hardware service has been configured yet
- distinguish installed/awaiting-robot states from running services in the Software UI
- add a visible **Repair Hardware package** action when a saved managed checkout has no attached robot services

## Root cause

Robot discovery used the legacy `blacknode-hardware` package identity to validate the organized `blacknode-robot` checkout. The editor also inferred installation from its saved path and provided no recovery control when the actual remote checkout or setup was missing.

## Impact

A managed Raspberry Pi can repair or set up its Robot package through the editor and then discover its robot services. Package status remains accurate before a service is configured. Motion remains disarmed during setup.

## Validation

- `python -m unittest discover -s tests -p test_editor_devices.py` (115 passed)
- `cd editor && npm run build`