### PR TITLE
Keep robot deployments on selected target

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -7966,16 +7966,11 @@ def _start_replacing_device_deployment(
         for item in (deployment.get("superseded_deployment_ids") or [])
         if str(item)
     )
-    cleanup_warnings: list[str] = []
-    for old_id in sorted(superseded_ids):
-        try:
-            runtime_client.delete_deployment(old_id)
-        except DeviceRegistryError as exc:
-            cleanup_warnings.append(
-                f"Replacement started, but superseded deployment "
-                f"'{old_id}' could not be removed: {exc}"
-            )
-    return deployment, sorted(superseded_ids), cleanup_warnings
+    # Retain stopped deployments and their revisions until the operator uses
+    # the explicit Remove action. Automatic deletion made a deployment appear
+    # to vanish and could erase the recoverable record when multiple robots
+    # share one Runtime.
+    return deployment, sorted(superseded_ids), []
 
 
 def _stage_device_deployment_payload(

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -385,17 +385,6 @@ export default function DeploymentsPanel({
       .catch(err => setError(err instanceof Error ? err.message : String(err)))
   }, [targetDeviceId])
 
-  useEffect(() => {
-    if (!calibrationMatchedDevice) return
-    setSelectedDeviceId(current => (
-      current === calibrationMatchedDevice.id
-        ? current
-        : calibrationMatchedDevice.id
-    ))
-    setPreflight(null)
-    setRemoteNotice(null)
-  }, [activeTabId, calibrationMatchedDevice?.id, selectedCalibration?.hardware_id])
-
   // Only the open row's log is fetched, and only while it is open, so a long
   // list of deployments does not turn into a log-tail storm every 3s.
   useEffect(() => {
@@ -627,7 +616,7 @@ export default function DeploymentsPanel({
           replacements.some(deployment => deployment.state === 'running')
             ? 'the running workflow'
             : 'any running workflow'
-        }, start "${name}", then remove the superseded deployment records.`,
+        }, start "${name}", and keep the previous deployment stopped for review.`,
       )
     ) return
     setBusy(true)
@@ -655,7 +644,7 @@ export default function DeploymentsPanel({
         start
           ? `"${name}" was sent to ${selectedComputeDevice?.name || 'the compute device'} and started for ${selectedRobot?.name || 'the selected robot'}.${
             (result.superseded_deployments?.length ?? 0) > 0
-              ? ` Replaced ${result.superseded_deployments.length} previous deployment${
+              ? ` Stopped ${result.superseded_deployments.length} previous deployment${
                 result.superseded_deployments.length === 1 ? '' : 's'
               }.`
               : ''
@@ -693,7 +682,7 @@ export default function DeploymentsPanel({
       && !window.confirm(
         `Run "${deployment.name}" and replace ${replacements.length} other deployment${
           replacements.length === 1 ? '' : 's'
-        } for this robot? Superseded deployment records will be removed after the replacement starts.`,
+        } for this robot? The other deployment will remain available in a stopped state.`,
       )
     ) return
     await actRemote(() => api.startRemoteDeployment(
@@ -924,6 +913,15 @@ export default function DeploymentsPanel({
             <strong>Matched to the graph calibration:</strong>
             {' '}
             {calibrationMatchedDevice.name} · {selectedCalibration?.hardware_id}
+          </div>
+        )}
+        {calibrationMatchedDevice && selectedDeviceId !== calibrationMatchedDevice.id && (
+          <div className="bn-robot-step-status is-warning">
+            <strong>Calibration target mismatch:</strong>
+            {' '}
+            The graph calibration belongs to {calibrationMatchedDevice.name}, while this
+            deployment targets {selectedRobot?.name || selectedDeviceId}. Choose a calibration
+            recorded for the selected robot before deployment.
           </div>
         )}
 

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -5573,7 +5573,7 @@ class EditorDeviceApiTests(unittest.TestCase):
             workflow["node_meta"]["controller"]["params"]["armed"]
         )
 
-    def test_send_and_run_replaces_and_removes_older_target_deployments(self):
+    def test_send_and_run_stops_but_retains_older_target_deployments(self):
         hardware = _HardwareService()
         workflow = _workflow([])
         with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
@@ -5606,12 +5606,15 @@ class EditorDeviceApiTests(unittest.TestCase):
         payload = response.json()
         self.assertEqual(payload["superseded_deployments"], ["follower-old"])
         self.assertEqual(payload["cleanup_warnings"], [])
-        self.assertNotIn("follower-old", hardware.runtime_deployments)
+        self.assertEqual(
+            hardware.runtime_deployments["follower-old"]["state"],
+            "stopped",
+        )
         self.assertEqual(payload["deployment"]["state"], "running")
         replacement_id = payload["deployment"]["id"]
         self.assertEqual(
             set(hardware.runtime_deployments),
-            {replacement_id},
+            {"follower-old", replacement_id},
         )
         deployment_requests = [
             (method, path)
@@ -5622,7 +5625,7 @@ class EditorDeviceApiTests(unittest.TestCase):
             ("POST", "/deployments/follower-old/stop"),
             deployment_requests,
         )
-        self.assertIn(
+        self.assertNotIn(
             ("DELETE", "/deployments/follower-old"),
             deployment_requests,
         )


### PR DESCRIPTION
## What changed

- stop calibration matching from silently changing the selected deployment robot
- show a visible warning when the graph calibration belongs to another robot
- stop superseded same-robot deployments while retaining their records and revisions
- require the explicit Remove action before deployment history is deleted
- update replacement confirmation and completion wording

## Root cause

Opening Deployments from a robot card supplied the correct `targetDeviceId`. A later calibration-matching effect then silently overwrote the selected device—even though the target picker was hidden in robot context. A Leader workflow carrying or discovering the Follower calibration was consequently posted to the Follower deployment endpoint. Replacement cleanup then deleted the earlier record because both deployments appeared to belong to the Follower.

## Impact

The robot chosen in Devices remains authoritative. Calibration mismatches block or warn through the normal preflight path instead of retargeting the workflow. Replaced deployments remain visible and recoverable in a stopped state.

## Validation

- `python -m pytest tests/test_editor_devices.py -q`: 115 passed
- `npm run build`: passed
- `git diff --check`