### PR TITLE
Block cross-robot feedback deployments

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -7102,19 +7102,28 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
             ),
         ))
 
-    requires_joint_motion = "joint_group" in required_capabilities
     calibrated = remote_status.get("calibrated")
-    if requires_joint_motion:
-        selection = _workflow_calibration_selection(workflow)
-        hardware_identity_match = (
-            _remote_hardware_identity_match(
-                remote_status,
-                selection["hardware_id"],
-            )
-            if selection
-            else None
+    selection = _workflow_calibration_selection(workflow)
+    hardware_identity_match = (
+        _remote_hardware_identity_match(
+            remote_status,
+            selection["hardware_id"],
         )
-        hardware_mismatch = hardware_identity_match is False
+        if selection
+        else None
+    )
+    hardware_mismatch = hardware_identity_match is False
+    requires_joint_motion = "joint_group" in required_capabilities
+    if selection and hardware_mismatch:
+        checks.append(_preflight_check(
+            "calibration",
+            "Calibration",
+            "fail",
+            _calibration_hardware_mismatch_message(selection, remote_status),
+            blocking=True,
+            action="choose_matching_hardware",
+        ))
+    elif requires_joint_motion:
         active_calibration = (
             remote_status.get("calibration")
             if isinstance(remote_status.get("calibration"), dict)
@@ -7148,8 +7157,6 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
         calibration_action = (
             "select_calibration"
             if selection is None or selection_error
-            else "choose_matching_hardware"
-            if hardware_mismatch
             else "activate_calibration"
             if not calibration_matches
             else None
@@ -7166,11 +7173,6 @@ def validate_device_deployment(device_id: str, req: DeploymentPreflightReq):
                 )
                 if calibration_matches and not selection_error
                 else selection_error
-                or (
-                    _calibration_hardware_mismatch_message(selection, remote_status)
-                    if selection and hardware_mismatch
-                    else ""
-                )
                 or (
                     "Select a saved device calibration."
                     if selection is None

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -4970,6 +4970,15 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "/devices/paired/deployment-preflight",
                 json={"workflow": workflow},
             )
+            feedback_workflow = json.loads(json.dumps(workflow))
+            feedback_workflow["metadata"]["required_capabilities"] = [
+                "position_feedback",
+                "servo_bus",
+            ]
+            feedback_preflight = self.client.post(
+                "/devices/paired/deployment-preflight",
+                json={"workflow": feedback_workflow},
+            )
 
         self.assertEqual(preflight.status_code, 200)
         checks = {item["id"]: item for item in preflight.json()["checks"]}
@@ -4984,6 +4993,21 @@ class EditorDeviceApiTests(unittest.TestCase):
             checks["calibration"]["message"],
         )
         self.assertIn("Do not activate", checks["calibration"]["message"])
+        self.assertEqual(feedback_preflight.status_code, 200)
+        feedback_checks = {
+            item["id"]: item
+            for item in feedback_preflight.json()["checks"]
+        }
+        self.assertEqual(feedback_checks["calibration"]["status"], "fail")
+        self.assertTrue(feedback_checks["calibration"]["blocking"])
+        self.assertEqual(
+            feedback_checks["calibration"]["action"],
+            "choose_matching_hardware",
+        )
+        self.assertIn(
+            "different physical robot",
+            feedback_checks["calibration"]["message"],
+        )
 
     def test_inactive_calibration_message_reports_missing_servo_topology(self):
         workflow = {


### PR DESCRIPTION
## What changed
- validate selected calibration hardware identity for every robot deployment
- block feedback-only and servo-bus workflows when the calibration belongs to a different physical robot
- retain the existing actionable `choose_matching_hardware` preflight result
- add regression coverage for the Leader-calibration-to-Follower case

## Why
A feedback-only Leader workflow did not require `joint_group`, so the calibration hardware identity check was skipped and the workflow could be deployed to the Follower. The monitor then showed six healthy Follower servos under the misleading deployment name "ROS 2 Leader Deploy."

## Impact
Deployment preflight now rejects cross-robot targeting regardless of whether the workflow commands motion or only publishes feedback.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests/test_editor_devices.py -k "wrong_robot_calibration" -q`
- `.\.venv\Scripts\python.exe -m pytest tests/test_editor_devices.py -q` (116 passed)
