### PR TITLE
Render live servo debugging nodes

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -7694,6 +7694,18 @@ def _monitor_payload_from_device_state(payload: dict[str, Any]) -> dict[str, Any
     positions = dict(joint_state.get("positions") or {})
     velocities = dict(joint_state.get("velocities") or {})
     limits = dict(joint_state.get("limits") or {})
+    values = (
+        payload.get("values")
+        if isinstance(payload.get("values"), dict)
+        else {}
+    )
+    raw_positions = dict(values.get("raw_positions") or {})
+    servo_ids = dict(values.get("servo_ids") or {})
+    calibration = (
+        values.get("calibration")
+        if isinstance(values.get("calibration"), dict)
+        else {}
+    )
     position_unit = str(joint_state.get("position_unit") or "radian")
     velocity_unit = str(joint_state.get("velocity_unit") or "radian/s")
     to_display = math.degrees if position_unit == "radian" else float
@@ -7712,6 +7724,17 @@ def _monitor_payload_from_device_state(payload: dict[str, Any]) -> dict[str, Any
             "position": position,
             "velocity": velocity,
         }
+        reported_servo_id = servo_ids.get(name)
+        servo_match = re.fullmatch(r"servo_(\d+)", str(name))
+        if (
+            isinstance(reported_servo_id, int)
+            and not isinstance(reported_servo_id, bool)
+        ):
+            item["servo_id"] = int(reported_servo_id)
+        elif servo_match:
+            item["servo_id"] = int(servo_match.group(1))
+        if name in raw_positions and isinstance(raw_positions[name], int):
+            item["raw_position"] = int(raw_positions[name])
         raw_limits = limits.get(name)
         if isinstance(raw_limits, dict):
             try:
@@ -7733,6 +7756,8 @@ def _monitor_payload_from_device_state(payload: dict[str, Any]) -> dict[str, Any
         "faults": list(payload.get("faults") or []),
         "temperatures_c": dict(payload.get("temperatures_c") or {}),
         "voltage_v": payload.get("voltage_v"),
+        "calibrated": values.get("calibrated"),
+        "calibration": calibration,
     }
 
 
@@ -7822,7 +7847,73 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
     joint_names = reported_joint_names + [
         name for name in positions if name not in reported_joint_names
     ]
+    raw_positions = dict(status.get("raw_positions") or {})
+    status_limits = dict(status.get("limits") or {})
+    calibration = (
+        status.get("calibration")
+        if isinstance(status.get("calibration"), dict)
+        else {}
+    )
+    calibration_topology = dict(calibration.get("topology") or {})
+    calibration_joints = dict(calibration.get("joints") or {})
+
+    def hardware_joint(name: str) -> dict[str, Any]:
+        item: dict[str, Any] = {
+            "name": name,
+            "position": positions[name],
+            "velocity": 0.0,
+        }
+        servo_match = re.fullmatch(r"servo_(\d+)", name)
+        servo_id = int(servo_match.group(1)) if servo_match else None
+        if servo_id is not None:
+            item["servo_id"] = servo_id
+            semantic_name = str(calibration_topology.get(str(servo_id)) or "")
+            if semantic_name:
+                item["semantic_name"] = semantic_name
+        if isinstance(raw_positions.get(name), int):
+            item["raw_position"] = int(raw_positions[name])
+
+        raw_limit = status_limits.get(name)
+        if isinstance(raw_limit, dict):
+            try:
+                item["lower_limit"] = float(
+                    raw_limit["lower"]
+                    if "lower" in raw_limit
+                    else raw_limit["min"]
+                )
+                item["upper_limit"] = float(
+                    raw_limit["upper"]
+                    if "upper" in raw_limit
+                    else raw_limit["max"]
+                )
+            except (KeyError, TypeError, ValueError):
+                pass
+        semantic_name = str(item.get("semantic_name") or "")
+        calibrated_joint = calibration_joints.get(semantic_name)
+        if isinstance(calibrated_joint, dict):
+            try:
+                item["lower_limit"] = float(calibrated_joint["safe_min_deg"])
+                item["upper_limit"] = float(calibrated_joint["safe_max_deg"])
+            except (KeyError, TypeError, ValueError):
+                pass
+        return item
+
     available = bool(status.get("connected") and positions)
+    error = str(status.get("error") or "")
+    faults = [
+        dict(item)
+        for item in (status.get("faults") or [])
+        if isinstance(item, dict)
+    ]
+    if error and not faults:
+        faults = [{
+            "kind": "blacknode.fault-state",
+            "schema_version": 1,
+            "code": "device-error",
+            "message": error,
+            "severity": "error",
+            "active": True,
+        }]
     return {
         "type": "robot_telemetry",
         "robot_id": device_id,
@@ -7841,15 +7932,16 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
             "position_unit": "degree",
             "velocity_unit": "degree/s",
             "joints": [
-                {
-                    "name": name,
-                    "position": positions[name],
-                    "velocity": 0.0,
-                }
+                hardware_joint(name)
                 for name in joint_names
                 if name in positions
             ],
-            "error": str(status.get("error") or ""),
+            "error": error,
+            "faults": faults,
+            "temperatures_c": dict(status.get("temperatures_c") or {}),
+            "voltage_v": status.get("voltage_v"),
+            "calibrated": status.get("calibrated"),
+            "calibration": calibration,
         },
         "message": (
             "Receiving state from Robot Hardware."

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -12,6 +12,7 @@ import ValueNode from './components/ValueNode'
 import ModelNode from './components/ModelNode'
 import OutputNode from './components/OutputNode'
 import RobotMonitorNode from './components/RobotMonitorNode'
+import RobotServoNode from './components/RobotServoNode'
 import SubnetNode from './components/SubnetNode'
 import SubnetBreadcrumb from './components/SubnetBreadcrumb'
 import SubgraphInputNode from './components/SubgraphInputNode'
@@ -32,6 +33,7 @@ const NODE_TYPES = {
   modelnode: ModelNode,
   outputnode: OutputNode,
   robotmonitor: RobotMonitorNode,
+  robotservo: RobotServoNode,
   subnetnode: SubnetNode,
   subnetinput: SubgraphInputNode,
   subnetoutput: SubgraphOutputNode,

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -445,8 +445,12 @@ export interface HardwareDeviceStatus {
 
 export interface RobotTelemetryJoint {
   name: string
+  semantic_name?: string
+  servo_id?: number
   position: number
   velocity: number
+  effort?: number
+  raw_position?: number
   lower_limit?: number
   upper_limit?: number
 }
@@ -477,6 +481,30 @@ export interface RobotTelemetrySample {
     velocity_unit: string
     joints: RobotTelemetryJoint[]
     error?: string
+    calibrated?: boolean
+    calibration?: {
+      name?: string
+      profile_id?: string
+      hardware_id?: string
+      topology?: Record<string, string>
+      joints?: Record<string, {
+        safe_min_deg?: number
+        safe_max_deg?: number
+        home_ticks?: number
+        invert?: boolean
+      }>
+    }
+    faults?: Array<{
+      code?: string
+      message?: string
+      severity?: string
+      active?: boolean
+      recoverable?: boolean
+      vendor_code?: string
+      details?: Record<string, unknown>
+    }>
+    temperatures_c?: Record<string, number>
+    voltage_v?: number
     battery?: {
       level?: number
       voltage?: number

--- a/editor/src/components/RobotMonitorNode.tsx
+++ b/editor/src/components/RobotMonitorNode.tsx
@@ -3,15 +3,16 @@ import { Handle, Position, type NodeProps } from 'reactflow'
 
 import {
   api,
-  deviceMonitorSocketUrl,
   type HardwareDevice,
   type RobotTelemetryJoint,
   type RobotTelemetrySample,
 } from '../api'
+import {
+  subscribeRobotTelemetry,
+  type RobotMonitorConnection,
+} from '../robotTelemetryStream'
 import { useStore, type NodeData } from '../store'
 import NodeFrame from './NodeFrame'
-
-type MonitorConnection = 'idle' | 'connecting' | 'live' | 'offline'
 
 type JointTrace = {
   position: number[]
@@ -111,7 +112,7 @@ export function RobotLiveMonitor({
   emptyMessage: string
 }) {
   const [sample, setSample] = useState<RobotTelemetrySample | null>(null)
-  const [connection, setConnection] = useState<MonitorConnection>(
+  const [connection, setConnection] = useState<RobotMonitorConnection>(
     robotId ? 'connecting' : 'idle',
   )
   const [traces, setTraces] = useState<Record<string, JointTrace>>({})
@@ -128,22 +129,10 @@ export function RobotLiveMonitor({
       return
     }
 
-    let stopped = false
-    let socket: WebSocket | null = null
-    let reconnectTimer: number | undefined
-
-    const connect = () => {
-      if (stopped) return
-      setConnection('connecting')
-      socket = new WebSocket(deviceMonitorSocketUrl(robotId))
-      socket.onopen = () => setConnection('live')
-      socket.onmessage = event => {
-        let next: RobotTelemetrySample
-        try {
-          next = JSON.parse(String(event.data)) as RobotTelemetrySample
-        } catch {
-          return
-        }
+    return subscribeRobotTelemetry(
+      robotId,
+      nextSample => {
+        let next = nextSample
         const sourceKey = `${next.source || 'unknown'}:${next.source_label || ''}`
         if (activeSource.current && activeSource.current !== sourceKey) {
           previous.current = {}
@@ -189,21 +178,9 @@ export function RobotLiveMonitor({
           })
         }
         setSample(next)
-      }
-      socket.onerror = () => socket?.close()
-      socket.onclose = () => {
-        if (stopped) return
-        setConnection('offline')
-        reconnectTimer = window.setTimeout(connect, 1200)
-      }
-    }
-
-    connect()
-    return () => {
-      stopped = true
-      if (reconnectTimer !== undefined) window.clearTimeout(reconnectTimer)
-      socket?.close()
-    }
+      },
+      setConnection,
+    )
   }, [robotId])
 
   const joints = sample?.payload?.joints || []

--- a/editor/src/components/RobotServoNode.tsx
+++ b/editor/src/components/RobotServoNode.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Handle, Position, type NodeProps } from 'reactflow'
+
+import {
+  api,
+  type HardwareDevice,
+  type RobotTelemetryJoint,
+  type RobotTelemetrySample,
+} from '../api'
+import {
+  subscribeRobotTelemetry,
+  type RobotMonitorConnection,
+} from '../robotTelemetryStream'
+import { useStore, type NodeData } from '../store'
+import NodeFrame from './NodeFrame'
+
+function hardwareIdentity(value: unknown): string {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function servoIdOf(joint: RobotTelemetryJoint): number | null {
+  if (Number.isInteger(joint.servo_id)) return Number(joint.servo_id)
+  const match = /^(?:servo|joint)_(\d+)$/.exec(joint.name)
+  return match ? Number(match[1]) : null
+}
+
+function convert(value: number, source: string, target: string): number {
+  const sourceRadians = source.toLowerCase().startsWith('radian')
+  const targetRadians = target.toLowerCase().startsWith('radian')
+  if (sourceRadians === targetRadians) return value
+  return sourceRadians ? value * 180 / Math.PI : value * Math.PI / 180
+}
+
+export default function RobotServoNode({ id, data, selected }: NodeProps<NodeData>) {
+  const updateParam = useStore(state => state.updateParam)
+  const nodes = useStore(state => state.nodes)
+  const edges = useStore(state => state.edges)
+  const [devices, setDevices] = useState<HardwareDevice[]>([])
+  const [sample, setSample] = useState<RobotTelemetrySample | null>(null)
+  const [connection, setConnection] = useState<RobotMonitorConnection>('idle')
+  const [derivedVelocity, setDerivedVelocity] = useState(0)
+  const previous = useRef<{ position: number; at: number } | null>(null)
+  const servoId = Math.max(1, Math.min(253, Number(data.params?.servo_id ?? 1) || 1))
+  const units = String(data.params?.units ?? 'degrees')
+
+  const source = useMemo(() => {
+    const edge = edges.find(item => item.target === id && item.targetHandle === 'robot')
+    return edge ? nodes.find(node => node.id === edge.source) : undefined
+  }, [edges, id, nodes])
+  const sourceRobot = (
+    source?.data.portResults?.robot
+    && typeof source.data.portResults.robot === 'object'
+  )
+    ? source.data.portResults.robot as Record<string, unknown>
+    : {}
+  const driver = (
+    sourceRobot.driver
+    && typeof sourceRobot.driver === 'object'
+  )
+    ? sourceRobot.driver as Record<string, unknown>
+    : {}
+  const directRobotId = String(data.params?.robot_id ?? '').trim()
+  const sourceRobotId = source?.data.type === 'RobotMonitor'
+    ? String(source.data.params?.robot_id ?? '').trim()
+    : String(sourceRobot.robot_id ?? sourceRobot.device_id ?? '').trim()
+  const sourceHardwareId = String(
+    driver.hardware_id
+    ?? (source?.data.portResults?.hardware as Record<string, unknown> | undefined)?.serial
+    ?? '',
+  ).trim()
+  const mappedDevice = sourceHardwareId
+    ? devices.find(device => (
+      hardwareIdentity(device.remote_device_id).includes(hardwareIdentity(sourceHardwareId))
+      || hardwareIdentity(device.id).includes(hardwareIdentity(sourceHardwareId))
+    ))
+    : undefined
+  const robotId = directRobotId || sourceRobotId || mappedDevice?.id || ''
+  const robotName = devices.find(device => device.id === robotId)?.name
+    || String(source?.data.params?.robot_name ?? '')
+    || String(source?.data.params?.profile_id ?? '')
+    || 'Robot'
+
+  useEffect(() => {
+    let active = true
+    void api.listDevices()
+      .then(result => { if (active) setDevices(result.devices) })
+      .catch(() => undefined)
+    return () => { active = false }
+  }, [])
+
+  useEffect(() => {
+    setSample(null)
+    setDerivedVelocity(0)
+    previous.current = null
+    return subscribeRobotTelemetry(
+      robotId,
+      next => {
+        const joint = (next.payload?.joints || []).find(item => servoIdOf(item) === servoId)
+        if (joint) {
+          const now = Date.now()
+          const prior = previous.current
+          if (prior && now > prior.at) {
+            setDerivedVelocity((joint.position - prior.position) / ((now - prior.at) / 1000))
+          }
+          previous.current = { position: joint.position, at: now }
+        }
+        setSample(next)
+      },
+      setConnection,
+    )
+  }, [robotId, servoId])
+
+  const joints = sample?.payload?.joints || []
+  const joint = joints.find(item => servoIdOf(item) === servoId)
+  const detectedIds = [...new Set(joints.map(servoIdOf).filter((value): value is number => value != null))]
+    .sort((a, b) => a - b)
+  const sourcePositionUnit = sample?.payload?.position_unit || 'degree'
+  const sourceVelocityUnit = sample?.payload?.velocity_unit || 'degree/s'
+  const position = joint ? convert(joint.position, sourcePositionUnit, units) : 0
+  const velocityValue = sample?.source === 'hardware' ? derivedVelocity : joint?.velocity ?? 0
+  const velocity = convert(velocityValue, sourceVelocityUnit, `${units}/s`)
+  const lower = joint?.lower_limit == null
+    ? units === 'degrees' ? -180 : -Math.PI
+    : convert(joint.lower_limit, sourcePositionUnit, units)
+  const upper = joint?.upper_limit == null
+    ? units === 'degrees' ? 180 : Math.PI
+    : convert(joint.upper_limit, sourcePositionUnit, units)
+  const hasCalibratedLimits = Boolean(
+    sample?.payload?.calibrated
+    && joint?.lower_limit != null
+    && joint?.upper_limit != null,
+  )
+  const followFeedback = data.params?.follow_feedback !== false
+  const targetParam = Number(data.params?.target_position ?? 0)
+  const target = Math.max(lower, Math.min(upper, followFeedback ? position : targetParam))
+  const temperature = sample?.payload?.temperatures_c?.[joint?.name || '']
+    ?? sample?.payload?.temperatures_c?.[`servo_${servoId}`]
+  const faults = (sample?.payload?.faults || []).filter(fault => fault.active !== false)
+  const state = !robotId
+    ? 'CONNECT ROBOT'
+    : connection !== 'live'
+      ? connection.toUpperCase()
+      : sample?.stale
+        ? 'STALE'
+        : joint
+          ? 'LIVE'
+          : 'ID NOT REPORTED'
+  const stateTone = state === 'LIVE' ? '#22c55e' : state === 'STALE' ? '#f59e0b' : '#ef4444'
+  const unit = units === 'degrees' ? '°' : 'rad'
+
+  const chooseServo = (next: number) => {
+    void updateParam(id, 'servo_id', next)
+    void updateParam(id, 'follow_feedback', true)
+  }
+  const setTarget = (next: number) => {
+    void updateParam(id, 'follow_feedback', false)
+    void updateParam(id, 'target_position', next)
+  }
+
+  return (
+    <NodeFrame
+      id={id}
+      data={data}
+      selected={selected}
+      color="#14b8a6"
+      nodeType={data.type}
+      style={{ width: '100%', minWidth: 330 }}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="robot"
+        title="robot · Dict"
+        style={{ top: 72, background: '#a855f7', width: 10, height: 10 }}
+      />
+      <header className="bn-servo-node-title">
+        <div>
+          <span>SERVO</span>
+          <strong>{joint?.semantic_name || joint?.name || `ID ${servoId}`}</strong>
+          <small>{robotName}</small>
+        </div>
+        <label className="nodrag" onMouseDown={event => event.stopPropagation()}>
+          <span>ID</span>
+          <input
+            type="number"
+            min={1}
+            max={253}
+            value={servoId}
+            list={`servo-ids-${id}`}
+            onChange={event => chooseServo(Number(event.target.value))}
+          />
+          <datalist id={`servo-ids-${id}`}>
+            {detectedIds.map(value => <option key={value} value={value} />)}
+          </datalist>
+        </label>
+      </header>
+
+      <div className="bn-servo-node-state" style={{ color: stateTone }}>
+        <span style={{ background: stateTone }} />
+        {state}
+      </div>
+
+      {joint ? (
+        <>
+          <div className="bn-servo-node-reading">
+            <div>
+              <span>Position</span>
+              <strong>{position.toFixed(2)} {unit}</strong>
+            </div>
+            <div>
+              <span>Velocity</span>
+              <strong>{velocity.toFixed(2)} {unit}/s</strong>
+            </div>
+            <div>
+              <span>Raw</span>
+              <strong>{joint.raw_position ?? '—'}</strong>
+            </div>
+          </div>
+
+          <div className="bn-servo-node-slider nodrag" onMouseDown={event => event.stopPropagation()}>
+            <div>
+              <span>Target preview</span>
+              <button
+                type="button"
+                onClick={() => { void updateParam(id, 'follow_feedback', true) }}
+              >
+                Use current
+              </button>
+            </div>
+            <input
+              type="range"
+              min={lower}
+              max={upper}
+              step={units === 'degrees' ? 0.1 : 0.002}
+              value={target}
+              onChange={event => setTarget(Number(event.target.value))}
+            />
+            <div>
+              <span>{lower.toFixed(2)} {unit}</span>
+              <strong>{target.toFixed(2)} {unit}</strong>
+              <span>{upper.toFixed(2)} {unit}</span>
+            </div>
+          </div>
+
+          <div className="bn-servo-node-facts">
+            <span>Limits <strong>{hasCalibratedLimits ? 'Calibrated' : 'Profile/default'}</strong></span>
+            <span>Torque <strong>{sample?.payload?.torque_enabled == null ? 'Unknown' : sample.payload.torque_enabled ? 'On' : 'Off'}</strong></span>
+            <span>Temperature <strong>{temperature == null ? 'Not reported' : `${temperature.toFixed(1)} °C`}</strong></span>
+            <span>Voltage <strong>{sample?.payload?.voltage_v == null ? 'Not reported' : `${sample.payload.voltage_v.toFixed(2)} V`}</strong></span>
+            <span>Faults <strong className={faults.length ? 'is-error' : ''}>{faults.length || 'None'}</strong></span>
+          </div>
+          {faults.length > 0 && (
+            <div className="bn-servo-node-fault">
+              {faults.map((fault, index) => (
+                <span key={`${fault.code || 'fault'}-${index}`}>
+                  {fault.code || 'fault'}: {fault.message || 'Device fault reported'}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="bn-servo-node-note">
+            Preview only · connect <strong>joint</strong> and <strong>target</strong> to a motion node to execute.
+          </div>
+        </>
+      ) : (
+        <div className="bn-servo-node-empty">
+          <strong>{robotId ? `Servo ID ${servoId} is not in this robot stream` : 'Connect a Robot or Robot Monitor'}</strong>
+          <span>
+            {detectedIds.length
+              ? `Reported IDs: ${detectedIds.join(', ')}`
+              : 'Run the Robot node or select a registered Robot Monitor target.'}
+          </span>
+        </div>
+      )}
+
+      {[
+        ['servo', 82],
+        ['joint', 112],
+        ['position', 142],
+        ['target_position', 172],
+        ['command', 202],
+      ].map(([port, top]) => (
+        <Handle
+          key={String(port)}
+          type="source"
+          position={Position.Right}
+          id={String(port)}
+          title={String(port)}
+          style={{ top: Number(top), background: '#14b8a6', width: 9, height: 9 }}
+        />
+      ))}
+    </NodeFrame>
+  )
+}

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -8719,3 +8719,184 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+.bn-servo-node-title {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.bn-servo-node-title > div {
+  display: grid;
+  min-width: 0;
+}
+
+.bn-servo-node-title span,
+.bn-servo-node-title small {
+  color: var(--tx3);
+  font: 700 10px/1.3 var(--font-ui);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.bn-servo-node-title strong {
+  overflow: hidden;
+  color: var(--tx1);
+  font: 800 17px/1.35 var(--font-ui);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-servo-node-title label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--tx3);
+  font: 700 11px/1 var(--font-ui);
+}
+
+.bn-servo-node-title input {
+  width: 58px;
+  padding: 4px 5px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--lift);
+  color: var(--tx1);
+  font: 700 12px/1 var(--font-mono);
+}
+
+.bn-servo-node-state {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--line);
+  font: 800 10px/1 var(--font-ui);
+  letter-spacing: .07em;
+}
+
+.bn-servo-node-state > span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  box-shadow: 0 0 8px currentColor;
+}
+
+.bn-servo-node-reading {
+  display: grid;
+  grid-template-columns: 1.25fr 1.25fr .75fr;
+  gap: 6px;
+  padding: 10px 12px;
+}
+
+.bn-servo-node-reading > div {
+  display: grid;
+  gap: 2px;
+  padding: 7px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--lift);
+}
+
+.bn-servo-node-reading span,
+.bn-servo-node-facts > span {
+  color: var(--tx3);
+  font: 600 10px/1.3 var(--font-ui);
+}
+
+.bn-servo-node-reading strong,
+.bn-servo-node-facts strong {
+  color: var(--tx1);
+  font: 700 12px/1.3 var(--font-mono);
+}
+
+.bn-servo-node-slider {
+  display: grid;
+  gap: 5px;
+  margin: 0 12px 10px;
+  padding: 9px;
+  border: 1px solid color-mix(in srgb, #14b8a6 50%, var(--line));
+  border-radius: 8px;
+  background: color-mix(in srgb, #14b8a6 7%, var(--lift));
+}
+
+.bn-servo-node-slider > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--tx3);
+  font: 600 10px/1.2 var(--font-ui);
+}
+
+.bn-servo-node-slider button {
+  padding: 3px 6px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg2);
+  color: var(--tx2);
+  font: 700 10px/1 var(--font-ui);
+  cursor: pointer;
+}
+
+.bn-servo-node-slider input[type="range"] {
+  width: 100%;
+  accent-color: #14b8a6;
+}
+
+.bn-servo-node-slider strong {
+  color: #5eead4;
+  font: 800 12px/1 var(--font-mono);
+}
+
+.bn-servo-node-facts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px 10px;
+  padding: 0 14px 10px;
+}
+
+.bn-servo-node-facts > span {
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.bn-servo-node-facts .is-error {
+  color: var(--err);
+}
+
+.bn-servo-node-fault {
+  display: grid;
+  gap: 3px;
+  margin: 0 12px 8px;
+  padding: 7px;
+  border: 1px solid color-mix(in srgb, var(--err) 55%, transparent);
+  border-radius: 6px;
+  color: var(--err);
+  font: 600 10px/1.35 var(--font-ui);
+}
+
+.bn-servo-node-note,
+.bn-servo-node-empty {
+  margin: 0 12px 12px;
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--lift);
+  color: var(--tx3);
+  font: 600 10px/1.4 var(--font-ui);
+}
+
+.bn-servo-node-empty {
+  display: grid;
+  gap: 4px;
+  min-height: 74px;
+}
+
+.bn-servo-node-empty strong {
+  color: var(--tx1);
+  font-size: 12px;
+}

--- a/editor/src/robotTelemetryStream.ts
+++ b/editor/src/robotTelemetryStream.ts
@@ -1,0 +1,96 @@
+import {
+  deviceMonitorSocketUrl,
+  type RobotTelemetrySample,
+} from './api'
+
+export type RobotMonitorConnection = 'idle' | 'connecting' | 'live' | 'offline'
+
+type Listener = {
+  onSample: (sample: RobotTelemetrySample) => void
+  onConnection: (connection: RobotMonitorConnection) => void
+}
+
+type Stream = {
+  robotId: string
+  listeners: Set<Listener>
+  socket: WebSocket | null
+  reconnectTimer?: number
+  connection: RobotMonitorConnection
+  latest: RobotTelemetrySample | null
+  stopped: boolean
+}
+
+const streams = new Map<string, Stream>()
+
+function publishConnection(stream: Stream, connection: RobotMonitorConnection) {
+  stream.connection = connection
+  for (const listener of stream.listeners) listener.onConnection(connection)
+}
+
+function connect(stream: Stream) {
+  if (stream.stopped || stream.listeners.size === 0) return
+  publishConnection(stream, 'connecting')
+  const socket = new WebSocket(deviceMonitorSocketUrl(stream.robotId))
+  stream.socket = socket
+  socket.onopen = () => publishConnection(stream, 'live')
+  socket.onmessage = event => {
+    let sample: RobotTelemetrySample
+    try {
+      sample = JSON.parse(String(event.data)) as RobotTelemetrySample
+    } catch {
+      return
+    }
+    stream.latest = sample
+    for (const listener of stream.listeners) listener.onSample(sample)
+  }
+  socket.onerror = () => socket.close()
+  socket.onclose = () => {
+    if (stream.socket === socket) stream.socket = null
+    if (stream.stopped || stream.listeners.size === 0) return
+    publishConnection(stream, 'offline')
+    stream.reconnectTimer = window.setTimeout(() => connect(stream), 1200)
+  }
+}
+
+export function subscribeRobotTelemetry(
+  robotId: string,
+  onSample: Listener['onSample'],
+  onConnection: Listener['onConnection'],
+): () => void {
+  const cleanId = String(robotId || '').trim()
+  if (!cleanId) {
+    onConnection('idle')
+    return () => undefined
+  }
+  let stream = streams.get(cleanId)
+  if (!stream) {
+    stream = {
+      robotId: cleanId,
+      listeners: new Set(),
+      socket: null,
+      connection: 'connecting',
+      latest: null,
+      stopped: false,
+    }
+    streams.set(cleanId, stream)
+  }
+  const listener = { onSample, onConnection }
+  stream.listeners.add(listener)
+  onConnection(stream.connection)
+  if (stream.latest) onSample(stream.latest)
+  if (!stream.socket && stream.reconnectTimer === undefined) connect(stream)
+
+  return () => {
+    stream!.listeners.delete(listener)
+    if (stream!.listeners.size > 0) return
+    stream!.stopped = true
+    if (stream!.reconnectTimer !== undefined) {
+      window.clearTimeout(stream!.reconnectTimer)
+      stream!.reconnectTimer = undefined
+    }
+    const socket = stream!.socket
+    stream!.socket = null
+    socket?.close()
+    streams.delete(cleanId)
+  }
+}

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -331,6 +331,7 @@ function reactNodeType(typeName: string): string {
   if (typeName === 'SubnetInput') return 'subnetinput'
   if (typeName === 'SubnetOutput') return 'subnetoutput'
   if (typeName === 'RobotMonitor') return 'robotmonitor'
+  if (typeName === 'RobotServo') return 'robotservo'
   return OUTPUT_NODE_TYPES.has(typeName) ? 'outputnode' : MODEL_NODE_TYPES.has(typeName) ? 'modelnode' : VALUE_NODE_TYPES.has(typeName) ? 'valuenode' : 'blacknode'
 }
 
@@ -388,6 +389,7 @@ function makeReactNode(meta: BnNodeMeta): Node<NodeData> {
     ...(meta.type === 'ROS2Run' ? { style: { width: 520, height: 360 } } : {}),
     ...(meta.type === 'ROS2MotionDashboard' ? { style: { width: 860, height: 720 } } : {}),
     ...(meta.type === 'RobotMonitor' ? { style: { width: 760 } } : {}),
+    ...(meta.type === 'RobotServo' ? { style: { width: 360 } } : {}),
   }
 }
 

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -537,7 +537,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "name": "devices",
                     "default": True,
                     "node_types": [
-                        "HardwareCapabilities"
+                        "HardwareCapabilities",
+                        "RobotServo"
                     ]
                 },
                 "telemetry": {
@@ -584,6 +585,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "RobotProfileLoad",
                 "RobotProfileSave",
                 "RobotROSInterfaceCheck",
+                "RobotServo",
                 "RobotUSBDiscovery"
             ]
         },

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -5053,6 +5053,85 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn("missing servo ID: 2", message)
         self.assertIn("feedback-only workflow may run", message)
 
+    def test_hardware_monitor_exposes_servo_debug_fields_and_calibrated_limits(self):
+        status = {
+            "device_id": "robot-device",
+            "connected": True,
+            "armed": False,
+            "torque_enabled": False,
+            "joint_names": ["servo_2"],
+            "positions": {"servo_2": 12.5},
+            "raw_positions": {"servo_2": 2190},
+            "limits": {"servo_2": {"min": -180.0, "max": 180.0}},
+            "calibrated": True,
+            "calibration": {
+                "profile_id": "so_arm101",
+                "hardware_id": "SERIAL-42",
+                "topology": {"2": "shoulder_lift"},
+                "joints": {
+                    "shoulder_lift": {
+                        "safe_min_deg": -70.0,
+                        "safe_max_deg": 80.0,
+                    },
+                },
+            },
+            "temperatures_c": {"servo_2": 41.5},
+            "voltage_v": 12.2,
+            "error": "",
+        }
+        with (
+            patch.object(
+                server._device_registry,
+                "get_public",
+                return_value={"id": "robot", "name": "Robot"},
+            ),
+            patch.object(
+                server,
+                "_deployment_aware_device_status",
+                return_value=status,
+            ),
+        ):
+            snapshot = server._device_monitor_snapshot("robot")
+
+        payload = snapshot["payload"]
+        joint = payload["joints"][0]
+        self.assertEqual(joint["servo_id"], 2)
+        self.assertEqual(joint["semantic_name"], "shoulder_lift")
+        self.assertEqual(joint["raw_position"], 2190)
+        self.assertEqual(joint["lower_limit"], -70.0)
+        self.assertEqual(joint["upper_limit"], 80.0)
+        self.assertTrue(payload["calibrated"])
+        self.assertEqual(payload["temperatures_c"]["servo_2"], 41.5)
+        self.assertEqual(payload["voltage_v"], 12.2)
+
+    def test_deployment_monitor_preserves_semantic_joint_servo_ids(self):
+        payload = server._monitor_payload_from_device_state({
+            "kind": "blacknode.device-state",
+            "connected": True,
+            "armed": False,
+            "torque_enabled": False,
+            "joint_state": {
+                "position_unit": "radian",
+                "velocity_unit": "radian/s",
+                "positions": {"shoulder_lift": 0.25},
+                "velocities": {"shoulder_lift": 0.1},
+                "limits": {
+                    "shoulder_lift": {"lower": -1.0, "upper": 1.0},
+                },
+            },
+            "values": {
+                "servo_ids": {"shoulder_lift": 2},
+                "raw_positions": {"shoulder_lift": 2190},
+                "calibrated": True,
+            },
+        })
+
+        joint = payload["joints"][0]
+        self.assertEqual(joint["name"], "shoulder_lift")
+        self.assertEqual(joint["servo_id"], 2)
+        self.assertEqual(joint["raw_position"], 2190)
+        self.assertTrue(payload["calibrated"])
+
     def test_old_device_service_reports_calibration_upgrade_action(self):
         response = io.BytesIO(b'{"ok": false, "error": "not found"}')
         error = urllib.error.HTTPError(

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -57,7 +57,10 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["packages"]["blacknode-robot"]["layer"] == "robot"
     robot = payload["packages"]["blacknode-robot"]
     assert {"devices", "telemetry"}.issubset(robot["components"])
-    assert robot["components"]["devices"]["node_types"] == ["HardwareCapabilities"]
+    assert robot["components"]["devices"]["node_types"] == [
+        "HardwareCapabilities",
+        "RobotServo",
+    ]
     assert robot["components"]["telemetry"]["adapters"]["mqtt"]["default"] is False
     assert payload["packages"]["blacknode-perception"]["layer"] == "perception"
     assert payload["packages"]["blacknode-ros2"]["layer"] == "ros2"
@@ -142,6 +145,7 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["RobotMonitor"]["package"] == "blacknode-robot"
     assert payload["nodes"]["RobotCapabilityInspect"]["package"] == "blacknode-robot"
     assert payload["nodes"]["HardwareCapabilities"]["package"] == "blacknode-robot"
+    assert payload["nodes"]["RobotServo"]["package"] == "blacknode-robot"
     assert payload["nodes"]["EpisodeRecorder"] == {
         "package": "blacknode-dataset",
         "git_url": "https://github.com/temiroff/blacknode-dataset.git",


### PR DESCRIPTION
## What changed
- render `RobotServo` as a dedicated live canvas card with servo-ID selection and target preview slider
- show position, velocity, raw ticks, calibrated limits, torque, temperature, voltage, and faults
- share one robot WebSocket among all Servo and Robot Monitor subscribers
- preserve servo IDs and raw feedback in editor telemetry for hardware and deployment sources

## Why
Multiple per-servo cards must observe one robot without multiplying serial polling load, and semantic deployment joint names must retain their physical servo identity.

## Safety
The card is preview-only. It does not expose an arm switch or write endpoint; execution is wired separately through motion nodes.

## Validation
- `python -m pytest tests/test_editor_devices.py -q` (118 passed)
- `python -m unittest discover -s tests` (488 passed, 8 skipped)
- `npm run build` in `editor/`

Visual browser inspection was unavailable because no in-app browser was connected; TypeScript and production rendering compilation passed.
