### PR TITLE
Refresh deployment packages before staging

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -6731,7 +6731,15 @@ def _workflow_target_package_specs(
             for component, adapter in sorted(adapters)
             if component and adapter
         ]
-    return [specs[name] for name in sorted(specs)]
+    ordered_specs = [specs[name] for name in sorted(specs)]
+    for spec in ordered_specs:
+        if spec.get("git_url"):
+            # Package versions describe API compatibility, so multiple
+            # revisions can legitimately share one version. Deployments must
+            # still refresh Git-backed packages or a device may keep running
+            # stale driver/runtime adapter code indefinitely.
+            spec["update"] = True
+    return ordered_specs
 
 
 def _device_deployment_workflow(

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -5115,6 +5115,7 @@ class EditorDeviceApiTests(unittest.TestCase):
             "name": "blacknode-new-camera",
             "git_url": "https://github.com/example/blacknode-new-camera.git",
             "version": "1.4.0",
+            "update": True,
             "components": ["capture"],
             "adapters": [{"component": "capture", "adapter": "ros2"}],
         }])


### PR DESCRIPTION
## What changed

- mark Git-backed workflow package requirements for refresh during device deployment
- preserve existing version/component/adapter validation
- add editor-device regression coverage

## Root cause

Package versions describe compatibility and can span multiple commits. The deployment path synchronized requirements by version only, so a target could report `0.4.0` while continuing to run an older `0.4.0` driver checkout that did not publish deployment telemetry. The Runtime already supports same-version Git refreshes; the editor was not requesting one.

## Impact

Restaging a workflow now fast-forwards its Git-backed packages before launch, ensuring the device runs the current driver and ROS adapter code. Existing disarmed startup and required-telemetry watchdog behavior are unchanged.

## Validation

- `python -m pytest tests/test_editor_devices.py -q` (115 passed)
- `git diff --check`