### PR TITLE
Preserve robot calibration target

### DIFF
--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -351,10 +351,11 @@ export default function DeploymentsPanel({
     if (
       robotNodes.length !== 1
       || !automaticTargetCalibration
-      || (
-        selectedCalibration?.profile_id === automaticTargetCalibration.profile_id
-        && selectedCalibration?.hardware_id === automaticTargetCalibration.hardware_id
-      )
+      // Auto-selection is only a default for an unbound graph. Replacing an
+      // existing hardware identity when the operator opens another robot card
+      // would silently turn a Leader workflow into a Follower workflow before
+      // deployment preflight can reject the mismatched target.
+      || selectedCalibration
       || requirementsBusy
       || profileBusyId
       || isCalibrationWorkflow


### PR DESCRIPTION
## What changed

- Auto-select a target robot calibration only when the open workflow has no calibration identity.
- Preserve an existing Leader or Follower hardware identity when another robot card opens deployment setup.

## Why

The deployment panel was replacing an existing graph calibration as soon as the selected device changed. That allowed a Leader graph to be silently rebound to Follower before deployment preflight could detect the mismatch.

## Impact

Leader and Follower workflows retain their stable hardware identities. Selecting the wrong robot now leaves the graph unchanged and exposes the existing calibration-target mismatch, which the server blocks.

## Validation

- `npm run build` in `editor/`
- `python -m unittest discover -s tests -p test_editor_devices.py -k wrong_robot_calibration_is_rejected_before_activation`
- `git diff --check`