### PR TITLE
Explain inactive robot calibration

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -6218,6 +6218,64 @@ def _calibration_hardware_mismatch_message(
     )
 
 
+def _inactive_calibration_message(
+    workflow: dict[str, Any],
+    remote_status: dict[str, Any],
+) -> str:
+    selection = _workflow_calibration_selection(workflow)
+    if selection is None:
+        return (
+            "No calibration is selected or active. This feedback-only workflow "
+            "may run, but workflows requiring joint_group remain blocked."
+        )
+
+    prefix = (
+        f"Selected calibration {selection['profile_id']} / "
+        f"{selection['hardware_id']} is saved but not active on this device."
+    )
+    try:
+        profile, _calibration = _selected_local_calibration(workflow)
+    except ValueError:
+        return (
+            prefix
+            + " The saved calibration file is unavailable. Select or record it "
+            "again before using joint_group."
+        )
+
+    expected_ids = {
+        int(joint["servo_id"])
+        for joint in (profile.get("joints") or [])
+        if (
+            isinstance(joint, dict)
+            and isinstance(joint.get("servo_id"), int)
+            and not isinstance(joint.get("servo_id"), bool)
+        )
+    }
+    observed_ids = {
+        int(match.group(1))
+        for name in (remote_status.get("joint_names") or [])
+        if (match := re.fullmatch(r"servo_(\d+)", str(name)))
+    }
+    missing_ids = sorted(expected_ids - observed_ids)
+    if expected_ids and observed_ids and missing_ids:
+        missing = ", ".join(str(value) for value in missing_ids)
+        return (
+            prefix
+            + f" The current device configuration reports {len(observed_ids)} "
+            f"of {len(expected_ids)} expected servos; missing servo ID"
+            f"{'s' if len(missing_ids) != 1 else ''}: {missing}. Check that "
+            "servo's power, bus connector, and configured ID, then run read-only "
+            "robot discovery again. This feedback-only workflow may run, but "
+            "joint_group remains blocked."
+        )
+    return (
+        prefix
+        + " This feedback-only workflow may run. A workflow requiring "
+        "joint_group will prepare the matching calibration during Check setup "
+        "while the device is disarmed."
+    )
+
+
 def _robot_profiles_root() -> Path:
     configured = str(os.environ.get("BLACKNODE_ROBOTS_DIR") or "").strip()
     return (
@@ -7137,7 +7195,7 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
             "calibration",
             "Calibration",
             "warning",
-            "No calibration profile is active; any workflow that requires joint_group will be blocked.",
+            _inactive_calibration_message(workflow, remote_status),
         ))
 
     runtime_manifest = None

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -4985,6 +4985,50 @@ class EditorDeviceApiTests(unittest.TestCase):
         )
         self.assertIn("Do not activate", checks["calibration"]["message"])
 
+    def test_inactive_calibration_message_reports_missing_servo_topology(self):
+        workflow = {
+            "metadata": {
+                "device_calibration": {
+                    "profile_id": "so_arm101_v002",
+                    "hardware_id": "5B41531481",
+                },
+            },
+        }
+        profile = {
+            "id": "so_arm101_v002",
+            "joints": [
+                {"id": f"joint_{servo_id}", "servo_id": servo_id}
+                for servo_id in range(1, 7)
+            ],
+        }
+        calibration = {
+            "profile_id": "so_arm101_v002",
+            "hardware_id": "5B41531481",
+            "joints": {},
+        }
+        with patch.object(
+            server,
+            "_selected_local_calibration",
+            return_value=(profile, calibration),
+        ):
+            message = server._inactive_calibration_message(
+                workflow,
+                {
+                    "joint_names": [
+                        "servo_1",
+                        "servo_3",
+                        "servo_4",
+                        "servo_5",
+                        "servo_6",
+                    ],
+                },
+            )
+
+        self.assertIn("saved but not active", message)
+        self.assertIn("5 of 6 expected servos", message)
+        self.assertIn("missing servo ID: 2", message)
+        self.assertIn("feedback-only workflow may run", message)
+
     def test_old_device_service_reports_calibration_upgrade_action(self):
         response = io.BytesIO(b'{"ok": false, "error": "not found"}')
         error = urllib.error.HTTPError(


### PR DESCRIPTION
## What changed

- replace the generic inactive-calibration warning with selected profile and hardware identity
- compare the selected profile's expected servo topology with the hardware service's reported servo IDs
- identify missing servo IDs explicitly
- clarify that feedback-only workflows may run while `joint_group` remains blocked
- add regression coverage for a six-servo profile reporting IDs 1 and 3–6

## Root cause

The previous warning only inspected `calibrated: false`. It did not explain that the graph had already selected the correct saved calibration or that the configured Leader hardware topology omitted servo ID 2. Operators therefore saw a generic calibration problem instead of the actionable bus/topology mismatch.

## Validation

- `python -m pytest tests/test_editor_devices.py -q`: 116 passed
- `git diff --check`