### PR TITLE
Preserve workflow tabs when opening templates

### DIFF
--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -166,7 +166,7 @@ export default function NodePalette() {
   const [deploymentReturnTab, setDeploymentReturnTab] = useState<Tab>('devices')
   const [deploymentReturnDeviceId, setDeploymentReturnDeviceId] = useState('')
   const [templateSearch, setTemplateSearch] = useState('')
-  const [templateOpenInNewTab, setTemplateOpenInNewTab] = useState(false)
+  const [templateOpenInNewTab, setTemplateOpenInNewTab] = useState(true)
   const [openGroups, setOpenGroups] = useState<Set<string>>(() => new Set())
   const dragRef = useRef<{ startX: number; startW: number } | null>(null)
 
@@ -182,7 +182,7 @@ export default function NodePalette() {
     setActiveTab(tab)
     if (tab === 'templates') {
       setTemplateSearch('')
-      setTemplateOpenInNewTab(false)
+      setTemplateOpenInNewTab(true)
     }
     if (tab === 'deployments') {
       if (panelWidth < PANEL_DEPLOY_W) {

--- a/editor/src/components/TemplateGallery.tsx
+++ b/editor/src/components/TemplateGallery.tsx
@@ -31,7 +31,7 @@ function templateTags(template: TemplateMeta): string[] {
 
 export default function TemplateGallery({
   initialQuery = '',
-  openInNewTab = false,
+  openInNewTab = true,
 }: TemplateGalleryProps) {
   const { loadGraph, loadNodeTypes, openGraphAsTab, organizeNodes } = useStore()
   const [templates, setTemplates] = useState<TemplateMeta[]>([])


### PR DESCRIPTION
## What changed

- Open templates in a separate workflow tab by default.
- Keep the deployment-guided template path and the normal Templates panel consistent.

## Why

Opening the Follower template through the normal gallery reused the active Leader tab. Deploying Follower did not delete the remote Leader revision, but the canvas replacement made the Leader graph appear to disappear.

## Impact

Leader and Follower workflows remain visible as separate named tabs. Deploying or editing one workflow no longer replaces the other workflow's canvas.

## Validation

- `npm run build` in `editor/`
- `git diff --check`
- Confirmed the stored Leader revision remains targeted to Leader and disarmed; Follower remains a separate disarmed deployment.