### PR TITLE
Improve robot hardware operator workflows

### DIFF
--- a/.agents/skills/blacknode-development/SKILL.md
+++ b/.agents/skills/blacknode-development/SKILL.md
@@ -25,8 +25,10 @@ and a representative workflow when applicable.
    independent repositories, not tracked children of the core repository.
 4. Decide whether the capability belongs in core, an extension package, a
    user-local custom node, or a workflow-local `PythonFn`.
-5. Implement the narrowest coherent change, add tests, and update public docs.
-6. Build a small workflow/template when it materially proves discovery, ports,
+5. For a hardware, transport, simulation, or replay provider, read
+   `docs/provider-authoring.md` and inspect the live capability contract.
+6. Implement the narrowest coherent change, add tests, and update public docs.
+7. Build a small workflow/template when it materially proves discovery, ports,
    runtime behavior, or package resolution.
 
 ## Choose the Ownership Layer
@@ -82,7 +84,9 @@ Use current generic names in new templates and docs.
 ## Author an Extension Package
 
 Use `blacknode-cuda` as the smallest reference package. Read
-`docs/packages.md` and `docs/custom-nodes.md` before authoring.
+`docs/packages.md` and `docs/custom-nodes.md` before authoring. For a hardware,
+transport, simulation, or replay provider, also read
+`docs/provider-authoring.md`.
 
 Required shape:
 
@@ -123,6 +127,11 @@ node/package -> registry and schema -> editor-server/MCP -> editor -> template
 Update each affected layer in the same change. Do not persist editor-only fields
 such as `cookResult`, `cookError`, `cooking`, or `cookPort` in workflow JSON.
 
+For custom editor node headers or bodies, derive inner corners from the shared
+`--bn-node-inner-radius` token with the legacy radius as a fallback. Inspect
+later cascade overrides and do not introduce a separate fixed radius that can
+drift from the standard node shell.
+
 For hardware-facing contracts, test provider absence as well as provider
 presence. A missing optional module must degrade only its advertised
 capabilities, while compatible providers must produce the same normalized
@@ -131,6 +140,13 @@ state, lifecycle, status, error, and shutdown shapes.
 ## Hardware and Managed-Service Safety
 
 - Keep robot motion disarmed until explicitly authorized.
+- Treat communication presence and hardware health as separate states. Preserve
+  valid read-only telemetry when a response carries a hardware warning, expose
+  the raw status and decoded warning to nodes and monitors, and keep
+  motion/torque authorization strict.
+- A hardware warning may accompany a successful transition to a safer state.
+  Accept release, stop, or disarm only after independently reading the physical
+  state back as safe; never extend that tolerance to arm or torque-enable.
 - Never bypass calibrated limits, freshness checks, or emergency shutdown.
 - Treat worker heartbeat and source-data freshness as separate signals.
 - Preserve idempotent control behavior across retries.
@@ -160,6 +176,8 @@ Update the closest public contract alongside code:
 
 - `docs/agent-guide.md` for agent routing and workflow behavior.
 - `docs/packages.md` for package format and lifecycle.
+- `docs/provider-authoring.md` for capability providers, profile bindings,
+  adapters, managed lifecycle, and compatibility tests.
 - `docs/custom-nodes.md` for node authoring.
 - `CONTRIBUTING.md` for contributor setup and verification.
 - The affected package README for package-specific behavior.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ editor computer.
   [Datasets](docs/episode-datasets.md) ·
   [Policy training](docs/robot-policy-training.md)
 - Platform: [Packages](docs/packages.md) ·
+  [Provider authoring](docs/provider-authoring.md) ·
   [Projects](docs/projects.md) ·
   [Device deployment](docs/deployment-architecture.md) ·
   [Workflow schema](docs/workflow-schema.md) ·

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -34,7 +34,9 @@ When building a workflow:
    package index.
 3. Use `PythonFn` only for a small adapter owned by that one graph.
 4. If a reusable capability is genuinely missing, switch to
-   `blacknode-development` and add a core, custom, community, or package node.
+   `blacknode-development`. For hardware, transport, simulation, or replay
+   implementations, follow [Provider Authoring](provider-authoring.md); for
+   other behavior, add a core, custom, community, or package node.
 5. Test the new capability, then return to `blacknode-workflow` to build,
    validate, and run the final graph.
 
@@ -48,6 +50,13 @@ the device, and press **Software**. Enter the SSH password when the device is
 remote, press **Check updates**, then use **Update all** or the **Update**
 action on the Runtime or Hardware package card. Use the package card's
 **Restart** button when that service needs to restart.
+
+For a new remote computer that should remain unchanged, open **Add device →
+Remote SSH**, confirm its host key, and use **Confirm and inspect**. Review the
+read-only system and ROS 2 capability report, then choose **Close — device
+saved**. Use `ComputeDevice` → `DeviceInspect` in a workflow when the inspection
+snapshot should feed downstream graph nodes. Treat that snapshot as captured
+state; live streams and control require a managed provider.
 
 Agent instructions should point users to these controls for setup, package
 updates, restarts, deployment, and removal. SSH commands, `git pull`,
@@ -462,6 +471,8 @@ git status -sb
 - `python/blacknode/graph.py`: lazy graph execution engine.
 - `python/blacknode/node.py`: node decorator and port parsing.
 - `python/blacknode/nodes/*.py`: built-in node implementations and port definitions.
+- `docs/provider-authoring.md`: capability ownership, provider lifecycle,
+  profile binding, adapters, and compatibility tests.
 - `editor-server/server.py`: editor persistence, workflow routes, template routes.
 - `editor/src/components/TemplateGallery.tsx`: UI that lists and loads tracked templates.
 - `editor/src/api.ts`: frontend API client.

--- a/docs/managed-robot-attachments.md
+++ b/docs/managed-robot-attachments.md
@@ -6,6 +6,9 @@ capability, ROS 2 interfaces, frames, calibration, and mounting extrinsics.
 Workflows consume the stable capability and attachment ID; provider-specific
 topics and launch commands stay in the device configuration.
 
+See [Provider Authoring](provider-authoring.md) to add a provider component,
+bind it to a robot profile, and prove it against the shared contract.
+
 ## Lifecycle model
 
 An enabled attachment has an explicit managed-service lifecycle:
@@ -111,6 +114,30 @@ Manage robot
 
 Advanced provider and ROS fields stay collapsed. The robot summary shows only
 attachment count and health.
+
+## Build and promote an add-on
+
+An add-on moves through one consistent graph:
+
+```text
+mock or replay provider
+  → stable capability
+  → preview, health, and feature tests
+  → RobotAttachment
+  → RobotCapabilityProfile
+  → explicit RobotProfileSave
+```
+
+For depth cameras, open **Depth Camera Component Lab**. The graph runs with
+deterministic mock data, exercises the same `DepthCamera` contract used by the
+ROS 2 adapter, and creates a `depth_camera` attachment. Replace the test
+provider with `DepthROS2Subscribe` for the physical device; the obstacle
+feature, attachment, and robot profile connections remain stable.
+
+Use replay data during development and CI. Attachments are promoted only after
+freshness, interface, frame, identity, and mount-transform checks pass. Saving
+the profile is a separate visible action, so testing the component does not
+modify the managed robot.
 
 ## Streaming and remote clients
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -167,6 +167,10 @@ only — capability adapters depend on the integration layer, never the reverse
 reorganizing any capability package. Each capability package also ships its
 own on-robot colcon sources under `<package>/ros2_ws/src/`.
 
+For the end-to-end process of choosing a contract, implementing lifecycle and
+status, binding a robot profile, adding a mock or replay provider, and proving
+compatibility, see [Provider Authoring](provider-authoring.md).
+
 The `blacknode-skills/follow@ros2` CV2 local-reasoning template
 (camera and VLM nodes from `blacknode-perception`) routes target selection
 through the VLM:

--- a/docs/project-lifecycle.md
+++ b/docs/project-lifecycle.md
@@ -89,11 +89,27 @@ recovery when an editor action is unavailable.
 
 For remote SSH setup, choose **Add device → Remote SSH** and enter the
 computer's IP address, username, and password. Blacknode first displays the
-SSH host-key fingerprint for confirmation. After confirmation it installs the
-Runtime and Robot Hardware packages, configures runtime port `8766` in UFW when
-UFW is active, and pairs the Runtime with the editor. The Hardware environment
-is ready for connected-robot configuration and starts with motion disarmed. The
-SSH password remains in memory for that setup request and is not saved.
+SSH host-key fingerprint for confirmation. **Confirm and inspect** performs a
+read-only pre-install check of the operating system, accelerator, ROS 2
+installation, existing Runtime instances, occupied ports, and live ROS graph.
+ROS graph inspection lists topics, nodes, and services with transient
+`--no-daemon` queries; it does not publish messages, call services, start the
+ROS CLI daemon, or change device files and settings. The confirmed computer is
+saved as an **INSPECTED** read-only device, including its sanitized system and
+ROS 2 snapshot. Choose **Close — device saved** to end there.
+
+Open the **Inspect a Compute Device** template to use that snapshot in a graph.
+Select the computer on `ComputeDevice`; `DeviceInspect` then exposes the
+environment, ROS graph inventory, capability candidates, and unclassified
+interfaces. Saved workflows contain the stable device ID and public snapshot,
+never the SSH password or a pairing token.
+
+Installation remains a separate explicit action after the inspection report.
+It installs the Runtime and Robot Hardware packages, configures runtime port
+`8766` in UFW when UFW is active, and pairs the Runtime with the editor. The
+Hardware environment is ready for connected-robot configuration and starts
+with motion disarmed. The SSH password remains in memory for that request and
+is not saved.
 
 Managed Linux installations use one visible root per stable Runtime instance:
 

--- a/docs/provider-authoring.md
+++ b/docs/provider-authoring.md
@@ -1,0 +1,366 @@
+# Provider Authoring
+
+Blacknode connects workflows to replaceable hardware, services, simulators, and
+transports through stable capabilities. A workflow asks for a capability such
+as `camera`, `mobile_base`, or `joint_group`; a robot profile binds that
+capability to an installed package component and optional adapter.
+
+Use this guide when adding a new physical device, vendor SDK, ROS 2 driver,
+simulator, replay source, or alternative implementation of an existing
+capability.
+
+## The provider model
+
+```text
+Workflow or skill
+       |
+       v
+Stable capability contract
+       |
+       v
+Robot-profile capability binding
+       |
+       v
+Provider component + optional adapter
+       |
+       v
+Vendor SDK, ROS 2 graph, service, simulator, or replay
+```
+
+The terms have distinct meanings:
+
+| Term | Meaning |
+|---|---|
+| Capability | A stable behavior or data contract consumed by workflows, such as `camera`, `mobile_base`, or `joint_group`. |
+| Contract | The normalized commands, state, lifecycle, status, errors, timestamps, and units shared by compatible providers. |
+| Provider | One implementation of a capability for concrete hardware, a service, simulation, or replay. |
+| Adapter | An optional integration boundary, such as ROS 2, nested under the component that owns the domain capability. |
+| Binding | The robot-profile record that selects a provider package, component, optional adapter, configuration, and hardware identity. |
+| Node | A typed workflow operation. A provider may expose nodes, but the provider and node are not the same abstraction. |
+
+Manifest capabilities describe what an installable component supplies. Robot
+profile capabilities describe what the configured robot can do. Keep both
+stable, but do not assume their identifiers are interchangeable.
+
+## Choose the owner first
+
+Add the provider to the narrowest package that owns the capability:
+
+| Provider responsibility | Owner |
+|---|---|
+| Robot profiles, capability bindings, calibration identity, normalized device state | `blacknode-robot` |
+| Concrete device protocols, vendor SDKs, firmware bridges, serial, CAN, USB, or I2C access | `blacknode-drivers` |
+| Camera, depth, LiDAR, IMU, tracking, or other perception behavior | `blacknode-perception` |
+| Arm, base, navigation, policy, arbitration, or motion safety | `blacknode-motion` |
+| ROS 2 graph, topic, service, process, and diagnostic primitives | `blacknode-ros2` |
+| Simulator-specific implementation | The simulator package, such as `blacknode-isaac` |
+| Reusable task behavior over capabilities | `blacknode-skills` |
+
+A domain node that uses ROS 2 stays with its domain. For example, a camera ROS
+2 provider belongs under `blacknode-perception/camera`, while generic topic and
+process primitives belong in `blacknode-ros2`. Domain adapters depend on the
+integration layer; the integration layer does not depend on domain packages.
+
+Create a separate extension package when the implementation introduces a new
+vendor SDK, hardware stack, large optional dependency, or independently
+versioned provider family. Keep a small workflow-local conversion in
+`PythonFn` only when it is not reusable.
+
+## Find or define the contract
+
+Inspect the live contract before writing provider code. Current robot device
+contracts include:
+
+- [`DeviceState`, `JointState`, `FaultState`, and `MobileBaseProvider`](../packages/blacknode-robot/blacknode_robot/devices/contracts.py)
+- [`JointGroupState`, `JointGroupCommand`, and `JointGroupProvider`](../packages/blacknode-robot/blacknode_robot/devices/joint_group.py)
+- capability bindings and status normalization in
+  [`capabilities.py`](../packages/blacknode-robot/nodes/capabilities.py)
+- attachment lifecycle and interface requirements in
+  [Managed robot attachments](managed-robot-attachments.md)
+
+Provider contracts are capability-specific. Blacknode does not define one
+universal Python `Provider` class. An implementation may be:
+
+1. An in-process object implementing a capability `Protocol`.
+2. A managed process or ROS 2 launch whose interfaces are described by an
+   attachment or driver descriptor.
+3. A capability-specific registration hook defined by the owning package.
+4. A simulator or replay implementation returning the same normalized
+   contract.
+
+If the capability has no reusable contract, add the transport-neutral contract
+to its owning package first. Include a mock or replay provider and contract
+tests before adding vendor-specific behavior. Applications and workflows must
+not import a provider class directly.
+
+## Scaffold the extension
+
+An independently versioned provider package normally has this shape:
+
+```text
+blacknode-example/
+  blacknode-package.toml
+  AGENTS.md
+  README.md
+  components/
+    device-family/
+      nodes/
+        __init__.py
+        provider.py
+      adapters/
+        ros2/
+          nodes/
+            __init__.py
+          ros2_ws/          # only when this package owns colcon sources
+  templates/
+  tests/
+  requirements.txt         # optional
+```
+
+Start from `blacknode-cuda` for a small flat package or `blacknode-drivers` for
+a component and adapter package. Package worktrees under `packages/` are
+independent Git repositories and use their own `AGENTS.md`.
+
+## Implement the provider
+
+Use the exact methods and normalized state type declared by the capability
+contract. The existing mobile-base contract, for example, requires `state`,
+`arm`, `disarm`, `command`, and `stop`. Its I2C reference implementation is
+[`I2CMecanumBase`](../packages/blacknode-robot/blacknode_robot/devices/adapters/i2c_mecanum.py).
+
+Every hardware provider must preserve these common behaviors:
+
+- Import optional SDKs only when the provider is used. Package discovery must
+  still work when the hardware library, ROS installation, or device is absent.
+- Keep discovery and checking read-only. Never start a provider or authorize
+  motion as a side effect of inspection.
+- Start explicitly and idempotently. Repeating the same start request should
+  reuse or safely reconcile the service.
+- Return normalized state, units, timestamps, freshness, faults, and hardware
+  identity defined by the contract.
+- Treat communication presence and hardware health separately. Valid telemetry
+  may coexist with a warning; motion authorization remains strict.
+- Stop explicitly and idempotently. Stop the complete managed process group and
+  place hardware in the contract's safe shutdown state.
+- Return a structured unavailable or unhealthy status with an actionable
+  reason. Do not raise during package import or break unrelated capabilities.
+
+Persistent streams, controllers, subscriptions, and launched drivers are
+managed services. A workflow cook may start or update one service, but it must
+not become a polling loop.
+
+## Declare the component
+
+Declare only implemented capabilities. A component becomes public after its
+implementation, dependencies, lifecycle, unavailable state, and tests exist.
+
+```toml
+[package]
+name = "blacknode-example"
+version = "0.1.0"
+description = "Example hardware provider for Blacknode."
+requires-blacknode = ">=0.3.0"
+layer = "drivers"
+component-mode = true
+
+[components.device-family]
+description = "Concrete example device provider."
+default = false
+capabilities = ["driver.example-device"]
+nodes = ["components/device-family/nodes"]
+node-types = ["ExampleDeviceCheck"]
+
+[components.device-family.dependencies]
+pip = ["example-sdk>=1"]
+imports = ["example_sdk"]
+
+[components.device-family.adapters.ros2]
+description = "ROS 2 adapter for the example device."
+default = false
+capabilities = ["adapter.example-device.ros2"]
+nodes = ["components/device-family/adapters/ros2/nodes"]
+
+[components.device-family.adapters.ros2.dependencies]
+requires = [
+  { package = "blacknode-ros2", component = "core", version = ">=0.5.0,<1.0.0" }
+]
+```
+
+Use the established capability identifier from the owning package when one
+exists. Do not publish placeholder components or planned capabilities in the
+manifest.
+
+If the package owns a colcon workspace, declare its relative path on the
+component or adapter:
+
+```toml
+ros2-workspaces = ["components/device-family/adapters/ros2/ros2_ws"]
+```
+
+The path must remain inside the package. `build/`, `install/`, and `log/` are
+generated artifacts and must not be committed. An external robot workspace is
+part of device deployment configuration; do not escape the package with an
+absolute manifest path.
+
+## Connect the binding to the implementation
+
+The manifest makes provider code loadable, and the robot profile selects a
+package/component/adapter. Neither operation starts hardware by itself. The
+capability-owning package supplies the resolver that connects that binding to
+an implementation.
+
+Use the resolver already defined by the capability:
+
+- Calibration control discovers capability-specific provider registrations and
+  opens the implementation selected by the profile.
+- Servo motion discovers `_bn_robot_joint_motion_provider` registrations and
+  opens only the package/component selected by the profile's `joint_group`,
+  `calibration_control`, or `position_feedback` binding. A session supplies
+  `sample()`, `hold()`, `command(positions_deg, deadline=...)`, `release()`,
+  and `close()`. `hold()` seeds every configured joint from current feedback
+  before torque; `command()` verifies freshness, torque, and hardware health at
+  the physical driver boundary.
+- Managed attachments synchronize the selected package, build a process
+  descriptor from provider configuration, and ask Runtime to start or reuse it.
+- Existing-topic providers remain read-only and use ROS interface checks as
+  their live provider status.
+- In-process device facades construct an object that implements their declared
+  capability `Protocol`.
+
+When a new capability has no resolver, add one to the owning domain package. It
+must read the normalized binding, merge provider configuration explicitly,
+match only the requested package/component/adapter, return structured
+unavailable status when no implementation matches, and start hardware only
+after an explicit action. Keep provider selection out of the editor server and
+workflow-specific code.
+
+## Bind the provider to a robot
+
+Robot profiles select providers through a versioned capability binding:
+
+```json
+{
+  "kind": "blacknode.robot-capability-binding",
+  "schema_version": 1,
+  "capability": "camera",
+  "provider": {
+    "package": "blacknode-perception",
+    "component": "camera",
+    "adapter": "ros2"
+  },
+  "configuration": {
+    "ros2_interfaces": [
+      {
+        "kind": "topic",
+        "direction": "output",
+        "topic": "/camera/image_raw",
+        "message_type": "sensor_msgs/msg/Image",
+        "frame_id": "camera_link"
+      }
+    ]
+  },
+  "hardware_identity": {
+    "id": "camera-serial-123"
+  },
+  "required": true
+}
+```
+
+Use `RobotCapabilityBinding`, `RobotAttachment`, and
+`RobotCapabilityProfile` to create these records visually. Configuration may
+change when a provider changes; the semantic capability and downstream
+workflow ports remain stable.
+
+Calibration, limits, and sensor extrinsics bind to stable physical hardware
+identity. Do not bind them only to a component, device path, or enumeration
+index.
+
+## Add ROS 2 behavior
+
+Choose one lifecycle owner for each ROS process:
+
+- **Existing topics:** inspect and consume a provider already started by the
+  robot's bringup stack.
+- **Blacknode-managed process:** start it explicitly through Runtime and
+  `blacknode-ros2` process primitives, then verify required interfaces and
+  freshness.
+
+Do not start a second copy of an existing driver. A ROS transport reconnect
+must not restart healthy physical hardware.
+
+Keep topic names, message types, frames, launch arguments, and provider
+configuration behind the binding or attachment. Workflows consume normalized
+capabilities instead of vendor topic names.
+
+## Expose workflow nodes and templates
+
+Add typed nodes only for useful operator or workflow actions:
+
+- A read-only discovery or check node.
+- A generic capability facade or status node.
+- An explicit managed-service start/stop node when the owning package defines
+  that lifecycle.
+- Advanced adapter nodes when direct ROS or vendor configuration is useful.
+
+Use semantic public names. Keep vendor, SDK, device-path, and transport details
+inside the component or under advanced controls. Preserve old public node names
+as compatibility aliases when saved workflows may use them.
+
+Add a minimal template that proves package resolution, provider configuration,
+status, and safe stop behavior. Declare `metadata.required_packages`,
+`metadata.required_components`, and `metadata.required_adapters` as applicable.
+
+## Prove compatibility
+
+Run one shared contract suite against the mock or replay provider and every
+supported real provider. Cover:
+
+- package discovery with optional dependencies absent;
+- structured unavailable state when the SDK, ROS graph, permission, or device
+  is missing;
+- normalized state shape, units, timestamps, faults, and hardware identity;
+- repeated start, reconnect, command, stop, and shutdown behavior;
+- worker heartbeat separately from source-data freshness;
+- wrong or stale hardware identity;
+- malformed configuration and bounded error/log payloads;
+- provider-specific safeguards at the physical boundary;
+- template validation and one representative workflow.
+
+Motion providers additionally test disarmed startup, current-pose
+synchronization before torque, command expiry, calibrated limits, emergency
+stop, and torque release. Hardware-free tests do not establish physical safety;
+report the exact hardware paths exercised.
+
+Use the target package's `AGENTS.md` for its focused test command. When shared
+core contracts change, also run:
+
+```powershell
+python -m unittest discover -s tests
+```
+
+Validate package templates from the repository root:
+
+```powershell
+Get-ChildItem packages\<package>\templates\*.json |
+  ForEach-Object { blacknode validate $_.FullName }
+```
+
+## Definition of done
+
+A provider is complete when:
+
+- the owning capability contract remains transport- and vendor-neutral;
+- package discovery works when the provider is absent;
+- the manifest declares only implemented components and dependencies;
+- a robot profile can bind configuration and stable hardware identity;
+- status distinguishes available, unavailable, and unhealthy;
+- start, reconnect, stop, and shutdown are explicit and testable;
+- a mock or replay provider passes the same contract suite;
+- a validated template demonstrates the provider;
+- the package README documents configuration, lifecycle, outputs, dependencies,
+  and hardware verification.
+
+See [Extension Packages](packages.md), [Custom Nodes](custom-nodes.md),
+[Managed robot attachments](managed-robot-attachments.md), and
+[Modular Device Deployment](deployment-architecture.md) for the supporting
+package, node, attachment, and deployment contracts.

--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -30,6 +30,7 @@ import json
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import urllib.request
@@ -210,6 +211,90 @@ def host_environment():
         "runtime_setup_packages": ["git", "python3-pip", "python3-venv"],
     }
 
+def ros2_graph(environment):
+    # Inspect the live graph without starting the persistent ROS 2 CLI daemon.
+    ros = environment.get("ros2") or {}
+    selected = str(ros.get("selected_distribution") or "")
+    report = {
+        "available": False,
+        "state": "unavailable",
+        "distribution": selected,
+        "domain_id": str(os.environ.get("ROS_DOMAIN_ID") or "0"),
+        "read_only": True,
+        "daemon_used": False,
+        "topics": [],
+        "nodes": [],
+        "services": [],
+        "errors": [],
+    }
+    if not ros.get("available") or not selected:
+        report["errors"].append("ROS 2 was not detected on this computer.")
+        return report
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", selected):
+        report["errors"].append("The selected ROS 2 distribution name is invalid.")
+        return report
+    setup = Path("/opt/ros") / selected / "setup.bash"
+    if not setup.is_file():
+        report["errors"].append(
+            f"ROS 2 setup was not found at {setup}."
+        )
+        return report
+
+    def ros_command(arguments, timeout=15.0):
+        invocation = " ".join(
+            shlex.quote(str(value))
+            for value in ["ros2", *arguments]
+        )
+        shell = (
+            f"source {shlex.quote(str(setup))} >/dev/null 2>&1"
+            f" && {invocation}"
+        )
+        return command(["bash", "-c", shell], timeout=timeout)
+
+    help_result = ros_command(["topic", "list", "--help"])
+    if "--no-daemon" not in (help_result.stdout + help_result.stderr):
+        report["state"] = "unsupported"
+        report["errors"].append(
+            "This ROS 2 CLI cannot inspect the graph without starting its "
+            "background daemon, so Blacknode skipped graph discovery."
+        )
+        return report
+
+    commands = {
+        "topics": ["topic", "list", "-t", "--no-daemon"],
+        "nodes": ["node", "list", "--no-daemon"],
+        "services": ["service", "list", "-t", "--no-daemon"],
+    }
+    succeeded = 0
+    for key, arguments in commands.items():
+        result = ros_command(arguments)
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            report["errors"].append(
+                f"{key} inventory failed"
+                + (f": {detail[:300]}" if detail else ".")
+            )
+            continue
+        report[key] = [
+            line.strip()[:512]
+            for line in result.stdout.splitlines()
+            if line.strip()
+        ][:2000]
+        succeeded += 1
+    report["available"] = succeeded > 0
+    report["state"] = (
+        "available"
+        if succeeded == len(commands)
+        else "partial"
+        if succeeded
+        else "unavailable"
+    )
+    if report["available"] and not any(
+        report[key] for key in ("topics", "nodes", "services")
+    ):
+        report["state"] = "empty"
+    return report
+
 ids = {"default"}
 organized_root = home / "Blacknode" / "devices"
 legacy_side_root = home / "blacknode-runtimes"
@@ -311,9 +396,11 @@ used_ids = {item["instance_id"] for item in instances}
 counter = 2
 while f"instance-{counter}" in used_ids:
     counter += 1
+environment = host_environment()
 print("__BLACKNODE_RUNTIME_INSPECTION__=" + json.dumps({
     "instances": instances,
-    "environment": host_environment(),
+    "environment": environment,
+    "ros2_graph": ros2_graph(environment),
     "used_ports": sorted(used),
     "suggested_port": suggested_port,
     "suggested_instance_id": f"instance-{counter}",
@@ -579,6 +666,11 @@ def _public_inspection(payload: dict[str, Any]) -> dict[str, Any]:
             for key, value in item.items()
             if not str(key).startswith("_")
         })
+    ros2_graph = (
+        payload.get("ros2_graph")
+        if isinstance(payload.get("ros2_graph"), dict)
+        else {}
+    )
     return {
         "ok": True,
         "instances": instances,
@@ -587,6 +679,34 @@ def _public_inspection(payload: dict[str, Any]) -> dict[str, Any]:
             if isinstance(payload.get("environment"), dict)
             else {}
         ),
+        "ros2_graph": {
+            "available": bool(ros2_graph.get("available")),
+            "state": str(ros2_graph.get("state") or "unavailable")[:32],
+            "distribution": str(ros2_graph.get("distribution") or "")[:64],
+            "domain_id": str(ros2_graph.get("domain_id") or "0")[:32],
+            "read_only": True,
+            "daemon_used": False,
+            "topics": [
+                str(value or "")[:512]
+                for value in (ros2_graph.get("topics") or [])
+                if str(value or "").strip()
+            ][:2000],
+            "nodes": [
+                str(value or "")[:512]
+                for value in (ros2_graph.get("nodes") or [])
+                if str(value or "").strip()
+            ][:2000],
+            "services": [
+                str(value or "")[:512]
+                for value in (ros2_graph.get("services") or [])
+                if str(value or "").strip()
+            ][:2000],
+            "errors": [
+                str(value or "")[:500]
+                for value in (ros2_graph.get("errors") or [])
+                if str(value or "").strip()
+            ][:20],
+        },
         "suggested_port": int(payload.get("suggested_port") or 0),
         "suggested_instance_id": str(payload.get("suggested_instance_id") or "instance-2"),
     }

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -777,7 +777,90 @@ class DeviceRegistry:
             host = hosts.get(host_id)
             if host is None:
                 raise KeyError(host_id)
+            if host.get("inspection_only"):
+                raise DeviceRegistryError(
+                    "This compute device is registered for read-only inspection. "
+                    "Install or pair Blacknode Runtime before using runtime APIs."
+                )
             return RuntimeDeviceClient(host["runtime_url"], host["runtime_token"])
+
+    def register_inspection_host(
+        self,
+        *,
+        name: str,
+        runtime_url: str,
+        ssh_host: str,
+        ssh_port: int,
+        ssh_username: str,
+        host_fingerprint: str,
+        inspection: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Persist a credential-free SSH inspection target for graph selection."""
+        clean_url = normalize_base_url(runtime_url)
+        clean_host = str(ssh_host or "").strip()
+        clean_username = str(ssh_username or "").strip()
+        clean_fingerprint = str(host_fingerprint or "").strip()
+        if not clean_host or not clean_username or not clean_fingerprint:
+            raise DeviceRegistryError(
+                "SSH host, username, and confirmed host fingerprint are required."
+            )
+        try:
+            clean_port = int(ssh_port)
+        except (TypeError, ValueError) as exc:
+            raise DeviceRegistryError("SSH port must be a number.") from exc
+        if not 1 <= clean_port <= 65535:
+            raise DeviceRegistryError("SSH port must be between 1 and 65535.")
+        snapshot = json.loads(json.dumps(inspection))
+        now = _iso_now()
+        with self._lock:
+            hosts, records = self._load_payload()
+            hosts, _changed = self._materialize_hosts(hosts, records)
+            existing = next(
+                (item for item in hosts.values() if item.get("runtime_url") == clean_url),
+                None,
+            )
+            host_id = existing["id"] if existing else _host_id(clean_url)
+            host = {
+                "id": host_id,
+                "name": (
+                    str(name or "").strip()
+                    or str(snapshot.get("hostname") or "").strip()
+                    or clean_host
+                ),
+                "runtime_url": clean_url,
+                "runtime_token": str((existing or {}).get("runtime_token") or ""),
+                "runtime_token_fingerprint": str(
+                    (existing or {}).get("runtime_token_fingerprint") or ""
+                ),
+                "remote_device_id": str(
+                    (existing or {}).get("remote_device_id") or ""
+                ),
+                "paused": bool((existing or {}).get("paused", False)),
+                "inspection_only": not bool(
+                    (existing or {}).get("runtime_token")
+                ),
+                "inspection_connection": {
+                    "ssh_host": clean_host,
+                    "ssh_port": clean_port,
+                    "ssh_username": clean_username,
+                    "host_fingerprint": clean_fingerprint,
+                },
+                "last_inspection": snapshot,
+                "inspection_updated_at": now,
+                "created_at": str((existing or {}).get("created_at") or now),
+                "updated_at": now,
+            }
+            if (existing or {}).get("managed_runtime"):
+                host["managed_runtime"] = dict(existing["managed_runtime"])
+            hosts[host_id] = host
+            self._save_payload(hosts, records)
+            public = self._public_host(host)
+            public["robots"] = [
+                self._public(record)
+                for record in records.values()
+                if str(record.get("host_id") or "") == host_id
+            ]
+            return public
 
     def pair_host(
         self,
@@ -807,6 +890,48 @@ class DeviceRegistry:
                 (item for item in hosts.values() if item.get("runtime_url") == clean_url),
                 None,
             )
+            if existing is None and managed_runtime:
+                requested_identity = (
+                    str(managed_runtime.get("ssh_host") or "").strip(),
+                    int(managed_runtime.get("ssh_port") or 22),
+                    str(managed_runtime.get("ssh_username") or "").strip(),
+                    str(managed_runtime.get("host_fingerprint") or "").strip(),
+                )
+                existing = next(
+                    (
+                        item
+                        for item in hosts.values()
+                        if item.get("inspection_only")
+                        and (
+                            str(
+                                (item.get("inspection_connection") or {}).get(
+                                    "ssh_host"
+                                )
+                                or ""
+                            ).strip(),
+                            int(
+                                (item.get("inspection_connection") or {}).get(
+                                    "ssh_port"
+                                )
+                                or 22
+                            ),
+                            str(
+                                (item.get("inspection_connection") or {}).get(
+                                    "ssh_username"
+                                )
+                                or ""
+                            ).strip(),
+                            str(
+                                (item.get("inspection_connection") or {}).get(
+                                    "host_fingerprint"
+                                )
+                                or ""
+                            ).strip(),
+                        )
+                        == requested_identity
+                    ),
+                    None,
+                )
             now = _iso_now()
             host_id = existing["id"] if existing else _host_id(clean_url)
             created_at = existing.get("created_at") if existing else now
@@ -855,9 +980,19 @@ class DeviceRegistry:
                 "runtime_token_fingerprint": token_fingerprint(clean_token),
                 "remote_device_id": remote_id,
                 "paused": False,
+                "inspection_only": False,
                 "created_at": created_at or now,
                 "updated_at": now,
             }
+            if (existing or {}).get("last_inspection"):
+                host["last_inspection"] = dict(existing["last_inspection"])
+                host["inspection_updated_at"] = str(
+                    existing.get("inspection_updated_at") or ""
+                )
+            if (existing or {}).get("inspection_connection"):
+                host["inspection_connection"] = dict(
+                    existing["inspection_connection"]
+                )
             if management:
                 host["managed_runtime"] = management
             hosts[host_id] = host

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -1,6 +1,6 @@
 """Blacknode editor backend — FastAPI server the React editor talks to."""
 from __future__ import annotations
-import asyncio, uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex, hashlib, math
+import asyncio, uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex, hashlib, math, copy
 import urllib.error, urllib.parse, urllib.request
 from datetime import datetime
 from pathlib import Path
@@ -291,6 +291,7 @@ class UpdateParamReq(BaseModel):
 
 class NodeControlReq(BaseModel):
     action: str
+    payload: dict[str, Any] = Field(default_factory=dict)
 
 class PickDirectoryReq(BaseModel):
     initial_path: str = ""
@@ -463,6 +464,8 @@ class SshDeviceReq(SshProbeReq):
 
 class InspectDeviceHostReq(SshDeviceReq):
     host_fingerprint: str
+    name: str = ""
+    save_inspection: bool = False
 
 class InstallDeviceHostReq(InspectDeviceHostReq):
     name: str = ""
@@ -618,6 +621,8 @@ _RUNTIME_MODULES = {
     "ros2": "blacknode.pkg.blacknode_ros2.ros2_runtime",
     "ros2_live": "blacknode.pkg.blacknode_skills.follow.leader_follower_runtime",
     "joint_control": "blacknode.pkg.blacknode_motion.arm.adapters.ros2.joint_motion",
+    "robot_servo_motion": "blacknode.pkg.blacknode_motion.arm.servo_control",
+    "robot_calibration_control": "blacknode.pkg.blacknode_robot.calibration_control",
     "vision": "blacknode.pkg.blacknode_perception.cv2_runtime",
     "cuda": "blacknode.pkg.blacknode_cuda.cuda_stream_runtime",
     "robot": "blacknode.pkg.blacknode_robot.robot",
@@ -634,6 +639,7 @@ _RUNTIME_REGISTRY_ANCHORS = {
     "robot": "RobotDriverLauncher",
     "isaac": "IsaacPolicyBridge",
     "joint_control": "ROS2ManualMove",
+    "robot_calibration_control": "RobotCalibrationControl",
 }
 
 _RUNTIME_CALLABLE_ALIASES = {
@@ -1444,10 +1450,34 @@ def _node_def_payload(name: str, fn: Any) -> dict[str, Any]:
 
 @app.get("/node-defs")
 def list_node_defs():
-    return {
+    definitions = {
         name: _node_def_payload(name, fn)
         for name, fn in sorted(_NODE_REGISTRY.items())
     }
+    # Enum metadata is captured when a package module loads, but robot profiles
+    # can be created while the editor is running. Refresh Robot's choices from
+    # disk for every schema request so Properties and other schema consumers do
+    # not require a server restart to discover a newly saved profile.
+    robot_definition = definitions.get("Robot")
+    if isinstance(robot_definition, dict):
+        try:
+            profile_ids = [
+                str(profile.get("id") or "").strip()
+                for profile in _available_robot_profiles({
+                    "node_meta": _session.node_meta,
+                })
+                if str(profile.get("id") or "").strip() not in {"", "auto"}
+            ]
+        except (OSError, ValueError):
+            profile_ids = []
+        if profile_ids:
+            input_choices = {
+                key: list(values)
+                for key, values in (robot_definition.get("input_choices") or {}).items()
+            }
+            input_choices["profile_id"] = profile_ids
+            robot_definition["input_choices"] = input_choices
+    return definitions
 
 @app.get("/graph")
 def get_graph():
@@ -1594,6 +1624,14 @@ def add_node(req: AddNodeReq):
 def remove_node(node_id: str):
     if node_id not in _session.node_meta:
         raise HTTPException(404, "Node not found")
+    if _session.node_meta[node_id].get("type") == "RobotServo":
+        disarm = _runtime_callable(
+            "robot_servo_motion",
+            _RUNTIME_MODULES["robot_servo_motion"],
+            "disarm_servo_motion",
+        )
+        if disarm is not None:
+            disarm(f"robot-servo:{node_id}")
     del _session.node_meta[node_id]
     _session.graph._edges = [
         e for e in _session.graph._edges
@@ -1611,6 +1649,18 @@ def update_param(node_id: str, req: UpdateParamReq):
         raise HTTPException(404, "Node not found")
     meta = _session.node_meta[node_id]
     old_params = dict(meta.get("params", {}))
+    if (
+        meta.get("type") == "RobotServo"
+        and req.key in {"robot_id", "profile_id", "servo_id", "joint_name", "units"}
+        and old_params.get(req.key) != req.value
+    ):
+        disarm = _runtime_callable(
+            "robot_servo_motion",
+            _RUNTIME_MODULES["robot_servo_motion"],
+            "disarm_servo_motion",
+        )
+        if disarm is not None:
+            disarm(f"robot-servo:{node_id}")
     meta["params"][req.key] = req.value
     _session.graph._nodes[node_id]["params"][req.key] = req.value
     _session.graph._mark_dirty(node_id)
@@ -1651,6 +1701,157 @@ def control_node(node_id: str, req: NodeControlReq):
     meta = _session.node_meta.get(node_id)
     if meta is None:
         raise HTTPException(404, "Node not found")
+    if meta.get("type") == "RobotServo":
+        action = str(req.action or "").strip().lower()
+        if action not in {"arm", "disarm", "joint-command", "status"}:
+            raise HTTPException(
+                400,
+                "RobotServo supports arm, disarm, joint-command, or status",
+            )
+        run_id = f"robot-servo:{node_id}"
+        function_name = {
+            "arm": "arm_servo_motion",
+            "disarm": "disarm_servo_motion",
+            "joint-command": "command_servo_motion",
+            "status": "servo_motion_status",
+        }[action]
+        control_fn = _runtime_callable(
+            "robot_servo_motion",
+            _RUNTIME_MODULES["robot_servo_motion"],
+            function_name,
+        )
+        if control_fn is None:
+            raise HTTPException(503, "blacknode-motion Servo control is not loaded")
+
+        def reject_servo_command(detail: str) -> None:
+            disarm_fn = _runtime_callable(
+                "robot_servo_motion",
+                _RUNTIME_MODULES["robot_servo_motion"],
+                "disarm_servo_motion",
+            )
+            if disarm_fn is not None:
+                try:
+                    disarm_fn(run_id)
+                except Exception:
+                    pass
+            raise HTTPException(409, detail)
+
+        try:
+            if action == "arm":
+                robot_id = str(req.payload.get("robot_id") or "").strip()
+                profile_id = _monitor_profile_selection(
+                    req.payload.get("profile_id")
+                    or meta.get("params", {}).get("profile_id")
+                )
+                if not robot_id.startswith("local-usb-"):
+                    raise HTTPException(
+                        409,
+                        "Standalone Servo motion currently requires a Local USB robot target",
+                    )
+                target = _local_robot_monitor_target(robot_id, profile_id)
+                if target is None or not target.get("available"):
+                    raise HTTPException(409, "The selected Local USB robot is unavailable")
+                if target.get("raw_mode"):
+                    raise HTTPException(409, "Select a calibrated robot profile before motion")
+                profile = dict(target.get("profile") or {})
+                calibration = dict(target.get("calibration") or {})
+                result = dict(control_fn(run_id, {
+                    "robot_id": robot_id,
+                    "profile": profile,
+                    "hardware": dict(target.get("hardware") or {}),
+                    "hardware_id": str(target.get("hardware_id") or ""),
+                    "calibration": calibration,
+                }))
+            elif action == "joint-command":
+                command = (
+                    dict(req.payload.get("command") or {})
+                    if isinstance(req.payload.get("command"), dict)
+                    else {}
+                )
+                try:
+                    servo_id = int(meta.get("params", {}).get("servo_id") or 1)
+                    command_servo_id = int(command.get("servo_id") or 0)
+                except (TypeError, ValueError):
+                    reject_servo_command("Servo command has an invalid ID")
+                joint_name = str(meta.get("params", {}).get("joint_name") or "").strip()
+                if command_servo_id != servo_id:
+                    reject_servo_command("Servo command ID does not match this node")
+                if not joint_name or str(command.get("joint_name") or "") != joint_name:
+                    reject_servo_command(
+                        "Servo command joint does not match live telemetry"
+                    )
+                result = dict(control_fn(run_id, command))
+            else:
+                result = dict(control_fn(run_id))
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(409, str(exc)) from exc
+        if not result.get("ok", False):
+            raise HTTPException(409, str(result.get("report") or "Servo motion was blocked"))
+        outputs = {
+            key: value
+            for key, value in result.items()
+            if key != "ok"
+        }
+        return {"ok": True, "node_id": node_id, "outputs": outputs}
+    if meta.get("type") == "ROS2JointSliders":
+        if req.action != "joint-command":
+            raise HTTPException(400, "ROS2JointSliders supports the joint-command control")
+        source_id = str(req.payload.get("source_node_id") or "").strip()
+        source_meta = _session.node_meta.get(source_id)
+        if source_meta is None or source_meta.get("type") != "RobotServo":
+            raise HTTPException(409, "Connect a RobotServo command output before moving")
+        connected = any(
+            edge.get("from") == source_id
+            and edge.get("from_port") == "command"
+            and edge.get("to") == node_id
+            and edge.get("to_port") == "command"
+            for edge in _session.graph._edges
+        )
+        if not connected:
+            raise HTTPException(
+                409,
+                "Connect RobotServo.command to ROS2JointSliders.command before moving",
+            )
+        command = (
+            dict(req.payload.get("command") or {})
+            if isinstance(req.payload.get("command"), dict)
+            else {}
+        )
+        source_params = dict(source_meta.get("params") or {})
+        try:
+            source_servo_id = int(source_params.get("servo_id") or 1)
+            command_servo_id = int(command.get("servo_id") or 0)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(409, "The Servo command has an invalid servo ID") from exc
+        if command_servo_id != source_servo_id:
+            raise HTTPException(409, "The Servo command does not match the connected Servo ID")
+        source_joint = str(source_params.get("joint_name") or "").strip()
+        command_joint = str(command.get("joint_name") or "").strip()
+        if not source_joint or command_joint != source_joint:
+            raise HTTPException(
+                409,
+                "The Servo joint identity is not synchronized with its live telemetry",
+            )
+        control_fn = _runtime_callable(
+            "joint_control",
+            _RUNTIME_MODULES["joint_control"],
+            "set_joint_slider_command",
+        )
+        if control_fn is None:
+            raise HTTPException(503, "blacknode-motion live joint control is not loaded")
+        run_id = str(meta.get("params", {}).get("run_id") or "joint_sliders").strip() or "joint_sliders"
+        result = dict(control_fn(run_id, command))
+        if not result.get("ok", False):
+            raise HTTPException(409, str(result.get("report") or "Joint command was blocked"))
+        outputs = {
+            "commanded": bool(result.get("commanded")),
+            "report": str(result.get("report") or "Joint command accepted"),
+        }
+        for port, value in outputs.items():
+            _session.graph._cache[(node_id, port)] = value
+        return {"ok": True, "node_id": node_id, "outputs": outputs}
     if meta.get("type") == "TrajectorySmoother":
         if req.action != "apply":
             raise HTTPException(400, "TrajectorySmoother supports the apply control")
@@ -3255,17 +3456,113 @@ def probe_device_host_ssh(req: SshProbeReq):
         raise HTTPException(400, str(exc)) from exc
 
 
+def _classify_inspected_ros2_graph(
+    inspection: dict[str, Any],
+) -> dict[str, Any]:
+    graph = (
+        dict(inspection.get("ros2_graph") or {})
+        if isinstance(inspection.get("ros2_graph"), dict)
+        else {}
+    )
+    topics = list(graph.get("topics") or [])
+    nodes = list(graph.get("nodes") or [])
+    services = list(graph.get("services") or [])
+    graph.setdefault("available", False)
+    graph.setdefault("state", "unavailable")
+    graph.setdefault("read_only", True)
+    graph.setdefault("daemon_used", False)
+    graph.setdefault("errors", [])
+    graph.update({
+        "found": False,
+        "capabilities": [],
+        "unclassified": [],
+        "inventory": {
+            "topics": topics,
+            "nodes": nodes,
+            "services": services,
+        },
+        "report": "",
+    })
+    if not graph["available"]:
+        errors = [
+            str(value or "").strip()
+            for value in graph.get("errors", [])
+            if str(value or "").strip()
+        ]
+        graph["report"] = (
+            errors[0]
+            if errors
+            else "The remote ROS 2 graph is unavailable."
+        )
+        inspection["ros2_graph"] = graph
+        return inspection
+
+    discover = _NODE_REGISTRY.get("RobotROSCapabilityDiscover")
+    if not callable(discover):
+        graph["report"] = (
+            "The ROS 2 graph was read successfully. Enable the "
+            "blacknode-robot capabilities component to classify it."
+        )
+        inspection["ros2_graph"] = graph
+        return inspection
+    try:
+        classified = discover({
+            "topics": topics,
+            "nodes": nodes,
+            "services": services,
+        })
+    except Exception as exc:
+        graph["errors"] = [
+            *list(graph.get("errors") or []),
+            f"Capability classification failed: {exc}",
+        ]
+        graph["report"] = (
+            "The ROS 2 graph was read, but capability classification failed."
+        )
+        inspection["ros2_graph"] = graph
+        return inspection
+    if isinstance(classified, dict):
+        graph.update({
+            key: classified.get(key)
+            for key in (
+                "found",
+                "capabilities",
+                "unclassified",
+                "inventory",
+                "report",
+            )
+        })
+    inspection["ros2_graph"] = graph
+    return inspection
+
+
 @app.post("/device-hosts/inspect")
 def inspect_device_host(req: InspectDeviceHostReq):
     try:
-        return inspect_runtime(
+        inspection = inspect_runtime(
             host=req.host,
             port=req.port,
             username=req.username,
             password=req.password,
             host_fingerprint=req.host_fingerprint,
         )
-    except DeviceInstallError as exc:
+        inspection = _classify_inspected_ros2_graph(inspection)
+        if req.save_inspection:
+            runtime_host = f"[{req.host}]" if ":" in req.host else req.host
+            inspection["device"] = _device_registry.register_inspection_host(
+                name=req.name,
+                runtime_url=f"http://{runtime_host}:8766",
+                ssh_host=req.host,
+                ssh_port=req.port,
+                ssh_username=req.username,
+                host_fingerprint=str(
+                    inspection.get("host_fingerprint")
+                    or req.host_fingerprint
+                ),
+                inspection=inspection,
+            )
+        return inspection
+    except (DeviceInstallError, DeviceRegistryError) as exc:
         raise HTTPException(400, str(exc)) from exc
 
 
@@ -5904,9 +6201,9 @@ def get_device_status(device_id: str):
 
 
 @app.get("/devices/{device_id}/monitor")
-def get_device_monitor(device_id: str):
+def get_device_monitor(device_id: str, profile_id: str = "auto"):
     try:
-        return _device_monitor_snapshot(device_id)
+        return _device_monitor_snapshot(device_id, profile_id)
     except KeyError as exc:
         raise HTTPException(404, "Device not found") from exc
     except DeviceRegistryError as exc:
@@ -6548,6 +6845,133 @@ def list_graph_calibrations():
         "profiles": _available_robot_profiles(workflow),
         "calibrations": _local_calibration_candidates(workflow),
         "selected": _workflow_calibration_selection(workflow),
+    }
+
+
+def _profile_editor_node(
+    node_id: str,
+    type_name: str,
+    pos: list[float],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    fn = _NODE_REGISTRY.get(type_name)
+    if fn is None:
+        raise HTTPException(503, f"{type_name} is unavailable; reload blacknode-robot")
+    definition = _node_def_payload(type_name, fn)
+    return {
+        "id": node_id,
+        "type": type_name,
+        "pos": pos,
+        "params": params,
+        "inputs": list(definition["inputs"]),
+        "outputs": list(definition["outputs"]),
+        "input_types": dict(definition["input_types"]),
+        "output_types": dict(definition["output_types"]),
+        "input_defaults": dict(definition["input_defaults"]),
+        "input_choices": dict(definition["input_choices"]),
+        "variadic_input": definition["variadic_input"],
+        "promoted_inputs": definition["primary_inputs"],
+        "promoted_outputs": definition["primary_outputs"],
+        "live_capable": bool(definition["live_capable"]),
+    }
+
+
+@app.get("/graph/profiles/{profile_id}/editor")
+def robot_profile_editor_graph(profile_id: str):
+    clean_id = str(profile_id or "").strip()
+    if not clean_id or clean_id == "auto":
+        raise HTTPException(400, "Select a concrete robot profile to edit.")
+    profile_path = _robot_profiles_root() / clean_id / "profile.json"
+    profile: dict[str, Any] | None = None
+    if profile_path.is_file():
+        try:
+            value = json.loads(profile_path.read_text(encoding="utf-8"))
+            profile = value if isinstance(value, dict) else None
+        except (OSError, json.JSONDecodeError) as exc:
+            raise HTTPException(409, f"Could not read profile '{clean_id}': {exc}") from exc
+    if profile is None:
+        robot_fn = _NODE_REGISTRY.get("Robot")
+        module = sys.modules.get(getattr(robot_fn, "__module__", "")) if robot_fn else None
+        load_profile = getattr(module, "load_profile", None)
+        if callable(load_profile):
+            profile, _path = load_profile(clean_id)
+    if not isinstance(profile, dict):
+        raise HTTPException(404, f"Robot profile '{clean_id}' was not found.")
+    joints = [
+        dict(joint)
+        for joint in (profile.get("joints") or [])
+        if isinstance(joint, dict) and joint.get("id")
+    ]
+    joints.sort(key=lambda joint: (int(joint.get("servo_id") or 0), str(joint.get("id"))))
+    if not joints:
+        raise HTTPException(409, "This profile has no editable joints.")
+    if len(joints) > 16:
+        raise HTTPException(409, "The visual profile editor currently supports up to 16 joints.")
+    nodes: list[dict[str, Any]] = []
+    edges: list[dict[str, Any]] = []
+    for index, joint in enumerate(joints):
+        node_id = f"joint_{index + 1}"
+        nodes.append(_profile_editor_node(
+            node_id,
+            "RobotJointDefinition",
+            [40.0 + (index % 3) * 340.0, 40.0 + (index // 3) * 300.0],
+            {
+                "joint_id": str(joint.get("id")),
+                "display_name": str(joint.get("display_name") or joint.get("id")),
+                "servo_id": int(joint.get("servo_id") or index + 1),
+                "min_deg": float(joint.get("min_deg", joint.get("safe_min_deg", -90.0))),
+                "max_deg": float(joint.get("max_deg", joint.get("safe_max_deg", 90.0))),
+                "home_ticks": int(joint.get("home_ticks") or 2048),
+                "invert": bool(joint.get("invert", False)),
+                "velocity_limit": float(joint.get("velocity_limit") or 0.0),
+                "torque_limit": float(joint.get("torque_limit") or 0.0),
+            },
+        ))
+        edges.append({
+            "from": node_id,
+            "from_port": "joint",
+            "to": "joints",
+            "to_port": f"joint_{index + 1}",
+        })
+    driver = profile.get("driver") if isinstance(profile.get("driver"), dict) else {}
+    match = profile.get("match") if isinstance(profile.get("match"), dict) else {}
+    rows = (len(joints) + 2) // 3
+    nodes.extend([
+        _profile_editor_node("joints", "RobotJointList", [1080.0, 170.0 + rows * 150.0], {}),
+        _profile_editor_node("definition", "RobotDefinition", [1440.0, 110.0 + rows * 150.0], {
+            "profile_id": str(profile.get("id") or clean_id),
+            "display_name": str(profile.get("display_name") or clean_id),
+            "protocol": str(profile.get("protocol") or "custom"),
+            "driver_script": str(driver.get("script") or ""),
+            "command_template": str(driver.get("command_template") or ""),
+            "baudrate": int(driver.get("baudrate") or 1_000_000),
+            "vendor_id": str(match.get("vendor_id") or ""),
+            "product_id": str(match.get("product_id") or ""),
+            "transport": str(driver.get("transport") or "auto"),
+            "host": str(driver.get("host") or "127.0.0.1"),
+            "port": int(driver.get("port") or 9090),
+            "state_topic": str(driver.get("state_topic") or "/joint_states"),
+            "command_topic": str(driver.get("command_topic") or "/joint_commands"),
+            "config_topic": str(driver.get("config_topic") or "/joint_config"),
+            "control_topic": str(driver.get("control_topic") or "/robot_control"),
+            "rate_hz": float(driver.get("rate_hz") or 15.0),
+            "units": str(driver.get("units") or "degrees"),
+        }),
+        _profile_editor_node("save", "RobotProfileSave", [1850.0, 170.0 + rows * 150.0], {"overwrite": True}),
+        _profile_editor_node("out", "Output", [2220.0, 190.0 + rows * 150.0], {"label": f"Saved {clean_id}"}),
+    ])
+    edges.extend([
+        {"from": "joints", "from_port": "joints", "to": "definition", "to_port": "joints"},
+        {"from": "definition", "from_port": "profile", "to": "save", "to_port": "profile"},
+        {"from": "save", "from_port": "report", "to": "out", "to_port": "value"},
+    ])
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "metadata": {
+            "description": f"Edit existing robot profile {clean_id}.",
+            "required_packages": ["blacknode-robot"],
+        },
     }
 
 
@@ -7701,6 +8125,12 @@ def _monitor_payload_from_device_state(payload: dict[str, Any]) -> dict[str, Any
     )
     raw_positions = dict(values.get("raw_positions") or {})
     servo_ids = dict(values.get("servo_ids") or {})
+    bus = values.get("bus") if isinstance(values.get("bus"), dict) else {}
+    temperatures_c = dict(payload.get("temperatures_c") or {})
+    voltages_v = dict(bus.get("voltages_v") or {})
+    hardware_error_flags = dict(bus.get("hardware_error_flags") or {})
+    hardware_errors = dict(bus.get("hardware_errors") or {})
+    servo_status = dict(bus.get("servo_status") or {})
     calibration = (
         values.get("calibration")
         if isinstance(values.get("calibration"), dict)
@@ -7735,6 +8165,20 @@ def _monitor_payload_from_device_state(payload: dict[str, Any]) -> dict[str, Any
             item["servo_id"] = int(servo_match.group(1))
         if name in raw_positions and isinstance(raw_positions[name], int):
             item["raw_position"] = int(raw_positions[name])
+        if bus:
+            item["communication_ok"] = True
+        if isinstance(temperatures_c.get(name), (int, float)):
+            item["temperature_c"] = float(temperatures_c[name])
+        if isinstance(voltages_v.get(name), (int, float)):
+            item["voltage_v"] = float(voltages_v[name])
+        if isinstance(hardware_error_flags.get(name), int):
+            item["hardware_error_flags"] = int(hardware_error_flags[name])
+        if isinstance(hardware_errors.get(name), list):
+            item["hardware_errors"] = [
+                str(value) for value in hardware_errors[name]
+            ]
+        if isinstance(servo_status.get(name), int):
+            item["servo_status"] = int(servo_status[name])
         raw_limits = limits.get(name)
         if isinstance(raw_limits, dict):
             try:
@@ -7754,15 +8198,662 @@ def _monitor_payload_from_device_state(payload: dict[str, Any]) -> dict[str, Any
         "joints": joints,
         "error": str(payload.get("error") or ""),
         "faults": list(payload.get("faults") or []),
-        "temperatures_c": dict(payload.get("temperatures_c") or {}),
+        "temperatures_c": temperatures_c,
         "voltage_v": payload.get("voltage_v"),
+        "voltages_v": voltages_v,
+        "bus": dict(bus),
         "calibrated": values.get("calibrated"),
         "calibration": calibration,
     }
 
 
-def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
+def _monitor_payload_with_status_metadata(
+    payload: dict[str, Any],
+    status: dict[str, Any],
+) -> dict[str, Any]:
+    """Fill stable robot identity metadata missing from live driver samples."""
+    result = dict(payload)
+    telemetry_calibration = (
+        result.get("calibration")
+        if isinstance(result.get("calibration"), dict)
+        else {}
+    )
+    status_calibration = (
+        status.get("calibration")
+        if isinstance(status.get("calibration"), dict)
+        else {}
+    )
+    calibration = {
+        **status_calibration,
+        **telemetry_calibration,
+    }
+    if calibration:
+        for field in (
+            "name",
+            "profile_id",
+            "hardware_id",
+            "activated_at",
+            "digest",
+        ):
+            if not calibration.get(field) and status_calibration.get(field):
+                calibration[field] = status_calibration[field]
+        expected_joint_count = calibration.get("joint_count")
+        if not isinstance(expected_joint_count, int) or isinstance(
+            expected_joint_count,
+            bool,
+        ):
+            topology = calibration.get("topology")
+            calibrated_joints = calibration.get("joints")
+            if isinstance(topology, dict) and topology:
+                calibration["joint_count"] = len(topology)
+            elif isinstance(calibrated_joints, dict) and calibrated_joints:
+                calibration["joint_count"] = len(calibrated_joints)
+        result["calibration"] = calibration
+
+    status_calibrated = status.get("calibrated")
+    if isinstance(status_calibrated, bool):
+        result["calibrated"] = status_calibrated
+    return result
+
+
+def _monitor_profile_selection(value: Any) -> str:
+    selected = str(value or "auto").strip()
+    return selected if selected else "auto"
+
+
+def _local_robot_monitor_targets(
+    requested_profile_id: str = "auto",
+) -> list[dict[str, Any]]:
+    """Discover local USB robots and resolve each through the Robot contract."""
+    discover = _NODE_REGISTRY.get("RobotUSBDiscovery")
+    robot_node = _NODE_REGISTRY.get("Robot")
+    raw_monitor = _NODE_REGISTRY.get("RobotRawMonitor")
+    selection = _monitor_profile_selection(requested_profile_id)
+    raw_mode = selection.lower() == "none"
+    if discover is None or (robot_node is None and not raw_mode):
+        return []
+    try:
+        discovered = discover({"probe_open": False})
+    except Exception:
+        return []
+    targets: list[dict[str, Any]] = []
+    for device in discovered.get("devices") or []:
+        if not isinstance(device, dict):
+            continue
+        serial_port = str(device.get("path") or "").strip()
+        if not serial_port or device.get("accessible") is False:
+            continue
+        hardware = {
+            "found": True,
+            "ready": bool(device.get("accessible", True)),
+            "port": serial_port,
+            "serial": str(
+                device.get("serial")
+                or device.get("serial_number")
+                or serial_port
+            ),
+            "devices": [dict(device)],
+            "recommended": dict(device),
+            "permissions": dict(discovered.get("permissions") or {}),
+            "report": str(discovered.get("report") or ""),
+        }
+        if raw_mode:
+            resolved = {
+                "profile": {},
+                "calibration": {},
+                "hardware_id": hardware["serial"],
+                "report": (
+                    "Raw read-only mode discovers responding servo IDs and "
+                    "shows uncalibrated register values."
+                    if raw_monitor is not None
+                    else "RobotRawMonitor is unavailable; reload blacknode-robot."
+                ),
+            }
+        else:
+            try:
+                resolved = robot_node({
+                    "profile_id": selection,
+                    "hardware": hardware,
+                    "auto_discover": False,
+                    "action": "check",
+                    "require_hardware": True,
+                    "serial_port": serial_port,
+                })
+            except Exception as exc:
+                resolved = {
+                    "profile": {},
+                    "calibration": {},
+                    "hardware_id": hardware["serial"],
+                    "report": f"{type(exc).__name__}: {exc}",
+                }
+        profile = (
+            resolved.get("profile")
+            if isinstance(resolved.get("profile"), dict)
+            else {}
+        )
+        profile_id = str(profile.get("id") or "").strip()
+        hardware_id = str(
+            resolved.get("hardware_id")
+            or hardware.get("serial")
+            or serial_port
+        ).strip()
+        target_token = json.dumps(
+            [serial_port, hardware_id, profile_id],
+            separators=(",", ":"),
+        ).encode("utf-8")
+        target_id = (
+            "local-usb-"
+            + hashlib.sha256(target_token).hexdigest()[:16]
+        )
+        profile_name = str(
+            profile.get("display_name")
+            or profile_id
+            or ("Raw servos" if raw_mode else "Unmatched robot")
+        )
+        targets.append({
+            "id": target_id,
+            "name": f"{profile_name} · {serial_port}",
+            "kind": "local_usb",
+            "available": bool(
+                hardware.get("ready")
+                and ((raw_mode and raw_monitor is not None) or profile_id)
+            ),
+            "profile_id": profile_id,
+            "requested_profile_id": selection,
+            "raw_mode": raw_mode,
+            "hardware_id": hardware_id,
+            "port": serial_port,
+            "profile": dict(profile),
+            "hardware": hardware,
+            "calibration": (
+                dict(resolved.get("calibration"))
+                if isinstance(resolved.get("calibration"), dict)
+                else {}
+            ),
+            "message": str(resolved.get("report") or ""),
+        })
+    return targets
+
+
+def _local_robot_monitor_target(
+    target_id: str,
+    profile_id: str = "auto",
+) -> dict[str, Any] | None:
+    return next(
+        (
+            target
+            for target in _local_robot_monitor_targets(profile_id)
+            if target["id"] == target_id
+        ),
+        None,
+    )
+
+
+@app.get("/robot-monitor-targets")
+def list_robot_monitor_targets(profile_id: str = "auto"):
+    selection = _monitor_profile_selection(profile_id)
+    try:
+        registered = _device_registry.list()
+    except DeviceRegistryError as exc:
+        raise HTTPException(500, str(exc)) from exc
+    targets = [
+        {
+            "id": str(device.get("id") or ""),
+            "name": str(device.get("name") or device.get("id") or "Robot"),
+            "kind": "registered",
+            "available": not bool(device.get("paused")),
+            "hardware_id": str(device.get("remote_device_id") or ""),
+            "device": device,
+        }
+        for device in registered
+        if str(device.get("id") or "")
+    ]
+    targets.extend(
+        _local_robot_monitor_targets()
+        if selection == "auto"
+        else _local_robot_monitor_targets(selection)
+    )
+    profiles = [
+        profile
+        for profile in _available_robot_profiles({})
+        if str(profile.get("id") or "").lower() not in {"auto", "none"}
+    ]
+    return {
+        "targets": targets,
+        "profiles": profiles,
+        "profile_id": selection,
+    }
+
+
+def _local_raw_robot_monitor_snapshot(
+    target: dict[str, Any],
+    now: str,
+) -> dict[str, Any]:
+    """Read one profile-free sample through a registered read-only provider."""
+    target_id = str(target.get("id") or "")
+    target_name = str(target.get("name") or target_id)
+    raw_monitor = _NODE_REGISTRY.get("RobotRawMonitor")
+    if raw_monitor is None:
+        return {
+            "type": "robot_telemetry",
+            "robot_id": target_id,
+            "robot_name": target_name,
+            "source": "hardware",
+            "source_label": f"Local USB raw · {target.get('port') or ''}",
+            "available": False,
+            "stale": True,
+            "received_at": now,
+            "message": "RobotRawMonitor is unavailable; reload blacknode-robot.",
+        }
+    result = raw_monitor({
+        "hardware": dict(target.get("hardware") or {}),
+        "max_servo_id": 32,
+        "__run_mode__": "once",
+    })
+    joints = [
+        dict(value)
+        for value in (result.get("joints") or [])
+        if isinstance(value, dict)
+    ]
+    warnings = [str(value) for value in (result.get("warnings") or []) if value]
+    errors = [str(value) for value in (result.get("errors") or []) if value]
+    faults: list[dict[str, Any]] = []
+    for joint in joints:
+        flags = int(joint.get("hardware_error_flags") or 0)
+        if not flags:
+            continue
+        message = next(
+            (
+                warning
+                for warning in warnings
+                if warning.startswith(f"{joint.get('name')} (")
+            ),
+            (
+                f"{joint.get('name')} hardware warning 0x{flags:02x}: "
+                + (
+                    ", ".join(
+                        str(value)
+                        for value in (joint.get("hardware_errors") or [])
+                    )
+                    or "vendor status"
+                )
+            ),
+        )
+        faults.append({
+            "kind": "blacknode.fault-state",
+            "schema_version": 1,
+            "code": "hardware-warning",
+            "message": message,
+            "severity": "warning",
+            "active": True,
+            "details": {
+                "joint": str(joint.get("name") or ""),
+                "servo_id": int(joint.get("servo_id") or 0),
+                "flags": flags,
+                "decoded": list(joint.get("hardware_errors") or []),
+            },
+        })
+    temperatures_c = {
+        str(joint.get("name") or ""): float(joint["temperature_c"])
+        for joint in joints
+        if isinstance(joint.get("temperature_c"), (int, float))
+        and not isinstance(joint.get("temperature_c"), bool)
+    }
+    voltages_v = {
+        str(joint.get("name") or ""): float(joint["voltage_v"])
+        for joint in joints
+        if isinstance(joint.get("voltage_v"), (int, float))
+        and not isinstance(joint.get("voltage_v"), bool)
+    }
+    available = bool(result.get("available") and joints)
+    return {
+        "type": "robot_telemetry",
+        "robot_id": target_id,
+        "robot_name": target_name,
+        "source": "hardware",
+        "source_label": f"Local USB raw · {target.get('port') or ''}",
+        "available": available,
+        "stale": not available,
+        "sequence": int(time.time() * 1000),
+        "sent_at": now,
+        "received_at": now,
+        "payload": {
+            "connected": available,
+            "armed": False,
+            "torque_enabled": result.get("torque_enabled"),
+            "raw_mode": True,
+            "position_unit": str(result.get("position_unit") or "ticks"),
+            "velocity_unit": str(result.get("velocity_unit") or "ticks/s"),
+            "joints": joints,
+            "error": "\n".join(errors),
+            "faults": faults,
+            "temperatures_c": temperatures_c,
+            "voltage_v": min(voltages_v.values()) if voltages_v else None,
+            "voltages_v": voltages_v,
+            "bus": dict(result.get("diagnostics") or {}),
+            "calibrated": False,
+            "calibration": {
+                "hardware_id": str(target.get("hardware_id") or ""),
+                "joint_count": 0,
+            },
+            "provider": dict(result.get("provider") or {}),
+        },
+        "message": str(result.get("report") or "\n".join(errors)),
+    }
+
+
+def _local_robot_monitor_snapshot(target: dict[str, Any]) -> dict[str, Any]:
+    """Read one local USB robot sample through its bound provider."""
+    now = datetime.now().astimezone().isoformat(timespec="milliseconds")
+    target_id = str(target.get("id") or "")
+    target_name = str(target.get("name") or target_id)
+    if target.get("raw_mode"):
+        return _local_raw_robot_monitor_snapshot(target, now)
+    profile = (
+        target.get("profile")
+        if isinstance(target.get("profile"), dict)
+        else {}
+    )
+    if not target.get("available") or not profile:
+        return {
+            "type": "robot_telemetry",
+            "robot_id": target_id,
+            "robot_name": target_name,
+            "source": "hardware",
+            "source_label": f"Local USB · {target.get('port') or ''}",
+            "available": False,
+            "stale": True,
+            "received_at": now,
+            "message": str(
+                target.get("message")
+                or "Select or save one matching robot profile for this USB device."
+            ),
+        }
+    control = _NODE_REGISTRY.get("RobotCalibrationControl")
+    if control is None:
+        return {
+            "type": "robot_telemetry",
+            "robot_id": target_id,
+            "robot_name": target_name,
+            "source": "hardware",
+            "source_label": f"Local USB · {target.get('port') or ''}",
+            "available": False,
+            "stale": True,
+            "received_at": now,
+            "message": "RobotCalibrationControl is unavailable; reload blacknode-robot.",
+        }
+    motion_sample = _runtime_callable(
+        "robot_servo_motion",
+        _RUNTIME_MODULES["robot_servo_motion"],
+        "sample_servo_motion_for_robot",
+    )
+    result = motion_sample(target_id) if motion_sample is not None else None
+    if not isinstance(result, dict):
+        result = control({
+            "action": "check",
+            "profile": profile,
+            "hardware": dict(target.get("hardware") or {}),
+            "__run_mode__": "once",
+        })
+    pose = {
+        str(name): float(value)
+        for name, value in dict(result.get("pose") or {}).items()
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+    }
+    servos = {
+        str(name): dict(value)
+        for name, value in dict(result.get("servos") or {}).items()
+        if isinstance(value, dict)
+    }
+    joints = []
+    for raw_joint in profile.get("joints") or []:
+        if not isinstance(raw_joint, dict):
+            continue
+        name = str(raw_joint.get("id") or "").strip()
+        if not name or name not in pose:
+            continue
+        servo = servos.get(name, {})
+        item: dict[str, Any] = {
+            "name": name,
+            "semantic_name": str(
+                raw_joint.get("display_name")
+                or name
+            ),
+            "servo_id": int(
+                servo.get("servo_id")
+                or raw_joint.get("servo_id")
+                or 0
+            ),
+            "position": pose[name],
+            "velocity": 0.0,
+            "communication_ok": bool(
+                servo.get("communication_ok", True)
+            ),
+        }
+        for field in (
+            "ticks",
+            "temperature_c",
+            "voltage_v",
+            "hardware_error_flags",
+            "hardware_errors",
+            "servo_status",
+        ):
+            if servo.get(field) is not None:
+                item[
+                    "raw_position" if field == "ticks" else field
+                ] = servo[field]
+        try:
+            item["lower_limit"] = float(
+                raw_joint.get("safe_min_deg", raw_joint.get("min_deg"))
+            )
+            item["upper_limit"] = float(
+                raw_joint.get("safe_max_deg", raw_joint.get("max_deg"))
+            )
+        except (TypeError, ValueError):
+            pass
+        joints.append(item)
+    diagnostics = dict(result.get("diagnostics") or {})
+    hardware_error_flags = {
+        name: int(servo.get("hardware_error_flags") or 0)
+        for name, servo in servos.items()
+    }
+    hardware_errors = {
+        name: list(servo.get("hardware_errors") or [])
+        for name, servo in servos.items()
+        if servo.get("hardware_errors")
+    }
+    servo_status = {
+        name: int(servo.get("servo_status") or 0)
+        for name, servo in servos.items()
+        if servo.get("servo_status") is not None
+    }
+    voltages_v = {
+        name: float(servo["voltage_v"])
+        for name, servo in servos.items()
+        if isinstance(servo.get("voltage_v"), (int, float))
+    }
+    temperatures_c = {
+        name: float(servo["temperature_c"])
+        for name, servo in servos.items()
+        if isinstance(servo.get("temperature_c"), (int, float))
+    }
+    bus = {
+        **diagnostics,
+        "hardware_error_flags": hardware_error_flags,
+        "hardware_errors": hardware_errors,
+        "servo_status": servo_status,
+        "voltages_v": voltages_v,
+    }
+    warnings = [str(value) for value in (result.get("warnings") or [])]
+    faults: list[dict[str, Any]] = []
+    joint_warning_messages: set[str] = set()
+    for name, servo in servos.items():
+        flags = int(servo.get("hardware_error_flags") or 0)
+        if not flags:
+            continue
+        warning = next(
+            (
+                value
+                for value in warnings
+                if value.startswith(f"{name} (")
+            ),
+            (
+                f"{name} (servo {servo.get('servo_id') or '?'}) "
+                f"hardware warning 0x{flags:02x}: "
+                + (
+                    ", ".join(str(value) for value in (servo.get("hardware_errors") or []))
+                    or "vendor status"
+                )
+            ),
+        )
+        joint_warning_messages.add(warning)
+        faults.append({
+            "kind": "blacknode.fault-state",
+            "schema_version": 1,
+            "code": "hardware-warning",
+            "message": warning,
+            "severity": "warning",
+            "active": True,
+            "details": {
+                "joint": name,
+                "servo_id": int(servo.get("servo_id") or 0),
+                "flags": flags,
+                "decoded": list(servo.get("hardware_errors") or []),
+            },
+        })
+    faults.extend(
+        {
+            "kind": "blacknode.fault-state",
+            "schema_version": 1,
+            "code": "hardware-warning",
+            "message": warning,
+            "severity": "warning",
+            "active": True,
+        }
+        for warning in warnings
+        if warning not in joint_warning_messages
+    )
+    calibration = dict(target.get("calibration") or {})
+    calibration.setdefault("profile_id", str(profile.get("id") or ""))
+    calibration.setdefault("hardware_id", str(target.get("hardware_id") or ""))
+    available = bool(result.get("data_ready") and joints)
+    return {
+        "type": "robot_telemetry",
+        "robot_id": target_id,
+        "robot_name": target_name,
+        "source": "hardware",
+        "source_label": f"Local USB · {target.get('port') or ''}",
+        "available": available,
+        "stale": not available,
+        "sequence": int(time.time() * 1000),
+        "sent_at": now,
+        "received_at": now,
+        "payload": {
+            "connected": available,
+            "armed": result.get("torque_enabled") is True,
+            "torque_enabled": result.get("torque_enabled"),
+            "position_unit": "degree",
+            "velocity_unit": "degree/s",
+            "joints": joints,
+            "error": "" if result.get("command_ok") else str(result.get("report") or ""),
+            "faults": faults,
+            "temperatures_c": temperatures_c,
+            "voltage_v": min(voltages_v.values()) if voltages_v else None,
+            "voltages_v": voltages_v,
+            "bus": bus,
+            "calibrated": bool(target.get("calibration")),
+            "calibration": calibration,
+        },
+        "message": str(result.get("report") or ""),
+    }
+
+
+_ROBOT_MONITOR_SAMPLE_INTERVAL_SECONDS = 0.1
+_ROBOT_MONITOR_STALE_GRACE_SECONDS = 1.5
+_robot_monitor_cache_lock = threading.Lock()
+_robot_monitor_device_locks: dict[str, threading.Lock] = {}
+_robot_monitor_snapshot_cache: dict[str, dict[str, Any]] = {}
+
+
+def _robot_monitor_device_lock(device_id: str) -> threading.Lock:
+    with _robot_monitor_cache_lock:
+        return _robot_monitor_device_locks.setdefault(
+            device_id,
+            threading.Lock(),
+        )
+
+
+def _cached_local_robot_monitor_snapshot(
+    device_id: str,
+    profile_id: str = "auto",
+) -> dict[str, Any]:
+    """Serialize local bus reads and preserve one brief failed sample as stale."""
+    target = _local_robot_monitor_target(device_id, profile_id)
+    if target is None:
+        raise KeyError(device_id)
+    physical_key = str(
+        target.get("hardware_id")
+        or target.get("port")
+        or device_id
+    )
+    selection = _monitor_profile_selection(profile_id)
+    cache_key = (
+        device_id
+        if selection == "auto"
+        else f"{device_id}\0{selection}"
+    )
+    lock = _robot_monitor_device_lock(physical_key)
+    with lock:
+        sampled_at = time.monotonic()
+        with _robot_monitor_cache_lock:
+            cached = _robot_monitor_snapshot_cache.get(cache_key)
+            if (
+                cached
+                and sampled_at - float(cached.get("sampled_at") or 0.0)
+                < _ROBOT_MONITOR_SAMPLE_INTERVAL_SECONDS
+            ):
+                return copy.deepcopy(cached["latest"])
+
+        snapshot = _local_robot_monitor_snapshot(target)
+        sampled_at = time.monotonic()
+        with _robot_monitor_cache_lock:
+            cached = _robot_monitor_snapshot_cache.setdefault(cache_key, {})
+            if snapshot.get("available"):
+                cached["last_good"] = copy.deepcopy(snapshot)
+                cached["last_good_at"] = sampled_at
+                latest = snapshot
+            else:
+                last_good = cached.get("last_good")
+                last_good_at = float(cached.get("last_good_at") or 0.0)
+                age = sampled_at - last_good_at
+                if (
+                    isinstance(last_good, dict)
+                    and age <= _ROBOT_MONITOR_STALE_GRACE_SECONDS
+                ):
+                    latest = copy.deepcopy(last_good)
+                    latest["stale"] = True
+                    latest["age_seconds"] = max(0.0, age)
+                    latest["message"] = (
+                        "Telemetry retrying; keeping the last good joint "
+                        "positions visible."
+                    )
+                    latest["transient_error"] = str(
+                        snapshot.get("message") or ""
+                    )
+                else:
+                    latest = snapshot
+            cached["latest"] = copy.deepcopy(latest)
+            cached["sampled_at"] = sampled_at
+        return copy.deepcopy(latest)
+
+
+def _device_monitor_snapshot(
+    device_id: str,
+    profile_id: str = "auto",
+) -> dict[str, Any]:
     """Return one normalized robot-state sample from the current bus owner."""
+    if device_id.startswith("local-usb-"):
+        return _cached_local_robot_monitor_snapshot(device_id, profile_id)
     device = _device_registry.get_public(device_id)
     if device is None:
         raise KeyError(device_id)
@@ -7810,6 +8901,11 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
             if available
             else None
         )
+        if isinstance(monitor_payload, dict):
+            monitor_payload = _monitor_payload_with_status_metadata(
+                monitor_payload,
+                status,
+            )
         return {
             "type": "robot_telemetry",
             "robot_id": device_id,
@@ -7856,6 +8952,39 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
     )
     calibration_topology = dict(calibration.get("topology") or {})
     calibration_joints = dict(calibration.get("joints") or {})
+    status_values = (
+        status.get("values")
+        if isinstance(status.get("values"), dict)
+        else {}
+    )
+    status_bus = (
+        status.get("bus")
+        if isinstance(status.get("bus"), dict)
+        else status_values.get("bus")
+        if isinstance(status_values.get("bus"), dict)
+        else {}
+    )
+    temperatures_c = dict(status.get("temperatures_c") or {})
+    voltages_v = dict(
+        status.get("voltages_v")
+        or status_bus.get("voltages_v")
+        or {}
+    )
+    hardware_error_flags = dict(
+        status.get("hardware_error_flags")
+        or status_bus.get("hardware_error_flags")
+        or {}
+    )
+    hardware_errors = dict(
+        status.get("hardware_errors")
+        or status_bus.get("hardware_errors")
+        or {}
+    )
+    servo_status = dict(
+        status.get("servo_status")
+        or status_bus.get("servo_status")
+        or {}
+    )
 
     def hardware_joint(name: str) -> dict[str, Any]:
         item: dict[str, Any] = {
@@ -7872,6 +9001,20 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
                 item["semantic_name"] = semantic_name
         if isinstance(raw_positions.get(name), int):
             item["raw_position"] = int(raw_positions[name])
+        if status_bus:
+            item["communication_ok"] = True
+        if isinstance(temperatures_c.get(name), (int, float)):
+            item["temperature_c"] = float(temperatures_c[name])
+        if isinstance(voltages_v.get(name), (int, float)):
+            item["voltage_v"] = float(voltages_v[name])
+        if isinstance(hardware_error_flags.get(name), int):
+            item["hardware_error_flags"] = int(hardware_error_flags[name])
+        if isinstance(hardware_errors.get(name), list):
+            item["hardware_errors"] = [
+                str(value) for value in hardware_errors[name]
+            ]
+        if isinstance(servo_status.get(name), int):
+            item["servo_status"] = int(servo_status[name])
 
         raw_limit = status_limits.get(name)
         if isinstance(raw_limit, dict):
@@ -7925,7 +9068,7 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
         "sequence": int(time.time() * 1000),
         "sent_at": now,
         "received_at": now,
-        "payload": {
+        "payload": _monitor_payload_with_status_metadata({
             "connected": bool(status.get("connected")),
             "armed": bool(status.get("armed")),
             "torque_enabled": status.get("torque_enabled"),
@@ -7938,11 +9081,13 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
             ],
             "error": error,
             "faults": faults,
-            "temperatures_c": dict(status.get("temperatures_c") or {}),
+            "temperatures_c": temperatures_c,
             "voltage_v": status.get("voltage_v"),
+            "voltages_v": voltages_v,
+            "bus": dict(status_bus),
             "calibrated": status.get("calibrated"),
             "calibration": calibration,
-        },
+        }, status),
         "message": (
             "Receiving state from Robot Hardware."
             if available
@@ -7956,12 +9101,26 @@ def _device_monitor_snapshot(device_id: str) -> dict[str, Any]:
 
 @app.websocket("/api/devices/{device_id}/monitor/ws")
 @app.websocket("/devices/{device_id}/monitor/ws")
-async def device_monitor_socket(websocket: WebSocket, device_id: str):
+async def device_monitor_socket(
+    websocket: WebSocket,
+    device_id: str,
+    profile_id: str = "auto",
+):
     await websocket.accept()
+    receive_task = asyncio.create_task(websocket.receive())
     try:
         while True:
+            if receive_task.done():
+                message = receive_task.result()
+                if message.get("type") == "websocket.disconnect":
+                    return
+                receive_task = asyncio.create_task(websocket.receive())
             try:
-                snapshot = await asyncio.to_thread(_device_monitor_snapshot, device_id)
+                snapshot = await asyncio.to_thread(
+                    _device_monitor_snapshot,
+                    device_id,
+                    profile_id,
+                )
             except KeyError:
                 await websocket.send_json({
                     "type": "robot_telemetry",
@@ -7983,10 +9142,30 @@ async def device_monitor_socket(websocket: WebSocket, device_id: str):
                     ),
                     "message": f"Monitoring temporarily unavailable: {exc}",
                 }
-            await websocket.send_json(snapshot)
-            await asyncio.sleep(0.1)
-    except (WebSocketDisconnect, RuntimeError):
+            try:
+                await websocket.send_json(snapshot)
+            except Exception:
+                return
+            done, _pending = await asyncio.wait(
+                {receive_task},
+                timeout=_ROBOT_MONITOR_SAMPLE_INTERVAL_SECONDS,
+            )
+            if done:
+                message = receive_task.result()
+                if message.get("type") == "websocket.disconnect":
+                    return
+                receive_task = asyncio.create_task(websocket.receive())
+    except (WebSocketDisconnect, RuntimeError, OSError, asyncio.CancelledError):
         return
+    finally:
+        if not receive_task.done():
+            receive_task.cancel()
+        with contextlib.suppress(
+            asyncio.CancelledError,
+            WebSocketDisconnect,
+            RuntimeError,
+        ):
+            await receive_task
 
 
 @app.get("/devices/{device_id}/deployments")
@@ -9707,17 +10886,26 @@ def setup_package(name: str):
 def set_package_component(name: str, component: str, action: str):
     if not re.fullmatch(r"[a-zA-Z0-9._-]{1,80}", name):
         raise HTTPException(400, "Invalid package name")
-    if not re.fullmatch(r"[a-zA-Z0-9._-]{1,80}", component):
+    component_name, separator, adapter_name = component.partition("@")
+    if not re.fullmatch(r"[a-zA-Z0-9._-]{1,80}", component_name):
         raise HTTPException(400, "Invalid component name")
+    if separator and not re.fullmatch(r"[a-zA-Z0-9._-]{1,80}", adapter_name):
+        raise HTTPException(400, "Invalid adapter name")
     if action not in {"enable", "disable", "reset"}:
         raise HTTPException(400, "Component action must be enable, disable, or reset")
     try:
-        if action == "enable":
-            info = bn_ensure_component_enabled(name, component)
+        if adapter_name and action == "enable":
+            info = bn_ensure_adapter_enabled(name, component_name, adapter_name)
+        elif adapter_name and action == "disable":
+            info = bn_set_adapter_enabled(name, component_name, adapter_name, False)
+        elif adapter_name:
+            info = bn_reset_component(name, component_name, adapter_name)
+        elif action == "enable":
+            info = bn_ensure_component_enabled(name, component_name)
         elif action == "disable":
-            info = bn_set_component_enabled(name, component, False)
+            info = bn_set_component_enabled(name, component_name, False)
         else:
-            info = bn_reset_component(name, component)
+            info = bn_reset_component(name, component_name)
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
     except RuntimeError as exc:

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -11,6 +11,7 @@ import { LIVE_STREAM_NODE_TYPES } from './liveNodeTypes'
 import ValueNode from './components/ValueNode'
 import ModelNode from './components/ModelNode'
 import OutputNode from './components/OutputNode'
+import ComputeDeviceNode from './components/ComputeDeviceNode'
 import RobotMonitorNode from './components/RobotMonitorNode'
 import RobotServoNode from './components/RobotServoNode'
 import SubnetNode from './components/SubnetNode'
@@ -32,6 +33,7 @@ const NODE_TYPES = {
   valuenode: ValueNode,
   modelnode: ModelNode,
   outputnode: OutputNode,
+  computedevice: ComputeDeviceNode,
   robotmonitor: RobotMonitorNode,
   robotservo: RobotServoNode,
   subnetnode: SubnetNode,

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -225,6 +225,20 @@ export interface HardwareDevice {
   updated_at: string
 }
 
+export interface RobotMonitorTarget {
+  id: string
+  name: string
+  kind: 'registered' | 'local_usb'
+  available: boolean
+  profile_id?: string
+  requested_profile_id?: string
+  raw_mode?: boolean
+  hardware_id?: string
+  port?: string
+  message?: string
+  device?: HardwareDevice
+}
+
 export interface ComputeDevice {
   id: string
   name: string
@@ -235,6 +249,15 @@ export interface ComputeDevice {
   created_at: string
   updated_at: string
   robots: HardwareDevice[]
+  inspection_only?: boolean
+  inspection_updated_at?: string
+  last_inspection?: SshRuntimeInspection
+  inspection_connection?: {
+    ssh_host: string
+    ssh_port: number
+    ssh_username: string
+    host_fingerprint: string
+  }
   managed_runtime?: {
     management_mode?: 'ssh' | 'local'
     ssh_host?: string
@@ -329,13 +352,66 @@ export interface SshHostEnvironment {
   runtime_setup_packages: string[]
 }
 
+export interface SshRos2CapabilityCandidate {
+  kind: 'blacknode.robot-capability-candidate'
+  schema_version: 1
+  capability: string
+  confidence: 'high' | 'medium' | 'low'
+  score: number
+  state_topics: string[]
+  command_topics: string[]
+  safe_to_read: boolean
+  requires_confirmation: boolean
+  evidence: Array<{
+    capability: string
+    kind: 'topic'
+    name: string
+    message_type: string
+    role: 'state' | 'metadata' | 'command'
+    score: number
+    reason: string
+  }>
+}
+
+export interface SshRos2GraphInspection {
+  available: boolean
+  state: 'available' | 'partial' | 'empty' | 'unavailable' | 'unsupported' | string
+  distribution: string
+  domain_id: string
+  read_only: true
+  daemon_used: false
+  topics: string[]
+  nodes: string[]
+  services: string[]
+  errors: string[]
+  found: boolean
+  capabilities: SshRos2CapabilityCandidate[]
+  unclassified: Array<{
+    name: string
+    message_types: string[]
+  }>
+  inventory: {
+    topics: Array<{
+      name: string
+      message_types: string[]
+    }> | string[]
+    nodes: string[]
+    services: string[]
+    classified_topic_count?: number
+    unclassified_topic_count?: number
+  }
+  report: string
+}
+
 export interface SshRuntimeInspection {
   ok: boolean
   host_fingerprint: string
   instances: SshRuntimeInstance[]
   environment: SshHostEnvironment
+  ros2_graph: SshRos2GraphInspection
   suggested_port: number
   suggested_instance_id: string
+  device?: ComputeDevice
 }
 
 export interface DeviceRuntimeStatus {
@@ -453,6 +529,12 @@ export interface RobotTelemetryJoint {
   raw_position?: number
   lower_limit?: number
   upper_limit?: number
+  communication_ok?: boolean
+  temperature_c?: number
+  voltage_v?: number
+  hardware_error_flags?: number
+  hardware_errors?: string[]
+  servo_status?: number
 }
 
 export interface RobotTelemetrySample {
@@ -477,6 +559,7 @@ export interface RobotTelemetrySample {
     connected: boolean
     armed?: boolean
     torque_enabled?: boolean | null
+    raw_mode?: boolean
     position_unit: string
     velocity_unit: string
     joints: RobotTelemetryJoint[]
@@ -486,6 +569,9 @@ export interface RobotTelemetrySample {
       name?: string
       profile_id?: string
       hardware_id?: string
+      activated_at?: string
+      joint_count?: number
+      digest?: string
       topology?: Record<string, string>
       joints?: Record<string, {
         safe_min_deg?: number
@@ -505,6 +591,22 @@ export interface RobotTelemetrySample {
     }>
     temperatures_c?: Record<string, number>
     voltage_v?: number
+    voltages_v?: Record<string, number>
+    bus?: {
+      operation_count?: number
+      timeout_count?: number
+      serial_packet_error_count?: number
+      serial_packet_error_rate?: number
+      exception_count?: number
+      hardware_error_count?: number
+      scan_miss_count?: number
+      hardware_error_flags?: Record<string, number>
+      hardware_errors?: Record<string, string[]>
+      servo_status?: Record<string, number>
+      voltages_v?: Record<string, number>
+      last_full_feedback_time?: number
+      last_diagnostic_time?: number
+    }
     battery?: {
       level?: number
       voltage?: number
@@ -519,9 +621,10 @@ export interface RobotTelemetrySample {
   message?: string
 }
 
-export function deviceMonitorSocketUrl(id: string): string {
+export function deviceMonitorSocketUrl(id: string, profileId = 'auto'): string {
   const path = `${BASE}/devices/${encodeURIComponent(id)}/monitor/ws`
   const url = new URL(path, window.location.href)
+  url.searchParams.set('profile_id', String(profileId || 'auto'))
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
   return url.toString()
 }
@@ -1283,13 +1386,24 @@ export const api = {
       calibrations: DeviceCalibrationCandidate[]
       selected: { profile_id: string; hardware_id: string } | null
     }>('GET', '/graph/calibrations', undefined, 10000),
+  robotProfileEditorGraph: (profileId: string) =>
+    req<GraphSnapshot>(
+      'GET',
+      `/graph/profiles/${encodeURIComponent(profileId)}/editor`,
+      undefined,
+      10000,
+    ),
   addNode:   (type_name: string, pos: [number,number], params = {}) =>
     req<BnNodeMeta>('POST', '/nodes', { type_name, pos, params }),
   removeNode: (id: string)                  => req('DELETE', `/nodes/${id}`),
   updateParam:(id: string, key: string, value: unknown) =>
     req('PATCH', `/nodes/${id}/params`, { key, value }, 10000),
-  controlNode:(id: string, action: string) =>
-    req<{ ok: boolean; node_id: string; outputs: Record<string, unknown> }>('POST', `/nodes/${id}/control`, { action }),
+  controlNode:(id: string, action: string, payload: Record<string, unknown> = {}) =>
+    req<{ ok: boolean; node_id: string; outputs: Record<string, unknown> }>(
+      'POST',
+      `/nodes/${id}/control`,
+      { action, payload },
+    ),
   pickDirectory:(initialPath = '', title = '') =>
     req<{ selected: string; cancelled: boolean }>(
       'POST',
@@ -1389,6 +1503,8 @@ export const api = {
     username: string,
     password: string,
     hostFingerprint: string,
+    name = '',
+    register = false,
   ) =>
     req<SshRuntimeInspection>(
       'POST',
@@ -1399,6 +1515,8 @@ export const api = {
         username,
         password,
         host_fingerprint: hostFingerprint,
+        name,
+        save_inspection: register,
       },
       60000,
     ),
@@ -1597,6 +1715,15 @@ export const api = {
       onProgress,
     ),
   listDevices:      () => req<{ devices: HardwareDevice[] }>('GET', '/devices'),
+  listRobotMonitorTargets: (profileId = 'auto') =>
+    req<{
+      targets: RobotMonitorTarget[]
+      profiles: DeviceRobotProfile[]
+      profile_id: string
+    }>(
+      'GET',
+      `/robot-monitor-targets?profile_id=${encodeURIComponent(profileId || 'auto')}`,
+    ),
   pairDevice:       (name: string, baseUrl: string, token: string, runtimeToken = '') =>
     req<{
       device: HardwareDevice

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -3,7 +3,11 @@ import { Handle, Position, NodeProps, useReactFlow, useUpdateNodeInternals } fro
 import { NodeResizer } from '@reactflow/node-resizer'
 import '@reactflow/node-resizer/dist/style.css'
 import { useStore } from '../store'
-import { api, type DeviceCalibrationCandidate } from '../api'
+import {
+  api,
+  type DeviceCalibrationCandidate,
+  type DeviceRobotProfile,
+} from '../api'
 import { portColor, portVisualColor } from '../portColors'
 import { headerColor } from '../categories'
 import { isWireOnlyInput } from '../inputControls'
@@ -477,6 +481,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const loadDriverStatus = useStore(s => s.loadDriverStatus)
   const workflowMetadata = useStore(s => s.workflowMetadata)
   const setWorkflowRequirements = useStore(s => s.setWorkflowRequirements)
+  const openGraphAsTab = useStore(s => s.openGraphAsTab)
   const qualifiedType = useQualifiedTypeLabel(data.type)
   const driverName  = TRIGGER_DRIVER[data.type]
   const driverLive  = driverName ? Boolean(driverStatus[driverName]?.live) : false
@@ -555,12 +560,16 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const updateNodeInternals = useUpdateNodeInternals()
   const color       = headerColor(data.type)
   const isToolBox   = data.type === 'ToolBox'
+  const isRobotJointDefinition = data.type === 'RobotJointDefinition'
   const isRobotJointList = data.type === 'RobotJointList'
   const variadicInput = data.variadic_input ?? null
   const isVariadic = Boolean(variadicInput)
-  const isManualMove = data.type === 'ROS2ManualMove'
+  const isManualMove = (
+    data.type === 'ROS2ManualMove'
+    || data.type === 'RobotCalibrationControl'
+  )
   const isRobot = data.type === 'Robot'
-  const robotProfileId = String(data.params?.profile_id ?? '').trim()
+  const robotProfileId = String(data.params?.profile_id ?? 'auto').trim() || 'auto'
   const requiredCapabilities = Array.isArray(workflowMetadata.required_capabilities)
     ? workflowMetadata.required_capabilities.map(String)
     : []
@@ -570,8 +579,11 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   )
     ? workflowMetadata.device_calibration
     : null
+  const [robotProfiles, setRobotProfiles] = useState<DeviceRobotProfile[]>([])
   const [robotCalibrations, setRobotCalibrations] = useState<DeviceCalibrationCandidate[]>([])
   const [robotCalibrationsLoading, setRobotCalibrationsLoading] = useState(false)
+  const [robotProfilePending, setRobotProfilePending] = useState(false)
+  const [robotProfileEditPending, setRobotProfileEditPending] = useState(false)
   const [robotCalibrationPending, setRobotCalibrationPending] = useState(false)
   const [robotCalibrationError, setRobotCalibrationError] = useState('')
   const matchingRobotCalibrations = robotCalibrations.filter(
@@ -586,12 +598,31 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       && calibration.hardware_id === selectedRobotCalibration?.hardware_id
     ),
   )
-  const loadRobotCalibrations = async () => {
+  const selectableRobotProfiles = robotProfiles.filter(profile => profile.id !== 'auto')
+  const robotProfileChoices = Array.from(new Map([
+    ...(robotProfileId !== 'auto'
+      ? [[
+          robotProfileId,
+          selectableRobotProfiles.find(profile => profile.id === robotProfileId) ?? {
+            id: robotProfileId,
+            name: robotProfileId,
+            saved: false,
+            calibration_count: 0,
+          },
+        ] as const]
+      : []),
+    ...selectableRobotProfiles.map(profile => [profile.id, profile] as const),
+  ]).values())
+  const selectedRobotProfileChoice = robotProfileChoices.find(
+    profile => profile.id === robotProfileId,
+  )
+  const loadRobotSetup = async () => {
     if (!isRobot) return
     setRobotCalibrationsLoading(true)
     setRobotCalibrationError('')
     try {
       const result = await api.listGraphCalibrations()
+      setRobotProfiles(result.profiles ?? [])
       setRobotCalibrations(result.calibrations ?? [])
     } catch (err) {
       setRobotCalibrationError(err instanceof Error ? err.message : String(err))
@@ -606,7 +637,10 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     setRobotCalibrationError('')
     void api.listGraphCalibrations()
       .then(result => {
-        if (!cancelled) setRobotCalibrations(result.calibrations ?? [])
+        if (!cancelled) {
+          setRobotProfiles(result.profiles ?? [])
+          setRobotCalibrations(result.calibrations ?? [])
+        }
       })
       .catch(err => {
         if (!cancelled) {
@@ -618,6 +652,55 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       })
     return () => { cancelled = true }
   }, [isRobot, robotProfileId])
+  useEffect(() => {
+    if (!isRobot) return
+    const refresh = () => { void loadRobotSetup() }
+    window.addEventListener('blacknode:robot-profiles-changed', refresh)
+    return () => window.removeEventListener('blacknode:robot-profiles-changed', refresh)
+  }, [isRobot])
+  const selectRobotProfile = async (profileId: string) => {
+    if (!profileId || profileId === robotProfileId) return
+    setRobotProfilePending(true)
+    setRobotCalibrationError('')
+    try {
+      await updateParam(id, 'profile_id', profileId)
+      if (
+        selectedRobotCalibration
+        && selectedRobotCalibration.profile_id !== profileId
+      ) {
+        await setWorkflowRequirements(requiredCapabilities, null)
+      }
+      await loadRobotSetup()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setRobotCalibrationError(message)
+      window.dispatchEvent(new CustomEvent('blacknode:notice', {
+        detail: { kind: 'error', title: 'Robot profile selection failed', message },
+      }))
+    } finally {
+      setRobotProfilePending(false)
+    }
+  }
+  const editRobotProfile = async () => {
+    if (!robotProfileId || robotProfileId === 'auto' || robotProfileEditPending) return
+    setRobotProfileEditPending(true)
+    try {
+      const graph = await api.robotProfileEditorGraph(robotProfileId)
+      const profile = selectableRobotProfiles.find(item => item.id === robotProfileId)
+      await openGraphAsTab(`Edit ${profile?.name || robotProfileId}`, graph)
+      window.dispatchEvent(new Event('blacknode:fit-view'))
+    } catch (err) {
+      window.dispatchEvent(new CustomEvent('blacknode:notice', {
+        detail: {
+          kind: 'error',
+          title: 'Could not open profile editor',
+          message: err instanceof Error ? err.message : String(err),
+        },
+      }))
+    } finally {
+      setRobotProfileEditPending(false)
+    }
+  }
   const selectRobotCalibration = async (value: string) => {
     const calibration = robotCalibrations.find(
       item => `${item.profile_id}\u0000${item.hardware_id}` === value,
@@ -715,10 +798,23 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     : streamPreview ?? (isImageSrc(inlineDashboardImage) ? inlineDashboardImage : null)
   const streamUrl = typeof data.portResults?.stream_url === 'string' ? data.portResults.stream_url : ''
   const streamActive = LIVE_STREAM_NODE_TYPES.has(data.type) && data.portResults?.streaming === true && streamUrl.length > 0
-  const manualMoveLive = data.type === 'ROS2ManualMove' && data.portResults?.live === true
+  const manualMoveLive = isManualMove && data.portResults?.live === true
   const manualMoveReady = manualMoveLive && data.portResults?.data_ready === true
   const manualMoveMode = data.portResults?.mode === 'released' ? 'RELEASED' : 'HOLD'
   const manualMoveJointCount = Array.isArray(data.portResults?.joints) ? data.portResults.joints.length : 0
+  const manualMovePoseEntries = isManualMove && data.portResults?.pose && typeof data.portResults.pose === 'object'
+    ? Object.entries(data.portResults.pose as Record<string, unknown>)
+      .filter((entry): entry is [string, number] => typeof entry[1] === 'number')
+      .sort(([left], [right]) => left.localeCompare(right))
+    : []
+  const manualMoveWarnings = isManualMove && Array.isArray(data.portResults?.warnings)
+    ? data.portResults.warnings.length
+    : 0
+  const manualMoveReport = isManualMove && (
+    data.portResults?.command_ok === false || manualMoveWarnings > 0
+  )
+    ? String(data.portResults?.report ?? '')
+    : ''
   const selectedManualAction = String(data.params?.action ?? 'check').toLowerCase()
   const releaseSelected = selectedManualAction === 'release' || selectedManualAction === 'enter'
   const holdSelected = selectedManualAction === 'hold' || selectedManualAction === 'exit'
@@ -1476,6 +1572,52 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       )}
 
       <div className="bn-node-parameter-area">
+      {isRobotJointDefinition && (
+        <div
+          className="bn-joint-definition-fields nodrag"
+          onMouseDown={e => e.stopPropagation()}
+          onKeyDown={e => e.stopPropagation()}
+        >
+          <div className="bn-joint-definition-fields-head">
+            <span>Joint identity</span>
+            <strong>Servo {String(data.params?.servo_id ?? 1)}</strong>
+          </div>
+          <div className="bn-joint-definition-fields-grid">
+            <label>
+              <span>Servo ID</span>
+              <input
+                key={`servo-${String(data.params?.servo_id ?? 1)}`}
+                type="number"
+                min={1}
+                step={1}
+                defaultValue={Number(data.params?.servo_id ?? 1)}
+                onBlur={e => {
+                  const next = Math.max(1, Math.trunc(Number(e.target.value) || 1))
+                  e.target.value = String(next)
+                  void updateParam(id, 'servo_id', next)
+                }}
+              />
+            </label>
+            <label>
+              <span>Joint ID</span>
+              <input
+                type="text"
+                value={String(data.params?.joint_id ?? 'joint')}
+                spellCheck={false}
+                onChange={e => { void updateParam(id, 'joint_id', e.target.value) }}
+              />
+            </label>
+            <label>
+              <span>Display name</span>
+              <input
+                type="text"
+                value={String(data.params?.display_name ?? 'Joint')}
+                onChange={e => { void updateParam(id, 'display_name', e.target.value) }}
+              />
+            </label>
+          </div>
+        </div>
+      )}
       {isRobot && (
         <div className="nodrag" onMouseDown={e => e.stopPropagation()}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 7, margin: '6px 8px 0' }}>
@@ -1507,12 +1649,26 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
           }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
               <span style={{ color: 'var(--tx2)', fontSize: 12, fontWeight: 700, flex: 1 }}>
-                Calibration used for deployment
+                Robot profile &amp; calibration
               </span>
               <button
+                disabled={robotProfileId === 'auto' || robotProfileEditPending}
+                title="Open the selected profile as editable joint nodes in a new tab"
+                onClick={e => { e.stopPropagation(); void editRobotProfile() }}
+                style={{
+                  padding: '1px 6px', borderRadius: 4, border: '1px solid var(--accent)',
+                  background: 'rgba(99,102,241,.12)', color: 'var(--tx1)',
+                  cursor: robotProfileId === 'auto' || robotProfileEditPending ? 'default' : 'pointer',
+                  fontSize: 11, fontWeight: 700,
+                  opacity: robotProfileId === 'auto' ? 0.55 : 1,
+                }}
+              >
+                {robotProfileEditPending ? 'Opening…' : 'Edit profile'}
+              </button>
+              <button
                 disabled={robotCalibrationsLoading}
-                title="Refresh saved calibrations"
-                onClick={e => { e.stopPropagation(); void loadRobotCalibrations() }}
+                title="Refresh saved profiles and calibrations"
+                onClick={e => { e.stopPropagation(); void loadRobotSetup() }}
                 style={{
                   padding: '1px 5px', borderRadius: 4, border: '1px solid var(--line)',
                   background: 'var(--lift)', color: 'var(--tx2)',
@@ -1522,14 +1678,63 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
                 {robotCalibrationsLoading ? '…' : '⟳'}
               </button>
             </div>
+            <label style={{
+              display: 'block', color: 'var(--tx3)', fontSize: 11,
+              marginBottom: 3,
+            }}>
+              Profile
+            </label>
+            <select
+              aria-label="Robot profile"
+              title={selectedRobotProfileChoice
+                ? `${selectedRobotProfileChoice.name} · ${selectedRobotProfileChoice.id}`
+                : 'Select a saved robot profile'}
+              value={robotProfileId === 'auto' ? '' : robotProfileId}
+              disabled={robotProfilePending}
+              onFocus={() => { void loadRobotSetup() }}
+              onChange={e => { void selectRobotProfile(e.target.value) }}
+              style={{
+                boxSizing: 'border-box', width: '100%', minWidth: 0,
+                background: 'var(--lift)', color: 'var(--tx1)',
+                border: '1px solid var(--line)', borderRadius: 5, padding: '3px 5px',
+                fontFamily: 'var(--font-ui)', fontSize: 12, marginBottom: 6,
+              }}
+            >
+              {robotProfileId === 'auto' && (
+                <option value="" disabled>Select a saved profile…</option>
+              )}
+              {robotProfileChoices.map(profile => (
+                <option value={profile.id} key={profile.id}>
+                  {profile.name === profile.id
+                    ? profile.id
+                    : profile.name}
+                </option>
+              ))}
+            </select>
+            {selectedRobotProfileChoice && (
+              <div className="bn-robot-node-profile-summary">
+                <strong>{selectedRobotProfileChoice.name}</strong>
+                <span>
+                  ID: {selectedRobotProfileChoice.id}
+                  {' · '}
+                  {selectedRobotProfileChoice.calibration_count
+                    ? `${selectedRobotProfileChoice.calibration_count} calibration${selectedRobotProfileChoice.calibration_count === 1 ? '' : 's'}`
+                    : 'No saved calibration'}
+                </span>
+              </div>
+            )}
+            <label style={{
+              display: 'block', color: 'var(--tx3)', fontSize: 11,
+              marginBottom: 3,
+            }}>
+              Calibration
+            </label>
             <select
               aria-label="Calibration used for deployment"
               value={selectedRobotCalibrationKey}
               disabled={robotCalibrationPending || robotCalibrationsLoading}
               onFocus={() => {
-                if (!robotCalibrations.length && !robotCalibrationsLoading) {
-                  void loadRobotCalibrations()
-                }
+                void loadRobotSetup()
               }}
               onChange={e => { void selectRobotCalibration(e.target.value) }}
               style={{
@@ -1934,6 +2139,31 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
               {manualMovePending === 'hold' ? 'Holding…' : `${holdSelected ? '✓ ' : ''}Hold position`}
             </button>
           </div>
+          {manualMovePoseEntries.length > 0 && (
+            <div style={{
+              marginTop: 8, display: 'grid', gridTemplateColumns: 'minmax(110px, 1fr) auto',
+              gap: '3px 10px', fontFamily: 'var(--font-mono)', fontSize: 12,
+            }}>
+              {manualMovePoseEntries.map(([joint, value]) => (
+                <div key={joint} style={{ display: 'contents' }}>
+                  <span style={{ color: 'var(--tx2)' }}>{joint}</span>
+                  <span style={{ color: 'var(--tx1)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                    {value.toFixed(2)}°
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+          {manualMoveReport && (
+            <div style={{
+              marginTop: 7, padding: '5px 7px', borderRadius: 5,
+              border: '1px solid var(--warn)', background: 'rgba(245,158,11,.08)',
+              color: 'var(--warn)', fontFamily: 'var(--font-ui)', fontSize: 11,
+              lineHeight: 1.35, whiteSpace: 'pre-wrap',
+            }}>
+              {manualMoveReport}
+            </div>
+          )}
           <div style={{ marginTop: 6, color: 'var(--tx3)', fontFamily: 'var(--font-ui)', fontSize: 11, lineHeight: 1.35 }}>
             Go live never changes torque by itself; it only keeps supported outputs updating.
           </div>

--- a/editor/src/components/ComputeDeviceNode.tsx
+++ b/editor/src/components/ComputeDeviceNode.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from 'react'
+import { NodeResizer } from '@reactflow/node-resizer'
+import { Handle, Position, type NodeProps } from 'reactflow'
+
+import {
+  api,
+  type ComputeDevice,
+  type SshRuntimeInspection,
+} from '../api'
+import { useStore, type NodeData } from '../store'
+import NodeFrame from './NodeFrame'
+
+
+const OUTPUTS = [
+  ['configured', '#f59e0b'],
+  ['inspection_available', '#f59e0b'],
+  ['device', '#a855f7'],
+  ['inspection', '#a855f7'],
+  ['report', '#38bdf8'],
+] as const
+
+
+export default function ComputeDeviceNode({
+  id,
+  data,
+  selected,
+}: NodeProps<NodeData>) {
+  const updateParam = useStore(state => state.updateParam)
+  const [devices, setDevices] = useState<ComputeDevice[]>([])
+  const [error, setError] = useState('')
+  const deviceId = String(data.params?.device_id || '').trim()
+  const deviceName = String(data.params?.device_name || '').trim()
+  const inspection = (
+    data.params?.inspection && typeof data.params.inspection === 'object'
+      ? data.params.inspection
+      : {}
+  ) as SshRuntimeInspection
+  const selectedDevice = devices.find(device => device.id === deviceId)
+  const graph = inspection.ros2_graph
+  const capabilityCount = graph?.capabilities?.length || 0
+
+  const loadDevices = async () => {
+    try {
+      const result = await api.listComputeDevices()
+      setDevices(result.devices)
+      setError('')
+      return result.devices
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+      return []
+    }
+  }
+
+  useEffect(() => {
+    void loadDevices()
+  }, [])
+
+  const saveSelection = async (device: ComputeDevice | undefined) => {
+    await updateParam(id, 'device_id', device?.id || '')
+    await updateParam(id, 'device_name', device?.name || '')
+    await updateParam(id, 'inspection', device?.last_inspection || {})
+  }
+
+  const chooseDevice = async (nextId: string) => {
+    await saveSelection(devices.find(device => device.id === nextId))
+  }
+
+  const refreshSnapshot = async () => {
+    const current = await loadDevices()
+    await saveSelection(current.find(device => device.id === deviceId))
+  }
+
+  return (
+    <NodeFrame
+      id={id}
+      data={data}
+      selected={selected}
+      color="#14b8a6"
+      nodeType={data.type}
+      style={{
+        width: '100%',
+        height: '100%',
+        minWidth: 420,
+        minHeight: 220,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <NodeResizer
+        minWidth={420}
+        minHeight={220}
+        isVisible={selected}
+        lineStyle={{ borderColor: '#14b8a6' }}
+        handleStyle={{
+          background: '#14b8a6',
+          borderColor: '#14b8a6',
+          width: 8,
+          height: 8,
+          borderRadius: 2,
+        }}
+      />
+
+      <header className="bn-compute-device-node-title">
+        <div>
+          <span>COMPUTE DEVICE</span>
+          <strong>{selectedDevice?.name || deviceName || 'Choose a device'}</strong>
+        </div>
+        <span className={inspection.ok ? 'is-ready' : 'is-idle'}>
+          {inspection.ok ? 'INSPECTED' : 'NO SNAPSHOT'}
+        </span>
+      </header>
+
+      <div className="bn-compute-device-node-body nodrag">
+        <label>
+          <span>Registered device</span>
+          <select
+            value={deviceId}
+            onChange={event => void chooseDevice(event.target.value)}
+            aria-label="Compute device"
+          >
+            <option value="">Choose a device…</option>
+            {devices.map(device => (
+              <option key={device.id} value={device.id}>
+                {device.name}{device.inspection_only ? ' · inspection only' : ''}
+              </option>
+            ))}
+            {deviceId && !selectedDevice && (
+              <option value={deviceId}>{deviceName || deviceId} · unavailable</option>
+            )}
+          </select>
+        </label>
+
+        <div className="bn-compute-device-node-facts">
+          <span>
+            ROS 2 <strong>{graph?.available ? graph.distribution || 'available' : 'unavailable'}</strong>
+          </span>
+          <span>
+            Topics <strong>{graph?.inventory?.topics?.length || graph?.topics?.length || 0}</strong>
+          </span>
+          <span>
+            Capabilities <strong>{capabilityCount}</strong>
+          </span>
+          <span>
+            Access <strong>read only</strong>
+          </span>
+        </div>
+
+        <div className="bn-compute-device-node-actions">
+          <button type="button" onClick={() => void refreshSnapshot()}>
+            Refresh saved snapshot
+          </button>
+          <small>
+            {error
+              || (selectedDevice?.inspection_updated_at
+                ? `Captured ${new Date(selectedDevice.inspection_updated_at).toLocaleString()}`
+                : 'Inspect this target from Devices to capture a snapshot.')}
+          </small>
+        </div>
+      </div>
+
+      {OUTPUTS.map(([port, color], index) => (
+        <Handle
+          key={port}
+          type="source"
+          position={Position.Right}
+          id={port}
+          title={port}
+          style={{
+            background: color,
+            width: 9,
+            height: 9,
+            top: 48 + index * 27,
+          }}
+        />
+      ))}
+    </NodeFrame>
+  )
+}

--- a/editor/src/components/DeploymentsPanel.tsx
+++ b/editor/src/components/DeploymentsPanel.tsx
@@ -1023,9 +1023,12 @@ export default function DeploymentsPanel({
                               const calibrationLabel = profile?.calibration_count
                                 ? ` · ${profile.calibration_count} calibration${profile.calibration_count === 1 ? '' : 's'}`
                                 : ''
+                              const profileLabel = profile && profile.name !== profileId
+                                ? `${profile.name} · ${profileId}`
+                                : profileId
                               return (
                                 <option value={profileId} key={profileId}>
-                                  {profile?.name || profileId}{calibrationLabel}
+                                  {profileLabel}{calibrationLabel}
                                 </option>
                               )
                             })}

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -1089,6 +1089,21 @@ export default function DevicesPanel({
           : null
       ))
       await Promise.all(result.devices.map(async device => {
+        if (device.inspection_only) {
+          setDeviceStates(previous => ({
+            ...previous,
+            [device.id]: {
+              runtime: {
+                ok: false,
+                state: 'inspection_only',
+                runtime_url: device.runtime_url,
+              },
+              loading: false,
+              checkedAt: Date.now(),
+            },
+          }))
+          return
+        }
         await Promise.all([
           refreshDevice(device),
           Promise.all(device.robots.map(refreshRobot)),
@@ -1257,8 +1272,11 @@ export default function DevicesPanel({
           sshUsername.trim(),
           sshPassword,
           sshProbe.host_fingerprint,
+          deviceName.trim(),
+          true,
         )
         setSshInspection(inspection)
+        await refresh()
         const reusable = inspection.instances.find(instance => instance.healthy)
         if (reusable) {
           setInstallAction('reuse')
@@ -2524,8 +2542,9 @@ export default function DevicesPanel({
                 <div>
                   <strong>Connect over SSH</strong>
                   <p>
-                    Blacknode verifies the computer, checks existing runtimes and occupied
-                    ports, then lets you reuse, replace, or install an independent instance.
+                    Blacknode verifies the computer, checks existing runtimes, occupied
+                    ports, and the live ROS 2 graph, then lets you close without installing
+                    or choose a managed Runtime setup.
                   </p>
                 </div>
               </div>
@@ -2704,6 +2723,71 @@ export default function DevicesPanel({
                       <p>
                         Runtime setup may install missing {sshInspection.environment.runtime_setup_packages.join(', ')}.
                         It does not replace NVIDIA drivers, CUDA, ROS 2, or Docker.
+                      </p>
+                    </div>
+                  )}
+                  {sshInspection.ros2_graph && (
+                    <div className="bn-ssh-ros-inspection">
+                      <div className="bn-host-environment-head">
+                        <div>
+                          <strong>Live ROS 2 graph</strong>
+                          <span>
+                            {sshInspection.ros2_graph.distribution || 'ROS 2'}
+                            {' · domain '}{sshInspection.ros2_graph.domain_id}
+                            {' · '}{sshInspection.ros2_graph.topics.length} topics
+                            {' · '}{sshInspection.ros2_graph.nodes.length} nodes
+                            {' · '}{sshInspection.ros2_graph.services.length} services
+                          </span>
+                        </div>
+                        <span className="bn-preserved-badge">Read only</span>
+                      </div>
+                      {sshInspection.ros2_graph.capabilities.length > 0 ? (
+                        <div className="bn-ssh-ros-capabilities">
+                          {sshInspection.ros2_graph.capabilities.map(candidate => (
+                            <article key={candidate.capability}>
+                              <div>
+                                <strong>{candidate.capability.replace(/_/g, ' ')}</strong>
+                                <span>{candidate.confidence} confidence</span>
+                              </div>
+                              <small>
+                                {[...candidate.state_topics, ...candidate.command_topics].join(', ')}
+                              </small>
+                            </article>
+                          ))}
+                        </div>
+                      ) : (
+                        <p>
+                          {sshInspection.ros2_graph.report
+                            || 'No standard robot capability candidates were identified.'}
+                        </p>
+                      )}
+                      {sshInspection.ros2_graph.unclassified.length > 0 && (
+                        <details className="bn-ssh-ros-unclassified">
+                          <summary>
+                            {sshInspection.ros2_graph.unclassified.length} unclassified topics
+                          </summary>
+                          <div>
+                            {sshInspection.ros2_graph.unclassified.slice(0, 20).map(topic => (
+                              <code key={topic.name}>
+                                {topic.name}
+                                {topic.message_types.length
+                                  ? ` [${topic.message_types.join(', ')}]`
+                                  : ''}
+                              </code>
+                            ))}
+                          </div>
+                        </details>
+                      )}
+                      {sshInspection.ros2_graph.errors.length > 0 && (
+                        <div className="bn-ssh-ros-errors">
+                          {sshInspection.ros2_graph.errors.map(message => (
+                            <span key={message}>{message}</span>
+                          ))}
+                        </div>
+                      )}
+                      <p>
+                        No packages, files, services, settings, or motion commands were
+                        changed. ROS inspection used transient no-daemon graph queries.
                       </p>
                     </div>
                   )}
@@ -2921,7 +3005,11 @@ export default function DevicesPanel({
           )}
 
           <div className="bn-device-form-actions">
-            <button type="button" onClick={resetDeviceForm} style={miniButton}>Cancel</button>
+            <button type="button" onClick={resetDeviceForm} style={miniButton}>
+              {setupMode === 'automatic' && sshInspection
+                ? 'Close — device saved'
+                : 'Cancel'}
+            </button>
             {setupMode === 'automatic' && !sshProbe ? (
               <button type="button" onClick={probeSsh} disabled={busy} style={primaryButton}>
                 {busy ? 'Checking…' : 'Check connection'}
@@ -3156,9 +3244,19 @@ export default function DevicesPanel({
             </div>
           </div>
 
+          {selectedDevice.inspection_only && (
+            <div className="bn-device-inspection-only" role="status">
+              <strong>Read-only inspection device</strong>
+              <span>
+                The saved system and ROS 2 snapshot is available to ComputeDevice
+                nodes. Blacknode Runtime and physical control are not enabled.
+              </span>
+            </div>
+          )}
+
           {isUiTest && (
             <div className="bn-device-detail-tabs" role="tablist" aria-label="Device sections">
-              <button
+              {!selectedDevice.inspection_only && <button
                 type="button"
                 role="tab"
                 aria-selected={deviceDetailTab === 'overview'}
@@ -3166,7 +3264,7 @@ export default function DevicesPanel({
                 onClick={() => openDeviceDetailTab('overview')}
               >
                 Overview
-              </button>
+              </button>}
               {selectedDevice.managed_runtime && (
                 <button
                   type="button"
@@ -3178,7 +3276,7 @@ export default function DevicesPanel({
                   Software
                 </button>
               )}
-              <button
+              {!selectedDevice.inspection_only && <button
                 type="button"
                 role="tab"
                 aria-selected={deviceDetailTab === 'diagnostics'}
@@ -3186,7 +3284,7 @@ export default function DevicesPanel({
                 onClick={() => openDeviceDetailTab('diagnostics')}
               >
                 Diagnostics
-              </button>
+              </button>}
               <button
                 type="button"
                 className="bn-device-check-action"
@@ -4872,10 +4970,13 @@ function ComputeDeviceCard({
   const paused = Boolean(device.paused || state?.runtime?.paused)
   const ready = !paused && state?.runtime?.ok === true
   const stopped = !paused && state?.runtime?.state === 'stopped'
+  const inspectionOnly = Boolean(device.inspection_only)
   const local = isLocalRuntimeUrl(device.runtime_url)
   const isolated = device.managed_runtime?.stack_mode === 'isolated'
   const label = state?.loading
     ? 'CHECKING'
+    : inspectionOnly
+      ? 'INSPECTED'
     : paused
       ? 'PAUSED'
       : stopped
@@ -4885,7 +4986,7 @@ function ComputeDeviceCard({
           : 'ATTENTION'
   const color = paused || stopped
     ? 'var(--tx3)'
-    : ready
+    : inspectionOnly || ready
       ? 'var(--ok)'
       : state?.runtime
         ? 'var(--warn)'
@@ -4900,7 +5001,9 @@ function ComputeDeviceCard({
     >
       <span className="bn-compute-device-card-top">
         <span className="bn-compute-device-kind">
-          {local ? 'LOCAL' : isolated ? 'REMOTE · ISOLATED' : 'REMOTE'}
+          {inspectionOnly
+            ? 'REMOTE · READ ONLY'
+            : local ? 'LOCAL' : isolated ? 'REMOTE · ISOLATED' : 'REMOTE'}
         </span>
         <span className="bn-compute-device-status">{label}</span>
       </span>

--- a/editor/src/components/Inspector.tsx
+++ b/editor/src/components/Inspector.tsx
@@ -447,10 +447,39 @@ export default function Inspector() {
 
   const [open, setOpen]             = useState(true)
   const [showAdvanced, setShowAdvanced] = useState(false)
+  const [robotProfileChoices, setRobotProfileChoices] = useState<string[]>([])
   const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_W)
   const dragRef = useRef<{ startX: number; startW: number } | null>(null)
 
   useEffect(() => { setShowAdvanced(false) }, [selectedId])
+  useEffect(() => {
+    if (node?.data.type !== 'Robot') {
+      setRobotProfileChoices([])
+      return
+    }
+    let cancelled = false
+    const loadProfiles = () => {
+      void api.listGraphCalibrations()
+        .then(result => {
+          if (!cancelled) {
+            setRobotProfileChoices(
+              (result.profiles ?? [])
+                .map(profile => profile.id)
+                .filter(profileId => profileId && profileId !== 'auto'),
+            )
+          }
+        })
+        .catch(() => {
+          // Keep the last usable list; the on-node refresh reports API errors.
+        })
+    }
+    loadProfiles()
+    window.addEventListener('blacknode:robot-profiles-changed', loadProfiles)
+    return () => {
+      cancelled = true
+      window.removeEventListener('blacknode:robot-profiles-changed', loadProfiles)
+    }
+  }, [node?.data.type, selectedId])
 
   const startResize = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -619,7 +648,14 @@ export default function Inspector() {
                 const type = (data.input_types as Record<string, string>)?.[inp] ?? 'Any'
                 const def  = (data.input_defaults as Record<string, unknown>)?.[inp]
                           ?? nodeDefs[data.type]?.input_defaults?.[inp]
-                const choices = nodeDefs[data.type]?.input_choices?.[inp]
+                const schemaChoices = nodeDefs[data.type]?.input_choices?.[inp]
+                const choices = data.type === 'Robot' && inp === 'profile_id'
+                  ? (
+                      robotProfileChoices.length > 0
+                        ? robotProfileChoices
+                        : (schemaChoices ?? []).filter(choice => choice !== 'auto')
+                    )
+                  : schemaChoices
                 const isOllamaModel = inp === 'model' && data.inputs.includes('provider')
                   && String(
                     data.params.provider
@@ -1649,6 +1685,11 @@ function EnumControl({ value, defaultValue, choices, onChange }: {
         borderLeft: `2px solid ${color}`,
       }}
     >
+      {!choices.includes(current) && (
+        <option value={current} disabled>
+          {current === 'auto' ? 'Select a saved profile…' : `${current} (unavailable)`}
+        </option>
+      )}
       {choices.map(opt => (
         <option key={opt} value={opt}>{opt}</option>
       ))}

--- a/editor/src/components/RobotMonitorNode.tsx
+++ b/editor/src/components/RobotMonitorNode.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
+import { NodeResizer } from '@reactflow/node-resizer'
 import { Handle, Position, type NodeProps } from 'reactflow'
 
 import {
   api,
-  type HardwareDevice,
+  type DeviceRobotProfile,
+  type RobotMonitorTarget,
   type RobotTelemetryJoint,
   type RobotTelemetrySample,
 } from '../api'
@@ -11,6 +13,7 @@ import {
   subscribeRobotTelemetry,
   type RobotMonitorConnection,
 } from '../robotTelemetryStream'
+import { hardwareWarningHint } from '../robotTelemetryDiagnostics'
 import { useStore, type NodeData } from '../store'
 import NodeFrame from './NodeFrame'
 
@@ -21,8 +24,10 @@ type JointTrace = {
 
 export default function RobotMonitorNode({ id, data, selected }: NodeProps<NodeData>) {
   const updateParam = useStore(state => state.updateParam)
-  const [robots, setRobots] = useState<HardwareDevice[]>([])
+  const [robots, setRobots] = useState<RobotMonitorTarget[]>([])
+  const [profiles, setProfiles] = useState<DeviceRobotProfile[]>([])
   const [listError, setListError] = useState('')
+  const profileId = String(data.params?.profile_id || 'auto').trim() || 'auto'
   const robotId = String(data.params?.robot_id || '').trim()
   const savedName = String(data.params?.robot_name || '').trim()
   const selectedRobot = robots.find(robot => robot.id === robotId)
@@ -30,10 +35,11 @@ export default function RobotMonitorNode({ id, data, selected }: NodeProps<NodeD
 
   useEffect(() => {
     let active = true
-    api.listDevices()
+    api.listRobotMonitorTargets(profileId)
       .then(result => {
         if (!active) return
-        setRobots(result.devices)
+        setRobots(result.targets)
+        setProfiles(result.profiles || [])
         setListError('')
       })
       .catch(error => {
@@ -41,12 +47,38 @@ export default function RobotMonitorNode({ id, data, selected }: NodeProps<NodeD
         setListError(error instanceof Error ? error.message : String(error))
       })
     return () => { active = false }
-  }, [])
+  }, [profileId])
 
   const chooseRobot = async (nextId: string) => {
     const robot = robots.find(item => item.id === nextId)
     await updateParam(id, 'robot_id', nextId)
     await updateParam(id, 'robot_name', robot?.name || '')
+  }
+
+  const chooseProfile = async (nextProfileId: string) => {
+    const current = robots.find(item => item.id === robotId)
+    await updateParam(id, 'profile_id', nextProfileId)
+    try {
+      const result = await api.listRobotMonitorTargets(nextProfileId)
+      setRobots(result.targets)
+      setProfiles(result.profiles || [])
+      setListError('')
+      if (current?.kind === 'local_usb') {
+        const replacement = result.targets.find(item => (
+          item.kind === 'local_usb'
+          && (
+            item.hardware_id === current.hardware_id
+            || item.port === current.port
+          )
+        ))
+        if (replacement) {
+          await updateParam(id, 'robot_id', replacement.id)
+          await updateParam(id, 'robot_name', replacement.name)
+        }
+      }
+    } catch (error) {
+      setListError(error instanceof Error ? error.message : String(error))
+    }
   }
 
   return (
@@ -56,38 +88,91 @@ export default function RobotMonitorNode({ id, data, selected }: NodeProps<NodeD
       selected={selected}
       color="#00b8d9"
       nodeType={data.type}
-      style={{ width: '100%', minWidth: 620 }}
+      style={{
+        width: '100%',
+        height: '100%',
+        minWidth: 620,
+        minHeight: 260,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
     >
+      <NodeResizer
+        minWidth={620}
+        minHeight={260}
+        isVisible={selected}
+        lineStyle={{ borderColor: '#00b8d9' }}
+        handleStyle={{
+          background: '#00b8d9',
+          borderColor: '#00b8d9',
+          width: 8,
+          height: 8,
+          borderRadius: 2,
+        }}
+      />
+
       <header className="bn-robot-monitor-node-title">
         <div>
           <span>ROBOT MONITOR</span>
           <strong>{robotName}</strong>
         </div>
-        <label
-          className="nodrag"
+        <div
+          className="bn-robot-monitor-node-pickers nodrag"
           onMouseDown={event => event.stopPropagation()}
           onClick={event => event.stopPropagation()}
         >
-          <span>Robot</span>
-          <select
-            value={robotId}
-            onChange={event => void chooseRobot(event.target.value)}
-            aria-label="Robot to monitor"
-          >
-            <option value="">Choose a robot…</option>
-            {robots.map(robot => (
-              <option key={robot.id} value={robot.id}>{robot.name}</option>
-            ))}
-            {robotId && !selectedRobot && (
-              <option value={robotId}>{savedName || robotId} (unavailable)</option>
-            )}
-          </select>
-        </label>
+          <label>
+            <span>Profile</span>
+            <select
+              value={profileId}
+              onChange={event => void chooseProfile(event.target.value)}
+              aria-label="Profile for local USB monitoring"
+            >
+              <option value="auto">Auto · match this hardware</option>
+              <option value="none">None · raw read-only</option>
+              {profiles.map(profile => (
+                <option key={profile.id} value={profile.id}>
+                  {profile.name} · {profile.id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>Robot</span>
+            <select
+              value={robotId}
+              onChange={event => void chooseRobot(event.target.value)}
+              aria-label="Robot to monitor"
+            >
+              <option value="">Choose a robot…</option>
+              {robots.some(robot => robot.kind === 'local_usb') && (
+                <optgroup label="Local USB">
+                  {robots.filter(robot => robot.kind === 'local_usb').map(robot => (
+                    <option key={robot.id} value={robot.id} disabled={!robot.available}>
+                      {robot.name}{robot.available ? '' : ' (profile needed)'}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+              {robots.some(robot => robot.kind === 'registered') && (
+                <optgroup label="Registered robots">
+                  {robots.filter(robot => robot.kind === 'registered').map(robot => (
+                    <option key={robot.id} value={robot.id}>{robot.name}</option>
+                  ))}
+                </optgroup>
+              )}
+              {robotId && !selectedRobot && (
+                <option value={robotId}>{savedName || robotId} (unavailable)</option>
+              )}
+            </select>
+          </label>
+        </div>
       </header>
 
       <RobotLiveMonitor
         robotId={robotId}
         robotName={robotName}
+        profileId={profileId}
         emptyMessage={listError}
       />
 
@@ -105,10 +190,12 @@ export default function RobotMonitorNode({ id, data, selected }: NodeProps<NodeD
 export function RobotLiveMonitor({
   robotId,
   robotName,
+  profileId = 'auto',
   emptyMessage,
 }: {
   robotId: string
   robotName: string
+  profileId?: string
   emptyMessage: string
 }) {
   const [sample, setSample] = useState<RobotTelemetrySample | null>(null)
@@ -131,6 +218,7 @@ export function RobotLiveMonitor({
 
     return subscribeRobotTelemetry(
       robotId,
+      profileId,
       nextSample => {
         let next = nextSample
         const sourceKey = `${next.source || 'unknown'}:${next.source_label || ''}`
@@ -181,13 +269,13 @@ export function RobotLiveMonitor({
       },
       setConnection,
     )
-  }, [robotId])
+  }, [profileId, robotId])
 
   const joints = sample?.payload?.joints || []
   const cameras = sample?.payload?.camera_streams || []
   const sourceLabel = sample?.source === 'deployment'
     ? `Deployment · ${sample.source_label || sample.deployment?.name || 'workflow'}`
-    : 'Robot Hardware'
+    : sample?.source_label || 'Robot Hardware'
   const stateLabel = connection !== 'live'
     ? connection
     : sample?.stale
@@ -199,6 +287,26 @@ export function RobotLiveMonitor({
   const armed = sample?.payload?.armed ?? sample?.deployment?.motion_armed
   const torque = sample?.payload?.torque_enabled
   const battery = sample?.payload?.battery
+  const calibrated = sample?.payload?.calibrated
+  const calibration = sample?.payload?.calibration
+  const rawMode = sample?.payload?.raw_mode === true
+  const topologyJointCount = Object.keys(calibration?.topology || {}).length
+  const calibratedJointCount = Object.keys(calibration?.joints || {}).length
+  const expectedJointCount = Number(calibration?.joint_count)
+    || topologyJointCount
+    || calibratedJointCount
+  const jointCoverageComplete = expectedJointCount > 0 && joints.length === expectedJointCount
+  const calibrationLabel = rawMode
+    ? 'Needs profile'
+    : calibrated === true
+    ? calibration?.name || 'Active'
+    : calibrated === false
+      ? calibration && Object.keys(calibration).length > 0 ? 'Not active' : 'None'
+      : calibration && Object.keys(calibration).length > 0 ? 'Reported' : 'Unknown'
+  const bus = sample?.payload?.bus
+  const hardwareWarningCount = joints.filter(
+    joint => Number(joint.hardware_error_flags || 0) !== 0,
+  ).length
 
   return (
     <section
@@ -253,6 +361,38 @@ export function RobotLiveMonitor({
             value={sample?.source === 'deployment' ? 'Deployment' : 'Hardware'}
             tone="live"
           />
+          <MonitorFact
+            label="Profile"
+            value={rawMode ? 'None · raw' : calibration?.profile_id || 'Unknown'}
+            tone={rawMode ? 'warning' : calibration?.profile_id ? 'ok' : 'muted'}
+          />
+          <MonitorFact
+            label="Calibration"
+            value={calibrationLabel}
+            tone={calibrated === true ? 'ok' : calibrated === false ? 'warning' : 'muted'}
+          />
+          <MonitorFact
+            label="Joint coverage"
+            value={expectedJointCount > 0 ? `${joints.length} / ${expectedJointCount}` : String(joints.length)}
+            tone={jointCoverageComplete ? 'ok' : expectedJointCount > 0 ? 'warning' : 'muted'}
+          />
+          <MonitorFact
+            label="Servo warnings"
+            value={String(hardwareWarningCount)}
+            tone={hardwareWarningCount ? 'warning' : joints.length ? 'ok' : 'muted'}
+          />
+          <MonitorFact
+            label="Bus timeouts"
+            value={bus?.timeout_count == null ? 'Unknown' : String(bus.timeout_count)}
+            tone={bus?.timeout_count ? 'warning' : bus ? 'ok' : 'muted'}
+          />
+          <MonitorFact
+            label="Packet errors"
+            value={bus?.serial_packet_error_count == null
+              ? 'Unknown'
+              : String(bus.serial_packet_error_count)}
+            tone={bus?.serial_packet_error_count ? 'warning' : bus ? 'ok' : 'muted'}
+          />
         </div>
       )}
 
@@ -279,6 +419,7 @@ export function RobotLiveMonitor({
         <>
           <div className="bn-robot-monitor-meta">
             <span>{joints.length} joints</span>
+            {calibration?.hardware_id && <span title={calibration.hardware_id}>Hardware {calibration.hardware_id}</span>}
             <span>{cameras.length} streams</span>
             <span>{sample.payload?.position_unit || 'degree'}</span>
             <span>
@@ -286,6 +427,7 @@ export function RobotLiveMonitor({
                 ? new Date(sample.received_at).toLocaleTimeString()
                 : 'now'}
             </span>
+            {bus?.operation_count != null && <span>{bus.operation_count} bus operations</span>}
           </div>
 
           {cameras.length > 0 && (
@@ -303,7 +445,12 @@ export function RobotLiveMonitor({
 
           {joints.length > 0 ? (
             <div className="bn-robot-monitor-grid">
-              {joints.map(joint => (
+              {[...joints]
+                .sort((left, right) => (
+                  Number(left.servo_id ?? Number.MAX_SAFE_INTEGER)
+                  - Number(right.servo_id ?? Number.MAX_SAFE_INTEGER)
+                ))
+                .map(joint => (
                 <JointMonitorCard
                   key={joint.name}
                   joint={joint}
@@ -311,7 +458,7 @@ export function RobotLiveMonitor({
                   positionUnit={sample.payload?.position_unit || 'degree'}
                   velocityUnit={sample.payload?.velocity_unit || 'degree/s'}
                 />
-              ))}
+                ))}
             </div>
           ) : (
             <div className="bn-robot-monitor-empty" role="status">
@@ -359,11 +506,21 @@ function JointMonitorCard({
     && Number.isFinite(upperLimit)
     && Number(upperLimit) > Number(lowerLimit)
   const unit = shortUnit(positionUnit)
+  const hardwareFlags = Number(joint.hardware_error_flags || 0)
+  const hardwareErrors = joint.hardware_errors || []
+  const warning = hardwareFlags !== 0
 
   return (
-    <article className="bn-joint-monitor-card">
+    <article className={`bn-joint-monitor-card${warning ? ' is-warning' : ''}`}>
       <div className="bn-joint-monitor-title">
-        <strong title={joint.name}>{joint.name.replace(/_/g, ' ')}</strong>
+        <div>
+          <strong title={joint.semantic_name || joint.name}>
+            {(joint.semantic_name || joint.name).replace(/_/g, ' ')}
+          </strong>
+          <small>
+            {joint.servo_id == null ? joint.name : `Servo ID ${joint.servo_id}`}
+          </small>
+        </div>
         <span>{joint.position.toFixed(2)} {unit}</span>
       </div>
       <TelemetrySparkline
@@ -382,6 +539,20 @@ function JointMonitorCard({
         <span>Speed</span>
         <strong>{joint.velocity.toFixed(2)} {shortUnit(velocityUnit)}</strong>
       </div>
+      <div className="bn-joint-monitor-diagnostics">
+        <span>Raw <strong>{joint.raw_position ?? '—'}</strong></span>
+        <span>Response <strong>{joint.communication_ok === false ? 'Failed' : 'OK'}</strong></span>
+        <span>Voltage <strong>{joint.voltage_v == null ? '—' : `${joint.voltage_v.toFixed(2)} V`}</strong></span>
+        <span>Temp <strong>{joint.temperature_c == null ? '—' : `${joint.temperature_c.toFixed(1)} °C`}</strong></span>
+        <span>Status <strong>{`0x${hardwareFlags.toString(16).padStart(2, '0')}`}</strong></span>
+      </div>
+      {warning && (
+        <div className="bn-joint-monitor-warning">
+          <strong>Hardware warning</strong>
+          <span>{hardwareErrors.join(', ') || 'Vendor status flag reported'}</span>
+          <small>{hardwareWarningHint(joint)}</small>
+        </div>
+      )}
     </article>
   )
 }

--- a/editor/src/components/RobotServoNode.tsx
+++ b/editor/src/components/RobotServoNode.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { NodeResizer } from '@reactflow/node-resizer'
 import { Handle, Position, type NodeProps } from 'reactflow'
 
 import {
   api,
-  type HardwareDevice,
+  type DeviceRobotProfile,
+  type RobotMonitorTarget,
   type RobotTelemetryJoint,
   type RobotTelemetrySample,
 } from '../api'
@@ -11,6 +13,7 @@ import {
   subscribeRobotTelemetry,
   type RobotMonitorConnection,
 } from '../robotTelemetryStream'
+import { hardwareWarningHint } from '../robotTelemetryDiagnostics'
 import { useStore, type NodeData } from '../store'
 import NodeFrame from './NodeFrame'
 
@@ -31,15 +34,27 @@ function convert(value: number, source: string, target: string): number {
   return sourceRadians ? value * 180 / Math.PI : value * Math.PI / 180
 }
 
+type QueuedMotionCommand = {
+  command: Record<string, unknown>
+}
+
 export default function RobotServoNode({ id, data, selected }: NodeProps<NodeData>) {
   const updateParam = useStore(state => state.updateParam)
   const nodes = useStore(state => state.nodes)
   const edges = useStore(state => state.edges)
-  const [devices, setDevices] = useState<HardwareDevice[]>([])
+  const [devices, setDevices] = useState<RobotMonitorTarget[]>([])
+  const [profiles, setProfiles] = useState<DeviceRobotProfile[]>([])
   const [sample, setSample] = useState<RobotTelemetrySample | null>(null)
   const [connection, setConnection] = useState<RobotMonitorConnection>('idle')
   const [derivedVelocity, setDerivedVelocity] = useState(0)
+  const [motionReport, setMotionReport] = useState('')
+  const [servoArmed, setServoArmed] = useState(false)
+  const [armPending, setArmPending] = useState(false)
   const previous = useRef<{ position: number; at: number } | null>(null)
+  const servoArmedRef = useRef(false)
+  const motionQueue = useRef<{ running: boolean; pending?: QueuedMotionCommand }>({
+    running: false,
+  })
   const servoId = Math.max(1, Math.min(253, Number(data.params?.servo_id ?? 1) || 1))
   const units = String(data.params?.units ?? 'degrees')
 
@@ -60,9 +75,13 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
     ? sourceRobot.driver as Record<string, unknown>
     : {}
   const directRobotId = String(data.params?.robot_id ?? '').trim()
+  const directProfileId = String(data.params?.profile_id ?? 'auto').trim() || 'auto'
   const sourceRobotId = source?.data.type === 'RobotMonitor'
     ? String(source.data.params?.robot_id ?? '').trim()
     : String(sourceRobot.robot_id ?? sourceRobot.device_id ?? '').trim()
+  const sourceProfileId = source?.data.type === 'RobotMonitor'
+    ? String(source.data.params?.profile_id ?? 'auto').trim() || 'auto'
+    : String(source?.data.params?.profile_id ?? 'auto').trim() || 'auto'
   const sourceHardwareId = String(
     driver.hardware_id
     ?? (source?.data.portResults?.hardware as Record<string, unknown> | undefined)?.serial
@@ -70,11 +89,12 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
   ).trim()
   const mappedDevice = sourceHardwareId
     ? devices.find(device => (
-      hardwareIdentity(device.remote_device_id).includes(hardwareIdentity(sourceHardwareId))
+      hardwareIdentity(device.hardware_id).includes(hardwareIdentity(sourceHardwareId))
       || hardwareIdentity(device.id).includes(hardwareIdentity(sourceHardwareId))
     ))
     : undefined
   const robotId = directRobotId || sourceRobotId || mappedDevice?.id || ''
+  const profileId = directRobotId ? directProfileId : source ? sourceProfileId : directProfileId
   const robotName = devices.find(device => device.id === robotId)?.name
     || String(source?.data.params?.robot_name ?? '')
     || String(source?.data.params?.profile_id ?? '')
@@ -82,11 +102,15 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
 
   useEffect(() => {
     let active = true
-    void api.listDevices()
-      .then(result => { if (active) setDevices(result.devices) })
+    void api.listRobotMonitorTargets(profileId)
+      .then(result => {
+        if (!active) return
+        setDevices(result.targets)
+        setProfiles(result.profiles || [])
+      })
       .catch(() => undefined)
     return () => { active = false }
-  }, [])
+  }, [profileId])
 
   useEffect(() => {
     setSample(null)
@@ -94,6 +118,7 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
     previous.current = null
     return subscribeRobotTelemetry(
       robotId,
+      profileId,
       next => {
         const joint = (next.payload?.joints || []).find(item => servoIdOf(item) === servoId)
         if (joint) {
@@ -108,7 +133,17 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
       },
       setConnection,
     )
-  }, [robotId, servoId])
+  }, [profileId, robotId, servoId])
+
+  useEffect(() => {
+    servoArmedRef.current = servoArmed
+  }, [servoArmed])
+
+  useEffect(() => () => {
+    if (servoArmedRef.current) {
+      void api.controlNode(id, 'disarm').catch(() => undefined)
+    }
+  }, [id])
 
   const joints = sample?.payload?.joints || []
   const joint = joints.find(item => servoIdOf(item) === servoId)
@@ -116,14 +151,19 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
     .sort((a, b) => a - b)
   const sourcePositionUnit = sample?.payload?.position_unit || 'degree'
   const sourceVelocityUnit = sample?.payload?.velocity_unit || 'degree/s'
-  const position = joint ? convert(joint.position, sourcePositionUnit, units) : 0
+  const rawMode = sample?.payload?.raw_mode === true || sourcePositionUnit === 'ticks'
+  const position = joint
+    ? rawMode ? joint.position : convert(joint.position, sourcePositionUnit, units)
+    : 0
   const velocityValue = sample?.source === 'hardware' ? derivedVelocity : joint?.velocity ?? 0
-  const velocity = convert(velocityValue, sourceVelocityUnit, `${units}/s`)
+  const velocity = rawMode
+    ? velocityValue
+    : convert(velocityValue, sourceVelocityUnit, `${units}/s`)
   const lower = joint?.lower_limit == null
-    ? units === 'degrees' ? -180 : -Math.PI
+    ? rawMode ? 0 : units === 'degrees' ? -180 : -Math.PI
     : convert(joint.lower_limit, sourcePositionUnit, units)
   const upper = joint?.upper_limit == null
-    ? units === 'degrees' ? 180 : Math.PI
+    ? rawMode ? 4095 : units === 'degrees' ? 180 : Math.PI
     : convert(joint.upper_limit, sourcePositionUnit, units)
   const hasCalibratedLimits = Boolean(
     sample?.payload?.calibrated
@@ -135,7 +175,20 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
   const target = Math.max(lower, Math.min(upper, followFeedback ? position : targetParam))
   const temperature = sample?.payload?.temperatures_c?.[joint?.name || '']
     ?? sample?.payload?.temperatures_c?.[`servo_${servoId}`]
-  const faults = (sample?.payload?.faults || []).filter(fault => fault.active !== false)
+    ?? joint?.temperature_c
+  const voltage = joint?.voltage_v ?? sample?.payload?.voltage_v
+  const hardwareFlags = Number(joint?.hardware_error_flags || 0)
+  const hardwareErrors = joint?.hardware_errors || []
+  const faults = (sample?.payload?.faults || []).filter(fault => {
+    if (fault.active === false) return false
+    const faultJoint = String(fault.details?.joint || '')
+    return !faultJoint || [
+      joint?.name,
+      joint?.semantic_name,
+      `servo_${servoId}`,
+    ].includes(faultJoint)
+  })
+  const bus = sample?.payload?.bus
   const state = !robotId
     ? 'CONNECT ROBOT'
     : connection !== 'live'
@@ -143,18 +196,183 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
       : sample?.stale
         ? 'STALE'
         : joint
-          ? 'LIVE'
+          ? hardwareFlags || faults.length ? 'WARNING' : 'LIVE'
           : 'ID NOT REPORTED'
-  const stateTone = state === 'LIVE' ? '#22c55e' : state === 'STALE' ? '#f59e0b' : '#ef4444'
-  const unit = units === 'degrees' ? '°' : 'rad'
+  const stateTone = state === 'LIVE'
+    ? '#22c55e'
+    : state === 'STALE' || state === 'WARNING'
+      ? '#f59e0b'
+      : '#ef4444'
+  const unit = rawMode ? 'ticks' : units === 'degrees' ? '°' : 'rad'
 
+  const disarmServo = async (report = 'Motion disarmed') => {
+    motionQueue.current.pending = undefined
+    try {
+      await api.controlNode(id, 'disarm')
+    } catch {
+      // Parameter changes also disarm on the server; keep the UI fail-safe.
+    }
+    servoArmedRef.current = false
+    setServoArmed(false)
+    setMotionReport(report)
+  }
   const chooseServo = (next: number) => {
+    if (servoArmedRef.current) void disarmServo('Motion disarmed because the servo ID changed')
     void updateParam(id, 'servo_id', next)
     void updateParam(id, 'follow_feedback', true)
   }
+  const stepServo = (delta: number) => {
+    chooseServo(Math.max(1, Math.min(253, servoId + delta)))
+  }
+  const queueMotionCommand = (queued: QueuedMotionCommand) => {
+    motionQueue.current.pending = queued
+    if (motionQueue.current.running) return
+    motionQueue.current.running = true
+    void (async () => {
+      try {
+        while (motionQueue.current.pending) {
+          const pending = motionQueue.current.pending
+          motionQueue.current.pending = undefined
+          const command = { ...pending.command, issued_at: Date.now() / 1000 }
+          const result = await api.controlNode(id, 'joint-command', { command })
+          const armed = result.outputs.armed === true
+          servoArmedRef.current = armed
+          setServoArmed(armed)
+          setMotionReport(String(result.outputs.report || 'Joint command accepted'))
+        }
+      } catch (error) {
+        servoArmedRef.current = false
+        setServoArmed(false)
+        setMotionReport(error instanceof Error ? error.message : String(error))
+      } finally {
+        motionQueue.current.running = false
+        if (motionQueue.current.pending) {
+          const next = motionQueue.current.pending
+          motionQueue.current.pending = undefined
+          queueMotionCommand(next)
+        }
+      }
+    })()
+  }
   const setTarget = (next: number) => {
-    void updateParam(id, 'follow_feedback', false)
-    void updateParam(id, 'target_position', next)
+    const jointName = String(joint?.name || joint?.semantic_name || data.params?.joint_name || '').trim()
+    void (async () => {
+      if (jointName && data.params?.joint_name !== jointName) {
+        await updateParam(id, 'joint_name', jointName)
+      }
+      void updateParam(id, 'follow_feedback', false)
+      void updateParam(id, 'target_position', next)
+      if (!servoArmedRef.current) {
+        setMotionReport('Preview only — press Arm on this Servo node to enable motion')
+        return
+      }
+      if (!jointName) {
+        setMotionReport('Motion blocked — the live joint name is unavailable')
+        return
+      }
+      if (
+        connection !== 'live'
+        || sample?.stale
+        || !hasCalibratedLimits
+        || hardwareFlags !== 0
+        || faults.length > 0
+      ) {
+        setMotionReport('Motion blocked — live, calibrated, warning-free feedback is required')
+        return
+      }
+      queueMotionCommand({
+        command: {
+          kind: 'blacknode.joint-command-request',
+          schema_version: 1,
+          joint_name: jointName,
+          servo_id: servoId,
+          position_rad: units === 'degrees' ? next * Math.PI / 180 : next,
+          source: 'RobotServo',
+          requires_motion_authorization: true,
+        },
+      })
+    })()
+  }
+  const toggleServoArm = async () => {
+    if (armPending) return
+    setArmPending(true)
+    try {
+      if (servoArmedRef.current) {
+        await disarmServo()
+        return
+      }
+      const jointName = String(joint?.name || joint?.semantic_name || data.params?.joint_name || '').trim()
+      if (!robotId) throw new Error('Choose a local USB robot before arming')
+      if (!robotId.startsWith('local-usb-')) {
+        throw new Error('Direct Servo motion currently requires a local USB robot')
+      }
+      if (!profileId || profileId === 'none') {
+        throw new Error('Choose a calibrated profile before arming; None is read-only')
+      }
+      if (!jointName) throw new Error(`Servo ID ${servoId} is not reported by this robot`)
+      if (
+        connection !== 'live'
+        || sample?.stale
+        || rawMode
+        || !hasCalibratedLimits
+        || joint?.communication_ok === false
+        || hardwareFlags !== 0
+        || faults.length > 0
+      ) {
+        throw new Error('Motion blocked — live, calibrated, warning-free feedback is required')
+      }
+
+      await updateParam(id, 'robot_id', robotId)
+      await updateParam(id, 'profile_id', profileId)
+      await updateParam(id, 'joint_name', jointName)
+      const result = await api.controlNode(id, 'arm', {
+        robot_id: robotId,
+        profile_id: profileId,
+      })
+      const armed = result.outputs.armed === true
+      servoArmedRef.current = armed
+      setServoArmed(armed)
+      setMotionReport(String(
+        result.outputs.report
+        || (armed ? `Motion armed for ${jointName}` : 'Motion remains disarmed'),
+      ))
+    } catch (error) {
+      servoArmedRef.current = false
+      setServoArmed(false)
+      setMotionReport(error instanceof Error ? error.message : String(error))
+    } finally {
+      setArmPending(false)
+    }
+  }
+  const chooseRobot = (nextId: string) => {
+    if (servoArmedRef.current) void disarmServo('Motion disarmed because the robot changed')
+    void updateParam(id, 'robot_id', nextId)
+  }
+  const chooseProfile = async (nextProfileId: string) => {
+    if (servoArmedRef.current) {
+      await disarmServo('Motion disarmed because the profile changed')
+    }
+    const current = devices.find(item => item.id === robotId)
+    await updateParam(id, 'profile_id', nextProfileId)
+    try {
+      const result = await api.listRobotMonitorTargets(nextProfileId)
+      setDevices(result.targets)
+      setProfiles(result.profiles || [])
+      if (current?.kind === 'local_usb') {
+        const replacement = result.targets.find(item => (
+          item.kind === 'local_usb'
+          && (
+            item.hardware_id === current.hardware_id
+            || item.port === current.port
+          )
+        ))
+        if (replacement) {
+          await updateParam(id, 'robot_id', replacement.id)
+        }
+      }
+    } catch {
+      // The stream status remains visible and will retry after target refresh.
+    }
   }
 
   return (
@@ -164,8 +382,29 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
       selected={selected}
       color="#14b8a6"
       nodeType={data.type}
-      style={{ width: '100%', minWidth: 330 }}
+      style={{
+        width: '100%',
+        height: '100%',
+        minWidth: 330,
+        minHeight: 350,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
     >
+      <NodeResizer
+        minWidth={330}
+        minHeight={350}
+        isVisible={selected}
+        lineStyle={{ borderColor: '#14b8a6' }}
+        handleStyle={{
+          background: '#14b8a6',
+          borderColor: '#14b8a6',
+          width: 8,
+          height: 8,
+          borderRadius: 2,
+        }}
+      />
+
       <Handle
         type="target"
         position={Position.Left}
@@ -179,21 +418,101 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
           <strong>{joint?.semantic_name || joint?.name || `ID ${servoId}`}</strong>
           <small>{robotName}</small>
         </div>
-        <label className="nodrag" onMouseDown={event => event.stopPropagation()}>
-          <span>ID</span>
-          <input
-            type="number"
-            min={1}
-            max={253}
-            value={servoId}
-            list={`servo-ids-${id}`}
-            onChange={event => chooseServo(Number(event.target.value))}
-          />
+        <div className="bn-servo-id-field nodrag" onMouseDown={event => event.stopPropagation()}>
+          <label htmlFor={`servo-id-${id}`}>ID</label>
+          <div className="bn-servo-id-control">
+            <input
+              id={`servo-id-${id}`}
+              type="number"
+              min={1}
+              max={253}
+              value={servoId}
+              list={`servo-ids-${id}`}
+              onChange={event => chooseServo(Number(event.target.value))}
+            />
+            <div className="bn-servo-id-stepper">
+              <button
+                type="button"
+                aria-label="Increase servo ID"
+                title="Increase servo ID"
+                disabled={servoId >= 253}
+                onClick={() => stepServo(1)}
+              >
+                ▲
+              </button>
+              <button
+                type="button"
+                aria-label="Decrease servo ID"
+                title="Decrease servo ID"
+                disabled={servoId <= 1}
+                onClick={() => stepServo(-1)}
+              >
+                ▼
+              </button>
+            </div>
+          </div>
           <datalist id={`servo-ids-${id}`}>
             {detectedIds.map(value => <option key={value} value={value} />)}
           </datalist>
-        </label>
+        </div>
       </header>
+
+      <div
+        className="bn-servo-source-pickers nodrag"
+        onMouseDown={event => event.stopPropagation()}
+        onClick={event => event.stopPropagation()}
+      >
+        <label className="bn-servo-robot-picker">
+          <span>Profile</span>
+          <select
+            value={profileId}
+            disabled={Boolean(source && !directRobotId)}
+            onChange={event => void chooseProfile(event.target.value)}
+            aria-label="Profile for local USB servo telemetry"
+          >
+            <option value="auto">
+              {source && !directRobotId ? 'From connected node · Auto' : 'Auto · match hardware'}
+            </option>
+            <option value="none">None · raw read-only</option>
+            {profiles.map(profile => (
+              <option key={profile.id} value={profile.id}>
+                {profile.name} · {profile.id}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="bn-servo-robot-picker">
+          <span>Robot source</span>
+          <select
+            value={directRobotId}
+            onChange={event => chooseRobot(event.target.value)}
+            aria-label="Robot for servo telemetry"
+          >
+            <option value="">
+              {source ? `Connected node · ${robotName}` : 'Choose a robot…'}
+            </option>
+            {devices.some(device => device.kind === 'local_usb') && (
+              <optgroup label="Local USB">
+                {devices.filter(device => device.kind === 'local_usb').map(device => (
+                  <option key={device.id} value={device.id} disabled={!device.available}>
+                    {device.name}{device.available ? '' : ' (profile needed)'}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+            {devices.some(device => device.kind === 'registered') && (
+              <optgroup label="Registered robots">
+                {devices.filter(device => device.kind === 'registered').map(device => (
+                  <option key={device.id} value={device.id}>{device.name}</option>
+                ))}
+              </optgroup>
+            )}
+            {directRobotId && !devices.some(device => device.id === directRobotId) && (
+              <option value={directRobotId}>{directRobotId} (unavailable)</option>
+            )}
+          </select>
+        </label>
+      </div>
 
       <div className="bn-servo-node-state" style={{ color: stateTone }}>
         <span style={{ background: stateTone }} />
@@ -219,19 +538,37 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
 
           <div className="bn-servo-node-slider nodrag" onMouseDown={event => event.stopPropagation()}>
             <div>
-              <span>Target preview</span>
-              <button
-                type="button"
-                onClick={() => { void updateParam(id, 'follow_feedback', true) }}
-              >
-                Use current
-              </button>
+              <span>
+                {rawMode
+                  ? 'Target unavailable in raw mode'
+                  : servoArmed
+                    ? 'Live target'
+                    : 'Target preview'}
+              </span>
+              <div className="bn-servo-node-slider-actions">
+                <button
+                  type="button"
+                  disabled={rawMode}
+                  onClick={() => { void updateParam(id, 'follow_feedback', true) }}
+                >
+                  Use current
+                </button>
+                <button
+                  type="button"
+                  className={`bn-servo-motion-arm${servoArmed ? ' is-armed' : ''}`}
+                  disabled={rawMode || armPending}
+                  onClick={() => { void toggleServoArm() }}
+                >
+                  {armPending ? 'Working…' : servoArmed ? 'Disarm' : 'Arm'}
+                </button>
+              </div>
             </div>
             <input
               type="range"
+              disabled={rawMode}
               min={lower}
               max={upper}
-              step={units === 'degrees' ? 0.1 : 0.002}
+              step={rawMode ? 1 : units === 'degrees' ? 0.1 : 0.002}
               value={target}
               onChange={event => setTarget(Number(event.target.value))}
             />
@@ -243,12 +580,25 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
           </div>
 
           <div className="bn-servo-node-facts">
-            <span>Limits <strong>{hasCalibratedLimits ? 'Calibrated' : 'Profile/default'}</strong></span>
+            <span>Limits <strong>{rawMode ? 'Unknown · raw' : hasCalibratedLimits ? 'Calibrated' : 'Profile/default'}</strong></span>
+            <span>Communication <strong>{joint.communication_ok === false ? 'Failed' : 'Responding'}</strong></span>
             <span>Torque <strong>{sample?.payload?.torque_enabled == null ? 'Unknown' : sample.payload.torque_enabled ? 'On' : 'Off'}</strong></span>
             <span>Temperature <strong>{temperature == null ? 'Not reported' : `${temperature.toFixed(1)} °C`}</strong></span>
-            <span>Voltage <strong>{sample?.payload?.voltage_v == null ? 'Not reported' : `${sample.payload.voltage_v.toFixed(2)} V`}</strong></span>
+            <span>Voltage <strong>{voltage == null ? 'Not reported' : `${voltage.toFixed(2)} V`}</strong></span>
+            <span>Status <strong className={hardwareFlags ? 'is-warning' : ''}>{hardwareFlags ? `0x${hardwareFlags.toString(16).padStart(2, '0')}` : '0x00'}</strong></span>
             <span>Faults <strong className={faults.length ? 'is-error' : ''}>{faults.length || 'None'}</strong></span>
+            <span>Timeouts <strong className={bus?.timeout_count ? 'is-warning' : ''}>{bus?.timeout_count ?? 'Not reported'}</strong></span>
+            <span>Packet errors <strong className={bus?.serial_packet_error_count ? 'is-warning' : ''}>{bus?.serial_packet_error_count ?? 'Not reported'}</strong></span>
           </div>
+          {hardwareErrors.length > 0 && (
+            <div className="bn-servo-node-warning">
+              <strong>Hardware warning</strong>
+              <span>
+                0x{hardwareFlags.toString(16).padStart(2, '0')} · {hardwareErrors.join(', ')}
+              </span>
+              <small>{hardwareWarningHint(joint)}</small>
+            </div>
+          )}
           {faults.length > 0 && (
             <div className="bn-servo-node-fault">
               {faults.map((fault, index) => (
@@ -259,7 +609,12 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
             </div>
           )}
           <div className="bn-servo-node-note">
-            Preview only · connect <strong>joint</strong> and <strong>target</strong> to a motion node to execute.
+            {rawMode
+              ? 'Read-only raw ticks · select a profile before calibration or motion.'
+              : servoArmed
+                ? <>Live motion armed · dragging this slider moves <strong>{joint?.name || joint?.semantic_name}</strong>.</>
+                : 'Preview only · press Arm here to enable live motion.'}
+            {motionReport && <small>{motionReport}</small>}
           </div>
         </>
       ) : (
@@ -268,7 +623,7 @@ export default function RobotServoNode({ id, data, selected }: NodeProps<NodeDat
           <span>
             {detectedIds.length
               ? `Reported IDs: ${detectedIds.join(', ')}`
-              : 'Run the Robot node or select a registered Robot Monitor target.'}
+              : 'Connect a Robot node or choose a local USB or registered robot above.'}
           </span>
         </div>
       )}

--- a/editor/src/components/TemplateGallery.tsx
+++ b/editor/src/components/TemplateGallery.tsx
@@ -17,6 +17,20 @@ interface TemplateGalleryProps {
   openInNewTab?: boolean
 }
 
+function normalizedEnableTarget(
+  target: { package: string; component: string; adapter?: string },
+): { package: string; component: string; adapter?: string } {
+  const separator = target.component.indexOf('@')
+  if (separator < 0) return target
+  const component = target.component.slice(0, separator)
+  const compactAdapter = target.component.slice(separator + 1)
+  return {
+    ...target,
+    component,
+    adapter: target.adapter || compactAdapter || undefined,
+  }
+}
+
 function templateTags(template: TemplateMeta): string[] {
   const tags = [
     ...(template.categories ?? []).filter(category => category !== 'Custom'),
@@ -199,14 +213,23 @@ export default function TemplateGallery({
   ) => {
     event.stopPropagation()
     if (enabling || installing) return
-    const label = target.adapter
-      ? `${target.package}/${target.component}@${target.adapter}`
-      : `${target.package}/${target.component}`
+    const normalized = normalizedEnableTarget(target)
+    const label = normalized.adapter
+      ? `${normalized.package}/${normalized.component}@${normalized.adapter}`
+      : `${normalized.package}/${normalized.component}`
     setEnabling({ slug: template.slug, label })
     try {
-      await api.setPackageComponent(target.package, target.component, true)
-      if (target.adapter) {
-        await api.setPackageAdapter(target.package, target.component, target.adapter, true)
+      if (normalized.adapter) {
+        // Adapter activation transactionally enables its parent component and
+        // dependency graph, so a separate component request is unnecessary.
+        await api.setPackageAdapter(
+          normalized.package,
+          normalized.component,
+          normalized.adapter,
+          true,
+        )
+      } else {
+        await api.setPackageComponent(normalized.package, normalized.component, true)
       }
       await loadNodeTypes()
       await refreshTemplates()

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -1624,6 +1624,94 @@ html[data-theme="light"] .bn-logo-image-light {
   margin: 0;
 }
 
+.bn-ssh-ros-inspection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 9px;
+  border: 1px solid color-mix(in srgb, var(--ok) 34%, var(--line));
+  border-radius: var(--control-radius);
+  background: color-mix(in srgb, var(--ok) 4%, var(--lift));
+}
+
+.bn-ssh-ros-inspection > p {
+  margin: 0;
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.bn-ssh-ros-capabilities {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.bn-ssh-ros-capabilities article {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+  padding: 7px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--panel);
+}
+
+.bn-ssh-ros-capabilities article > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.bn-ssh-ros-capabilities strong {
+  color: var(--tx1);
+  font-size: 11px;
+  text-transform: capitalize;
+}
+
+.bn-ssh-ros-capabilities span,
+.bn-ssh-ros-capabilities small {
+  color: var(--tx3);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
+.bn-ssh-ros-unclassified {
+  color: var(--tx2);
+  font-size: 11px;
+}
+
+.bn-ssh-ros-unclassified summary {
+  cursor: pointer;
+}
+
+.bn-ssh-ros-unclassified > div {
+  display: flex;
+  max-height: 180px;
+  margin-top: 6px;
+  flex-direction: column;
+  gap: 3px;
+  overflow: auto;
+}
+
+.bn-ssh-ros-unclassified code {
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
+.bn-ssh-ros-errors {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  color: var(--warn);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
 .bn-runtime-install-options {
   display: grid;
   gap: 6px;
@@ -3597,13 +3685,27 @@ button.bn-compute-device-card:active:not(:disabled) {
   gap: 18px;
   padding: 11px 13px;
   border-bottom: 1px solid var(--line2);
+  border-radius:
+    var(--bn-node-inner-radius, 8px)
+    var(--bn-node-inner-radius, 8px)
+    0
+    0;
   background:
     linear-gradient(90deg, color-mix(in srgb, #00b8d9 18%, transparent), transparent 55%),
     var(--lift);
+  flex-shrink: 0;
 }
 
 .bn-robot-monitor-node-title > div {
   min-width: 0;
+}
+
+.bn-robot-monitor-node-title .bn-robot-monitor-node-pickers {
+  display: grid;
+  width: min(500px, 68%);
+  min-width: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
 }
 
 .bn-robot-monitor-node-title > div span,
@@ -3630,7 +3732,7 @@ button.bn-compute-device-card:active:not(:disabled) {
 
 .bn-robot-monitor-node-title label {
   display: flex;
-  min-width: 250px;
+  min-width: 0;
   flex-direction: column;
   gap: 3px;
   color: var(--tx3);
@@ -3659,9 +3761,14 @@ button.bn-compute-device-card:active:not(:disabled) {
 }
 
 .bn-robot-monitor.bn-robot-monitor-node-panel {
+  flex: 1 1 auto;
   margin-top: 0;
   border: 0;
-  border-radius: 0 0 8px 8px;
+  border-radius:
+    0
+    0
+    var(--bn-node-inner-radius, 8px)
+    var(--bn-node-inner-radius, 8px);
   box-shadow: none;
 }
 
@@ -3753,7 +3860,7 @@ button.bn-compute-device-card:active:not(:disabled) {
 
 .bn-robot-monitor-overview {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(105px, 1fr));
   gap: 1px;
   padding: 1px 0;
   border-bottom: 1px solid color-mix(in srgb, #00d2ff 20%, var(--line));
@@ -3853,7 +3960,7 @@ button.bn-compute-device-card:active:not(:disabled) {
 
 .bn-robot-monitor-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 8px;
   padding: 9px 10px 10px;
 }
@@ -3864,6 +3971,13 @@ button.bn-compute-device-card:active:not(:disabled) {
   border: 1px solid #737373;
   border-radius: 6px;
   background: color-mix(in srgb, var(--lift) 91%, transparent);
+}
+
+.bn-joint-monitor-card.is-warning {
+  border-color: color-mix(in srgb, var(--warn) 70%, #737373);
+  background:
+    linear-gradient(color-mix(in srgb, var(--warn) 6%, transparent), transparent 55%),
+    color-mix(in srgb, var(--lift) 91%, transparent);
 }
 
 .bn-joint-monitor-title,
@@ -3880,6 +3994,21 @@ button.bn-compute-device-card:active:not(:disabled) {
   font-size: 11px;
   text-overflow: ellipsis;
   text-transform: capitalize;
+  white-space: nowrap;
+}
+
+.bn-joint-monitor-title > div {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.bn-joint-monitor-title small {
+  overflow: hidden;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -3942,6 +4071,56 @@ button.bn-compute-device-card:active:not(:disabled) {
 .bn-joint-monitor-speed strong {
   color: var(--tx2);
   font-weight: 600;
+}
+
+.bn-joint-monitor-diagnostics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px 8px;
+  margin-top: 7px;
+  padding-top: 7px;
+  border-top: 1px solid color-mix(in srgb, #737373 42%, transparent);
+}
+
+.bn-joint-monitor-diagnostics span {
+  display: flex;
+  min-width: 0;
+  justify-content: space-between;
+  gap: 5px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-joint-monitor-diagnostics strong {
+  overflow: hidden;
+  color: var(--tx2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-joint-monitor-warning {
+  display: grid;
+  gap: 2px;
+  margin-top: 7px;
+  padding: 6px 7px;
+  border: 1px solid color-mix(in srgb, var(--warn) 55%, transparent);
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--warn) 8%, transparent);
+  color: var(--warn);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.bn-joint-monitor-warning strong {
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.bn-joint-monitor-warning small {
+  color: var(--tx2);
+  font-size: 11px;
 }
 
 .bn-robot-monitor-empty {
@@ -4212,7 +4391,8 @@ button.bn-device-fact {
     grid-template-columns: 1fr;
   }
 
-  .bn-host-environment-grid {
+  .bn-host-environment-grid,
+  .bn-ssh-ros-capabilities {
     grid-template-columns: 1fr;
   }
 
@@ -4898,6 +5078,35 @@ button.bn-device-fact {
 .bn-robot-profile-row .bn-deploy-device-select,
 .bn-robot-calibration-choice .bn-deploy-device-select {
   margin-top: 0;
+}
+
+.bn-robot-node-profile-summary {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  margin: -2px 0 7px;
+  padding: 5px 7px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--accent) 5%, var(--panel));
+}
+
+.bn-robot-node-profile-summary strong,
+.bn-robot-node-profile-summary span {
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.bn-robot-node-profile-summary strong {
+  color: var(--tx1);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.bn-robot-node-profile-summary span {
+  color: var(--tx3);
+  font: 600 10px/1.35 var(--font-ui);
 }
 
 .bn-robot-step-empty {
@@ -7529,6 +7738,7 @@ html[data-ui-test="refined"][data-node-density="compact"] .react-flow__node-blac
 }
 
 html[data-ui-test="refined"] .bn-node-frame {
+  --bn-node-inner-radius: 15px;
   border-color:
     color-mix(in srgb, var(--bn-node-accent) 42%, var(--line2)) !important;
   border-radius: 16px !important;
@@ -7562,7 +7772,11 @@ html[data-ui-test="refined"] .bn-node-frame::before {
 html[data-ui-test="refined"] .bn-node-header {
   min-height: 64px;
   padding: 14px 13px 13px 15px !important;
-  border-radius: 15px 15px 0 0 !important;
+  border-radius:
+    var(--bn-node-inner-radius)
+    var(--bn-node-inner-radius)
+    0
+    0 !important;
   filter: saturate(1.045) brightness(1.045);
 }
 
@@ -8720,6 +8934,86 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   }
 }
 
+.bn-joint-definition-fields {
+  display: grid;
+  gap: 8px;
+  margin: 10px 12px 5px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--bn-node-accent) 34%, var(--line));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bn-node-accent) 7%, var(--lift));
+}
+
+.bn-joint-definition-fields-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.bn-joint-definition-fields-head span {
+  color: var(--tx3);
+  font: 750 10px/1.2 var(--font-ui);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.bn-joint-definition-fields-head strong {
+  color: var(--bn-node-accent);
+  font: 800 11px/1.2 var(--font-mono);
+}
+
+.bn-joint-definition-fields-grid {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 8px;
+}
+
+.bn-joint-definition-fields-grid label {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.bn-joint-definition-fields-grid label:last-child {
+  grid-column: 1 / -1;
+}
+
+.bn-joint-definition-fields-grid label > span {
+  color: var(--tx3);
+  font: 650 10px/1.2 var(--font-ui);
+}
+
+.bn-joint-definition-fields-grid input {
+  width: 100%;
+  min-width: 0;
+  min-height: 30px;
+  padding: 5px 7px;
+  border: 1px solid var(--line);
+  border-radius: var(--control-radius);
+  outline: 0;
+  background: var(--panel);
+  color: var(--tx1);
+  font: 700 12px/1.2 var(--font-ui);
+}
+
+.bn-joint-definition-fields-grid input[type="number"] {
+  appearance: textfield;
+  font-family: var(--font-mono);
+  text-align: center;
+}
+
+.bn-joint-definition-fields-grid input[type="number"]::-webkit-inner-spin-button,
+.bn-joint-definition-fields-grid input[type="number"]::-webkit-outer-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.bn-joint-definition-fields-grid input:focus {
+  border-color: var(--bn-node-accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--bn-node-accent) 18%, transparent);
+}
+
 .bn-servo-node-title {
   display: flex;
   align-items: flex-start;
@@ -8750,7 +9044,7 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   white-space: nowrap;
 }
 
-.bn-servo-node-title label {
+.bn-servo-id-field {
   display: flex;
   align-items: center;
   gap: 5px;
@@ -8758,14 +9052,114 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   font: 700 11px/1 var(--font-ui);
 }
 
-.bn-servo-node-title input {
-  width: 58px;
-  padding: 4px 5px;
+.bn-servo-id-control {
+  display: grid;
+  width: 74px;
+  min-height: 30px;
+  grid-template-columns: minmax(0, 1fr) 21px;
+  overflow: hidden;
   border: 1px solid var(--line);
-  border-radius: 5px;
-  background: var(--lift);
+  border-radius: 6px;
+  background: color-mix(in srgb, #14b8a6 6%, var(--lift));
+  box-shadow: inset 0 1px color-mix(in srgb, #fff 5%, transparent);
+}
+
+.bn-servo-id-control:focus-within {
+  border-color: #14b8a6;
+  box-shadow: 0 0 0 2px color-mix(in srgb, #14b8a6 20%, transparent);
+}
+
+.bn-servo-id-control input {
+  width: 100%;
+  min-width: 0;
+  padding: 5px 4px 5px 7px;
+  border: 0;
+  outline: 0;
+  appearance: textfield;
+  background: transparent;
   color: var(--tx1);
-  font: 700 12px/1 var(--font-mono);
+  font: 800 12px/1 var(--font-mono);
+  text-align: center;
+}
+
+.bn-servo-id-control input::-webkit-inner-spin-button,
+.bn-servo-id-control input::-webkit-outer-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.bn-servo-id-stepper {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  border-left: 1px solid var(--line);
+}
+
+.bn-servo-id-stepper button {
+  display: grid;
+  width: 20px;
+  min-height: 0;
+  padding: 0 !important;
+  place-items: center;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: color-mix(in srgb, #14b8a6 10%, var(--panel));
+  color: color-mix(in srgb, #14b8a6 78%, var(--tx1));
+  font: 700 7px/1 var(--font-ui);
+  cursor: pointer;
+}
+
+.bn-servo-id-stepper button:first-child {
+  border-bottom: 1px solid var(--line) !important;
+}
+
+.bn-servo-id-stepper button:hover:not(:disabled) {
+  background: color-mix(in srgb, #14b8a6 24%, var(--panel));
+  color: #5eead4;
+}
+
+.bn-servo-id-stepper button:disabled {
+  color: var(--tx3);
+  cursor: default !important;
+  opacity: .35;
+}
+
+.bn-servo-source-pickers {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.bn-servo-robot-picker {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.bn-servo-robot-picker > span {
+  color: var(--tx3);
+  font: 700 9px/1 var(--font-ui);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.bn-servo-robot-picker select {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  padding: 0 8px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  outline: 0;
+  background: color-mix(in srgb, #14b8a6 6%, var(--lift));
+  color: var(--tx1);
+  font: 700 11px/1 var(--font-ui);
+}
+
+.bn-servo-robot-picker select:focus {
+  border-color: #14b8a6;
+  box-shadow: 0 0 0 2px color-mix(in srgb, #14b8a6 20%, transparent);
 }
 
 .bn-servo-node-state {
@@ -8842,6 +9236,30 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   cursor: pointer;
 }
 
+.bn-servo-node-slider-actions {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.bn-servo-node-slider button.bn-servo-motion-arm {
+  min-width: 52px;
+  border-color: color-mix(in srgb, #14b8a6 65%, var(--line));
+  background: color-mix(in srgb, #14b8a6 14%, var(--bg2));
+  color: #5eead4;
+}
+
+.bn-servo-node-slider button.bn-servo-motion-arm.is-armed {
+  border-color: color-mix(in srgb, #ef4444 70%, var(--line));
+  background: color-mix(in srgb, #ef4444 14%, var(--bg2));
+  color: #fca5a5;
+}
+
+.bn-servo-node-slider button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .bn-servo-node-slider input[type="range"] {
   width: 100%;
   accent-color: #14b8a6;
@@ -8869,6 +9287,27 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   color: var(--err);
 }
 
+.bn-servo-node-facts .is-warning {
+  color: var(--warn);
+}
+
+.bn-servo-node-warning {
+  display: grid;
+  gap: 3px;
+  margin: 0 12px 8px;
+  padding: 7px;
+  border: 1px solid color-mix(in srgb, var(--warn) 55%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--warn) 7%, transparent);
+  color: var(--warn);
+  font: 600 10px/1.35 var(--font-ui);
+}
+
+.bn-servo-node-warning small {
+  color: var(--tx2);
+  font-size: 11px;
+}
+
 .bn-servo-node-fault {
   display: grid;
   gap: 3px;
@@ -8890,6 +9329,16 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   font: 600 10px/1.4 var(--font-ui);
 }
 
+.bn-servo-node-note {
+  display: grid;
+  gap: 3px;
+}
+
+.bn-servo-node-note small {
+  color: var(--tx2);
+  font: inherit;
+}
+
 .bn-servo-node-empty {
   display: grid;
   gap: 4px;
@@ -8898,5 +9347,108 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
 
 .bn-servo-node-empty strong {
   color: var(--tx1);
+  font-size: 12px;
+}
+.bn-compute-device-node-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid color-mix(in srgb, #14b8a6 30%, transparent);
+}
+
+.bn-compute-device-node-title > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.bn-compute-device-node-title span {
+  color: var(--tx3);
+  font-size: 11px;
+  letter-spacing: .08em;
+}
+
+.bn-compute-device-node-title strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-compute-device-node-title > span.is-ready {
+  color: var(--ok);
+}
+
+.bn-compute-device-node-body {
+  display: grid;
+  gap: 12px;
+  padding: 14px 16px 16px;
+}
+
+.bn-compute-device-node-body label {
+  display: grid;
+  gap: 5px;
+  color: var(--tx2);
+  font-size: 11px;
+}
+
+.bn-compute-device-node-body select {
+  width: 100%;
+}
+
+.bn-compute-device-node-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.bn-compute-device-node-facts span {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-compute-device-node-facts strong {
+  color: var(--tx1);
+  font-weight: 600;
+}
+
+.bn-compute-device-node-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.bn-compute-device-node-actions button {
+  flex: 0 0 auto;
+}
+
+.bn-compute-device-node-actions small {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--tx3);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-device-inspection-only {
+  display: grid;
+  gap: 3px;
+  margin: 0 0 14px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, #14b8a6 35%, var(--line));
+  border-radius: 8px;
+  background: color-mix(in srgb, #14b8a6 8%, transparent);
+}
+
+.bn-device-inspection-only span {
+  color: var(--tx2);
   font-size: 12px;
 }

--- a/editor/src/robotTelemetryDiagnostics.ts
+++ b/editor/src/robotTelemetryDiagnostics.ts
@@ -1,0 +1,17 @@
+import type { RobotTelemetryJoint } from './api'
+
+export function hardwareWarningHint(joint: RobotTelemetryJoint): string {
+  const errors = joint.hardware_errors || []
+  if (errors.includes('voltage')) {
+    const measured = joint.voltage_v == null
+      ? ''
+      : ` at ${joint.voltage_v.toFixed(1)} V`
+    return (
+      `Input voltage protection is active${measured}. `
+      + 'Check that the connected power supply matches this robot and servo '
+      + 'voltage rating; follower and leader supplies may differ. Keep torque '
+      + 'off until the warning clears.'
+    )
+  }
+  return 'Read-only telemetry remains available. Inspect the hardware warning before enabling motion.'
+}

--- a/editor/src/robotTelemetryStream.ts
+++ b/editor/src/robotTelemetryStream.ts
@@ -12,6 +12,7 @@ type Listener = {
 
 type Stream = {
   robotId: string
+  profileId: string
   listeners: Set<Listener>
   socket: WebSocket | null
   reconnectTimer?: number
@@ -30,7 +31,9 @@ function publishConnection(stream: Stream, connection: RobotMonitorConnection) {
 function connect(stream: Stream) {
   if (stream.stopped || stream.listeners.size === 0) return
   publishConnection(stream, 'connecting')
-  const socket = new WebSocket(deviceMonitorSocketUrl(stream.robotId))
+  const socket = new WebSocket(
+    deviceMonitorSocketUrl(stream.robotId, stream.profileId),
+  )
   stream.socket = socket
   socket.onopen = () => publishConnection(stream, 'live')
   socket.onmessage = event => {
@@ -54,25 +57,29 @@ function connect(stream: Stream) {
 
 export function subscribeRobotTelemetry(
   robotId: string,
+  profileId: string,
   onSample: Listener['onSample'],
   onConnection: Listener['onConnection'],
 ): () => void {
   const cleanId = String(robotId || '').trim()
+  const cleanProfileId = String(profileId || 'auto').trim() || 'auto'
   if (!cleanId) {
     onConnection('idle')
     return () => undefined
   }
-  let stream = streams.get(cleanId)
+  const streamKey = `${cleanId}\u0000${cleanProfileId}`
+  let stream = streams.get(streamKey)
   if (!stream) {
     stream = {
       robotId: cleanId,
+      profileId: cleanProfileId,
       listeners: new Set(),
       socket: null,
       connection: 'connecting',
       latest: null,
       stopped: false,
     }
-    streams.set(cleanId, stream)
+    streams.set(streamKey, stream)
   }
   const listener = { onSample, onConnection }
   stream.listeners.add(listener)
@@ -91,6 +98,6 @@ export function subscribeRobotTelemetry(
     const socket = stream!.socket
     stream!.socket = null
     socket?.close()
-    streams.delete(cleanId)
+    streams.delete(streamKey)
   }
 }

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -330,6 +330,7 @@ function reactNodeType(typeName: string): string {
   if (SUBGRAPH_NODE_TYPES.has(typeName)) return 'subnetnode'
   if (typeName === 'SubnetInput') return 'subnetinput'
   if (typeName === 'SubnetOutput') return 'subnetoutput'
+  if (typeName === 'ComputeDevice') return 'computedevice'
   if (typeName === 'RobotMonitor') return 'robotmonitor'
   if (typeName === 'RobotServo') return 'robotservo'
   return OUTPUT_NODE_TYPES.has(typeName) ? 'outputnode' : MODEL_NODE_TYPES.has(typeName) ? 'modelnode' : VALUE_NODE_TYPES.has(typeName) ? 'valuenode' : 'blacknode'
@@ -388,6 +389,7 @@ function makeReactNode(meta: BnNodeMeta): Node<NodeData> {
     ...(meta.type === 'ROS2VisualDashboard' ? { style: { width: 840, height: 760 } } : {}),
     ...(meta.type === 'ROS2Run' ? { style: { width: 520, height: 360 } } : {}),
     ...(meta.type === 'ROS2MotionDashboard' ? { style: { width: 860, height: 720 } } : {}),
+    ...(meta.type === 'ComputeDevice' ? { style: { width: 460, height: 260 } } : {}),
     ...(meta.type === 'RobotMonitor' ? { style: { width: 760 } } : {}),
     ...(meta.type === 'RobotServo' ? { style: { width: 360 } } : {}),
   }
@@ -3254,6 +3256,23 @@ export const useStore = create<Store>((set, get) => ({
     }
     const applyCookEvent = (event: CookEvent) => {
       queueLiveReplay(event)
+      const successfulNodeType = event.type === 'success'
+        ? (
+            event.node_type
+            ?? cookNodes.find(node => node.id === event.node_id)?.data.type
+            ?? ''
+          )
+        : ''
+      if (
+        event.type === 'success'
+        && successfulNodeType === 'RobotProfileSave'
+        && event.outputs?.saved === true
+      ) {
+        // Saved profiles are filesystem-backed and can appear after package
+        // registration. Refresh both schema dropdowns and live Robot cards.
+        void get().loadNodeTypes()
+        window.dispatchEvent(new Event('blacknode:robot-profiles-changed'))
+      }
       if (
         event.type === 'success'
         && cookProject
@@ -3266,12 +3285,9 @@ export const useStore = create<Store>((set, get) => ({
         const captureKey = `${cookProject.id}:${cookTab.slug}:${event.node_id}`
         if (signature && artifactCaptureSignatures.get(captureKey) !== signature) {
           artifactCaptureSignatures.set(captureKey, signature)
-          const nodeType = event.node_type
-            ?? cookNodes.find(node => node.id === event.node_id)?.data.type
-            ?? ''
           void api.importProjectArtifacts(cookProject.id, {
             workflow_slug: cookTab.slug,
-            node_type: nodeType,
+            node_type: successfulNodeType,
             value: candidates.payloads,
           }).then(() => {
             set(state => ({ projectRevision: state.projectRevision + 1 }))

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -292,7 +292,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "default": True,
                     "node_types": [
                         "FeetechBusConfig",
-                        "FeetechBusProbe"
+                        "FeetechBusProbe",
+                        "FeetechCalibrationProvider"
                     ],
                     "adapters": {
                         "ros2": {
@@ -324,6 +325,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "node_types": [
                 "FeetechBusConfig",
                 "FeetechBusProbe",
+                "FeetechCalibrationProvider",
                 "FeetechROS2Adapter"
             ]
         },
@@ -513,6 +515,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "name": "calibration",
                     "default": True,
                     "node_types": [
+                        "RobotCalibrationControl",
+                        "RobotCalibrationMockProvider",
                         "RobotCalibrationRecorder"
                     ]
                 },
@@ -566,6 +570,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "Robot",
                 "RobotAttachment",
                 "RobotAttachmentList",
+                "RobotCalibrationControl",
+                "RobotCalibrationMockProvider",
                 "RobotCalibrationRecorder",
                 "RobotCapabilityBinding",
                 "RobotCapabilityInspect",
@@ -631,7 +637,12 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "depth": {
                     "name": "depth",
                     "default": True,
-                    "node_types": [],
+                    "node_types": [
+                        "DepthCamera",
+                        "DepthCameraDeviceSelect",
+                        "DepthCameraTestProvider",
+                        "DepthObstacleWarning"
+                    ],
                     "adapters": {
                         "ros2": {
                             "name": "ros2",
@@ -707,6 +718,10 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "CameraStream",
                 "DetectionPrompt",
                 "DetectionStream",
+                "DepthCamera",
+                "DepthCameraDeviceSelect",
+                "DepthCameraTestProvider",
+                "DepthObstacleWarning",
                 "DepthROS2Subscribe",
                 "FramePrompt",
                 "ReasoningDashboard",
@@ -1115,6 +1130,9 @@ def template_component_requirements(workflow: Mapping[str, Any]) -> list[dict[st
             separator = "/" if package and component else ""
         else:
             continue
+        component_name, adapter_separator, adapter = component.partition("@")
+        if adapter_separator and component_name and adapter:
+            component = component_name
         if not separator or not package or not component:
             continue
         indexed = _CORE_PACKAGES.get(package, {})
@@ -1132,9 +1150,26 @@ def template_adapter_requirements(workflow: Mapping[str, Any]) -> list[dict[str,
     metadata = workflow.get("metadata")
     if not isinstance(metadata, Mapping):
         return []
-    raw_requirements = metadata.get("required_adapters")
-    if not isinstance(raw_requirements, list):
-        return []
+    raw_requirements: list[Any] = []
+    declared_adapters = metadata.get("required_adapters")
+    if isinstance(declared_adapters, list):
+        raw_requirements.extend(declared_adapters)
+    # Older templates sometimes placed compact component@adapter references in
+    # required_components. Preserve those saved workflows by resolving both the
+    # parent component and the nested adapter.
+    declared_components = metadata.get("required_components")
+    if isinstance(declared_components, list):
+        raw_requirements.extend(
+            raw
+            for raw in declared_components
+            if (
+                isinstance(raw, str)
+                and "@" in raw.partition("/")[2]
+            ) or (
+                isinstance(raw, Mapping)
+                and "@" in str(raw.get("component") or "")
+            )
+        )
     requirements: dict[tuple[str, str, str], dict[str, str]] = {}
     for raw in raw_requirements:
         if isinstance(raw, str):
@@ -1146,7 +1181,10 @@ def template_adapter_requirements(workflow: Mapping[str, Any]) -> list[dict[str,
             component = str(raw.get("component") or "").strip()
             adapter = str(raw.get("adapter") or "").strip()
             version = str(raw.get("version") or "").strip()
-            separator = "@" if adapter else ""
+            if not adapter:
+                component, separator, adapter = component.partition("@")
+            else:
+                separator = "@"
             component_separator = "/" if package and component else ""
         else:
             continue

--- a/skills/blacknode-development/SKILL.md
+++ b/skills/blacknode-development/SKILL.md
@@ -25,8 +25,10 @@ and a representative workflow when applicable.
    independent repositories, not tracked children of the core repository.
 4. Decide whether the capability belongs in core, an extension package, a
    user-local custom node, or a workflow-local `PythonFn`.
-5. Implement the narrowest coherent change, add tests, and update public docs.
-6. Build a small workflow/template when it materially proves discovery, ports,
+5. For a hardware, transport, simulation, or replay provider, read
+   `docs/provider-authoring.md` and inspect the live capability contract.
+6. Implement the narrowest coherent change, add tests, and update public docs.
+7. Build a small workflow/template when it materially proves discovery, ports,
    runtime behavior, or package resolution.
 
 ## Choose the Ownership Layer
@@ -82,7 +84,9 @@ Use current generic names in new templates and docs.
 ## Author an Extension Package
 
 Use `blacknode-cuda` as the smallest reference package. Read
-`docs/packages.md` and `docs/custom-nodes.md` before authoring.
+`docs/packages.md` and `docs/custom-nodes.md` before authoring. For a hardware,
+transport, simulation, or replay provider, also read
+`docs/provider-authoring.md`.
 
 Required shape:
 
@@ -123,6 +127,11 @@ node/package -> registry and schema -> editor-server/MCP -> editor -> template
 Update each affected layer in the same change. Do not persist editor-only fields
 such as `cookResult`, `cookError`, `cooking`, or `cookPort` in workflow JSON.
 
+For custom editor node headers or bodies, derive inner corners from the shared
+`--bn-node-inner-radius` token with the legacy radius as a fallback. Inspect
+later cascade overrides and do not introduce a separate fixed radius that can
+drift from the standard node shell.
+
 For hardware-facing contracts, test provider absence as well as provider
 presence. A missing optional module must degrade only its advertised
 capabilities, while compatible providers must produce the same normalized
@@ -131,6 +140,13 @@ state, lifecycle, status, error, and shutdown shapes.
 ## Hardware and Managed-Service Safety
 
 - Keep robot motion disarmed until explicitly authorized.
+- Treat communication presence and hardware health as separate states. Preserve
+  valid read-only telemetry when a response carries a hardware warning, expose
+  the raw status and decoded warning to nodes and monitors, and keep
+  motion/torque authorization strict.
+- A hardware warning may accompany a successful transition to a safer state.
+  Accept release, stop, or disarm only after independently reading the physical
+  state back as safe; never extend that tolerance to arm or torque-enable.
 - Never bypass calibrated limits, freshness checks, or emergency shutdown.
 - Treat worker heartbeat and source-data freshness as separate signals.
 - Preserve idempotent control behavior across retries.
@@ -160,6 +176,8 @@ Update the closest public contract alongside code:
 
 - `docs/agent-guide.md` for agent routing and workflow behavior.
 - `docs/packages.md` for package format and lifecycle.
+- `docs/provider-authoring.md` for capability providers, profile bindings,
+  adapters, managed lifecycle, and compatibility tests.
 - `docs/custom-nodes.md` for node authoring.
 - `CONTRIBUTING.md` for contributor setup and verification.
 - The affected package README for package-specific behavior.

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -8,6 +8,40 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class AgentSkillTests(unittest.TestCase):
+    def test_provider_authoring_is_documented_and_routed_by_development_skill(self):
+        guide = (ROOT / "docs" / "provider-authoring.md").read_text(
+            encoding="utf-8",
+        )
+        skill_paths = [
+            ROOT / "skills" / "blacknode-development" / "SKILL.md",
+            ROOT / ".agents" / "skills" / "blacknode-development" / "SKILL.md",
+        ]
+
+        for phrase in (
+            "Provider Authoring",
+            "Choose the owner first",
+            "Find or define the contract",
+            "Connect the binding to the implementation",
+            "Bind the provider to a robot",
+            "Prove compatibility",
+            "mock or replay provider",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, guide)
+
+        for path in skill_paths:
+            with self.subTest(path=str(path)):
+                self.assertIn(
+                    "docs/provider-authoring.md",
+                    path.read_text(encoding="utf-8"),
+                )
+
+        self.assertEqual(
+            skill_paths[0].read_text(encoding="utf-8"),
+            skill_paths[1].read_text(encoding="utf-8"),
+            "canonical and repository-local development skills must stay synchronized",
+        )
+
     def test_blacknode_skill_is_available_in_canonical_and_agents_paths(self):
         paths = [
             ROOT / "skills" / "blacknode-workflow" / "SKILL.md",

--- a/tests/test_compute_device_inspection.py
+++ b/tests/test_compute_device_inspection.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITOR_SERVER_DIR = ROOT / "editor-server"
+if str(EDITOR_SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(EDITOR_SERVER_DIR))
+
+import device_registry  # noqa: E402
+import server  # noqa: E402
+
+
+class ComputeDeviceInspectionTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.previous_registry = server._device_registry
+        server._device_registry = device_registry.DeviceRegistry(
+            Path(self.temporary.name) / "devices.json"
+        )
+        self.client = TestClient(server.app)
+
+    def tearDown(self):
+        self.client.close()
+        server._device_registry = self.previous_registry
+        self.temporary.cleanup()
+
+    def test_registered_ssh_inspection_is_credential_free_and_selectable(self):
+        inspection = {
+            "ok": True,
+            "host_fingerprint": "SHA256:trusted-key",
+            "instances": [],
+            "environment": {
+                "policy": "preserve",
+                "os": {"name": "Ubuntu", "version": "22.04"},
+                "ros2": {
+                    "available": True,
+                    "selected_distribution": "humble",
+                },
+            },
+            "ros2_graph": {
+                "available": False,
+                "state": "unavailable",
+                "read_only": True,
+                "daemon_used": False,
+                "topics": [],
+                "nodes": [],
+                "services": [],
+                "errors": [],
+            },
+            "suggested_port": 8766,
+            "suggested_instance_id": "instance-2",
+        }
+        with patch.object(server, "inspect_runtime", return_value=inspection):
+            response = self.client.post("/device-hosts/inspect", json={
+                "host": "192.168.55.1",
+                "port": 22,
+                "username": "ubuntu",
+                "password": "ssh-password",
+                "host_fingerprint": "SHA256:trusted-key",
+                "name": "Jetson",
+                "save_inspection": True,
+            })
+
+        self.assertEqual(response.status_code, 200)
+        device = response.json()["device"]
+        self.assertTrue(device["inspection_only"])
+        self.assertEqual(device["name"], "Jetson")
+        self.assertEqual(
+            device["inspection_connection"]["ssh_host"],
+            "192.168.55.1",
+        )
+        listed = self.client.get("/device-hosts").json()["devices"]
+        self.assertEqual([item["id"] for item in listed], [device["id"]])
+        serialized = json.dumps(listed)
+        self.assertNotIn("ssh-password", serialized)
+        self.assertNotIn('"runtime_token":', serialized)
+        self.assertTrue(listed[0]["last_inspection"]["ros2_graph"]["read_only"])
+
+    def test_inspection_only_host_rejects_runtime_client(self):
+        registry = server._device_registry
+        device = registry.register_inspection_host(
+            name="Jetson",
+            runtime_url="http://192.168.55.1:8766",
+            ssh_host="192.168.55.1",
+            ssh_port=22,
+            ssh_username="ubuntu",
+            host_fingerprint="SHA256:trusted-key",
+            inspection={"ok": True},
+        )
+
+        with self.assertRaisesRegex(
+            device_registry.DeviceRegistryError,
+            "read-only inspection",
+        ):
+            registry.host_client(device["id"])
+
+    def test_pairing_runtime_upgrades_matching_inspection_device_in_place(self):
+        registry = server._device_registry
+        inspected = registry.register_inspection_host(
+            name="Jetson",
+            runtime_url="http://192.168.55.1:8766",
+            ssh_host="192.168.55.1",
+            ssh_port=22,
+            ssh_username="ubuntu",
+            host_fingerprint="SHA256:trusted-key",
+            inspection={"ok": True},
+        )
+
+        paired = registry.pair_host(
+            name="Jetson",
+            runtime_url="http://192.168.55.1:8767",
+            runtime_token="runtime-secret-value-that-is-long-enough",
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "jetson-device",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.55.1",
+                "ssh_port": 22,
+                "ssh_username": "ubuntu",
+                "host_fingerprint": "SHA256:trusted-key",
+                "runtime_port": 8767,
+            },
+        )
+
+        self.assertEqual(paired["id"], inspected["id"])
+        self.assertFalse(paired["inspection_only"])
+        self.assertEqual(paired["runtime_url"], "http://192.168.55.1:8767")
+        self.assertEqual(len(registry.list_hosts()), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -9,6 +9,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 import urllib.error
 import urllib.parse
@@ -403,6 +404,37 @@ class EditorDeviceApiTests(unittest.TestCase):
         server._project_store = self._original_project_store
         self._tmp.cleanup()
 
+    def test_existing_robot_profile_opens_as_editable_joint_graph(self):
+        robots_root = Path(self._tmp.name) / "robots"
+        profile_dir = robots_root / "editable_arm"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "profile.json").write_text(json.dumps({
+            "id": "editable_arm",
+            "display_name": "Editable arm",
+            "protocol": "custom",
+            "driver": {"script": "arm_driver.py", "baudrate": 115200},
+            "joints": [
+                {"id": "second", "display_name": "Second", "servo_id": 2, "min_deg": -20, "max_deg": 20},
+                {"id": "first", "display_name": "First", "servo_id": 1, "min_deg": -10, "max_deg": 10},
+            ],
+        }), encoding="utf-8")
+
+        with patch.dict("os.environ", {"BLACKNODE_ROBOTS_DIR": str(robots_root)}):
+            response = self.client.get("/graph/profiles/editable_arm/editor")
+
+        self.assertEqual(response.status_code, 200)
+        graph = response.json()
+        joint_nodes = [node for node in graph["nodes"] if node["type"] == "RobotJointDefinition"]
+        self.assertEqual(
+            [node["params"]["joint_id"] for node in joint_nodes],
+            ["first", "second"],
+        )
+        definition = next(node for node in graph["nodes"] if node["type"] == "RobotDefinition")
+        save = next(node for node in graph["nodes"] if node["type"] == "RobotProfileSave")
+        self.assertEqual(definition["params"]["profile_id"], "editable_arm")
+        self.assertEqual(definition["params"]["baudrate"], 115200)
+        self.assertTrue(save["params"]["overwrite"])
+
     def test_runtime_inspection_keeps_remote_token_paths_private(self):
         output = (
             "remote preface\n"
@@ -417,6 +449,21 @@ class EditorDeviceApiTests(unittest.TestCase):
                     "policy": "preserve",
                     "docker": {"available": True, "server_version": "27.5.1"},
                 },
+                "ros2_graph": {
+                    "available": True,
+                    "state": "available",
+                    "distribution": "humble",
+                    "domain_id": "0",
+                    "read_only": True,
+                    "daemon_used": False,
+                    "topics": [
+                        "/scan [sensor_msgs/msg/LaserScan]",
+                        "/controller/cmd_vel [geometry_msgs/msg/Twist]",
+                    ],
+                    "nodes": ["/controller"],
+                    "services": ["/controller/get_parameters"],
+                    "errors": [],
+                },
                 "suggested_port": 8767,
                 "suggested_instance_id": "instance-2",
             })
@@ -429,7 +476,25 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertNotIn("_token_file", public["instances"][0])
         self.assertNotIn("auth.token", json.dumps(public))
         self.assertEqual(public["environment"]["docker"]["server_version"], "27.5.1")
+        self.assertTrue(public["ros2_graph"]["read_only"])
+        self.assertFalse(public["ros2_graph"]["daemon_used"])
+        self.assertEqual(
+            public["ros2_graph"]["topics"],
+            [
+                "/scan [sensor_msgs/msg/LaserScan]",
+                "/controller/cmd_vel [geometry_msgs/msg/Twist]",
+            ],
+        )
         self.assertEqual(public["suggested_port"], 8767)
+
+    def test_remote_ros_inspection_never_starts_a_daemon_or_sends_messages(self):
+        script = device_installer._INSPECTION_SCRIPT
+
+        self.assertIn("--no-daemon", script)
+        self.assertNotIn("ros2 topic echo", script)
+        self.assertNotIn("ros2 topic pub", script)
+        self.assertNotIn("ros2 service call", script)
+        self.assertNotIn("ros2 action send_goal", script)
 
     def test_runtime_instance_ids_reject_shell_metacharacters(self):
         self.assertEqual(device_installer._clean_instance_id("instance-2"), "instance-2")
@@ -1312,6 +1377,61 @@ class EditorDeviceApiTests(unittest.TestCase):
         )
         self.assertEqual(metadata["required_packages"], ["blacknode-robot"])
         self.assertEqual(graph["metadata"], metadata)
+
+    def test_node_defs_discover_profiles_saved_after_package_load(self):
+        robots_root = Path(self._tmp.name) / "robots"
+
+        def robot_node(ctx):
+            return ctx
+
+        robot_node._bn_inputs = ["profile_id"]
+        robot_node._bn_outputs = ["robot"]
+        robot_node._bn_input_types = {"profile_id": "Text"}
+        robot_node._bn_output_types = {"robot": "Dict"}
+        robot_node._bn_input_defaults = {"profile_id": "auto"}
+        robot_node._bn_input_choices = {
+            "profile_id": ["auto", "so_arm101"],
+        }
+
+        with (
+            patch.dict(server._NODE_REGISTRY, {"Robot": robot_node}),
+            patch.dict(
+                os.environ,
+                {"BLACKNODE_ROBOTS_DIR": str(robots_root)},
+            ),
+        ):
+            before = self.client.get("/node-defs").json()
+
+            profile_dir = robots_root / "new_workshop_arm"
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "profile.json").write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "id": "new_workshop_arm",
+                    "display_name": "New workshop arm",
+                    "joints": [{"id": "joint", "servo_id": 1}],
+                }),
+                encoding="utf-8",
+            )
+
+            after = self.client.get("/node-defs").json()
+
+        self.assertNotIn(
+            "new_workshop_arm",
+            before["Robot"]["input_choices"]["profile_id"],
+        )
+        self.assertIn(
+            "new_workshop_arm",
+            after["Robot"]["input_choices"]["profile_id"],
+        )
+        self.assertNotIn(
+            "auto",
+            after["Robot"]["input_choices"]["profile_id"],
+        )
+        self.assertEqual(
+            robot_node._bn_input_choices["profile_id"],
+            ["auto", "so_arm101"],
+        )
 
     def test_pairing_validates_and_keeps_token_out_of_api_responses(self):
         hardware = _HardwareService()
@@ -2623,6 +2743,91 @@ class EditorDeviceApiTests(unittest.TestCase):
             password="ssh-password",
             host_fingerprint="SHA256:trusted-device-key",
         )
+
+    def test_ssh_inspection_classifies_live_ros_graph_without_installing(self):
+        inspection = {
+            "ok": True,
+            "host_fingerprint": "SHA256:trusted-device-key",
+            "instances": [],
+            "environment": {
+                "policy": "preserve",
+                "ros2": {
+                    "available": True,
+                    "distributions": ["humble"],
+                    "selected_distribution": "humble",
+                    "ros2_on_path": False,
+                    "preserved": True,
+                },
+            },
+            "ros2_graph": {
+                "available": True,
+                "state": "available",
+                "distribution": "humble",
+                "domain_id": "0",
+                "read_only": True,
+                "daemon_used": False,
+                "topics": [
+                    "/scan [sensor_msgs/msg/LaserScan]",
+                    "/odom [nav_msgs/msg/Odometry]",
+                    "/controller/cmd_vel [geometry_msgs/msg/Twist]",
+                ],
+                "nodes": ["/controller"],
+                "services": ["/controller/get_parameters"],
+                "errors": [],
+            },
+            "suggested_port": 8766,
+            "suggested_instance_id": "instance-2",
+        }
+        received = []
+
+        def classify(ctx):
+            received.append(ctx)
+            return {
+                "found": True,
+                "capabilities": [{
+                    "kind": "blacknode.robot-capability-candidate",
+                    "schema_version": 1,
+                    "capability": "mobile_base",
+                    "confidence": "high",
+                    "score": 95,
+                    "state_topics": ["/odom"],
+                    "command_topics": ["/controller/cmd_vel"],
+                    "safe_to_read": True,
+                    "requires_confirmation": True,
+                    "evidence": [],
+                }],
+                "unclassified": [],
+                "inventory": {
+                    "topics": inspection["ros2_graph"]["topics"],
+                    "nodes": ["/controller"],
+                    "services": ["/controller/get_parameters"],
+                },
+                "report": "Generic ROS 2 capability discovery",
+            }
+
+        with (
+            patch.object(server, "inspect_runtime", return_value=inspection),
+            patch.dict(
+                server._NODE_REGISTRY,
+                {"RobotROSCapabilityDiscover": classify},
+            ),
+        ):
+            response = self.client.post("/device-hosts/inspect", json={
+                "host": "192.168.55.1",
+                "port": 22,
+                "username": "ubuntu",
+                "password": "ssh-password",
+                "host_fingerprint": "SHA256:trusted-device-key",
+            })
+
+        self.assertEqual(response.status_code, 200)
+        graph = response.json()["ros2_graph"]
+        self.assertTrue(graph["read_only"])
+        self.assertFalse(graph["daemon_used"])
+        self.assertEqual(graph["capabilities"][0]["capability"], "mobile_base")
+        self.assertTrue(graph["capabilities"][0]["requires_confirmation"])
+        self.assertEqual(received[0]["nodes"], ["/controller"])
+        self.assertNotIn("ssh-password", response.text)
 
     def test_manual_device_can_enable_ssh_management_after_pairing(self):
         runtime = _HardwareService("runtime-token")
@@ -4416,6 +4621,13 @@ class EditorDeviceApiTests(unittest.TestCase):
             "connected": False,
             "leased_to_deployment": True,
             "error": "serial hardware is leased to a Blacknode deployment",
+            "calibrated": True,
+            "calibration": {
+                "name": "Follower calibration",
+                "profile_id": "so_arm101_v002",
+                "hardware_id": "FOLLOWER-42",
+                "joint_count": 6,
+            },
         })
         with patch("device_registry.urllib.request.urlopen", side_effect=hardware):
             paired = self.client.post("/devices", json={
@@ -4467,6 +4679,13 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertTrue(payload["available"])
         self.assertEqual(payload["sequence"], 42)
         self.assertEqual(payload["payload"]["joints"][0]["velocity"], 2.0)
+        self.assertTrue(payload["payload"]["calibrated"])
+        self.assertEqual(payload["payload"]["calibration"], {
+            "name": "Follower calibration",
+            "profile_id": "so_arm101_v002",
+            "hardware_id": "FOLLOWER-42",
+            "joint_count": 6,
+        })
 
     def test_robot_monitor_websocket_streams_selected_robot(self):
         hardware = _HardwareService(status_overrides={
@@ -4487,6 +4706,35 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(payload["robot_id"], paired["id"])
         self.assertEqual(payload["source"], "hardware")
         self.assertEqual(payload["payload"]["joints"][0]["position"], 5.0)
+
+    def test_robot_monitor_websocket_stops_sampling_after_disconnect(self):
+        samples = []
+
+        def snapshot(device_id, _profile_id="auto"):
+            samples.append(time.monotonic())
+            return {
+                "type": "robot_telemetry",
+                "robot_id": device_id,
+                "available": True,
+                "stale": False,
+                "payload": {
+                    "connected": True,
+                    "position_unit": "degree",
+                    "velocity_unit": "degree/s",
+                    "joints": [],
+                },
+            }
+
+        with patch.object(server, "_device_monitor_snapshot", side_effect=snapshot):
+            with self.client.websocket_connect(
+                "/api/devices/local-usb-disconnect/monitor/ws"
+            ) as websocket:
+                websocket.receive_json()
+            time.sleep(0.25)
+            settled_count = len(samples)
+            time.sleep(0.25)
+
+        self.assertEqual(len(samples), settled_count)
 
     def test_device_status_reports_stopped_deployment_as_inactive(self):
         hardware = _HardwareService(status_overrides={
@@ -5077,6 +5325,19 @@ class EditorDeviceApiTests(unittest.TestCase):
             },
             "temperatures_c": {"servo_2": 41.5},
             "voltage_v": 12.2,
+            "voltages_v": {"servo_2": 12.2},
+            "hardware_error_flags": {"servo_2": 1},
+            "hardware_errors": {"servo_2": ["voltage"]},
+            "servo_status": {"servo_2": 1},
+            "bus": {
+                "operation_count": 20,
+                "timeout_count": 0,
+                "serial_packet_error_count": 0,
+                "hardware_error_flags": {"servo_2": 1},
+                "hardware_errors": {"servo_2": ["voltage"]},
+                "servo_status": {"servo_2": 1},
+                "voltages_v": {"servo_2": 12.2},
+            },
             "error": "",
         }
         with (
@@ -5103,6 +5364,306 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertTrue(payload["calibrated"])
         self.assertEqual(payload["temperatures_c"]["servo_2"], 41.5)
         self.assertEqual(payload["voltage_v"], 12.2)
+        self.assertTrue(joint["communication_ok"])
+        self.assertEqual(joint["temperature_c"], 41.5)
+        self.assertEqual(joint["voltage_v"], 12.2)
+        self.assertEqual(joint["hardware_error_flags"], 1)
+        self.assertEqual(joint["hardware_errors"], ["voltage"])
+        self.assertEqual(joint["servo_status"], 1)
+        self.assertEqual(payload["bus"]["operation_count"], 20)
+
+    def test_robot_monitor_targets_include_local_usb_robots(self):
+        local = {
+            "id": "local-usb-abc",
+            "name": "Workshop arm · COM4",
+            "kind": "local_usb",
+            "available": True,
+            "profile_id": "workshop_arm",
+            "hardware_id": "SERIAL-42",
+            "port": "COM4",
+        }
+        with patch.object(
+            server,
+            "_local_robot_monitor_targets",
+            return_value=[local],
+        ):
+            response = self.client.get("/robot-monitor-targets")
+
+        self.assertEqual(response.status_code, 200)
+        targets = response.json()["targets"]
+        self.assertIn(local, targets)
+
+    def test_robot_monitor_targets_accept_none_for_raw_usb_discovery(self):
+        raw = {
+            "id": "local-usb-raw",
+            "name": "Raw servos · COM4",
+            "kind": "local_usb",
+            "available": True,
+            "profile_id": "",
+            "requested_profile_id": "none",
+            "raw_mode": True,
+            "hardware_id": "SERIAL-42",
+            "port": "COM4",
+        }
+        with patch.object(
+            server,
+            "_local_robot_monitor_targets",
+            return_value=[raw],
+        ) as targets:
+            response = self.client.get(
+                "/robot-monitor-targets?profile_id=none"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["profile_id"], "none")
+        self.assertIn(raw, response.json()["targets"])
+        targets.assert_called_once_with("none")
+
+    def test_local_usb_raw_monitor_maps_uncalibrated_ticks(self):
+        def raw_monitor(_ctx):
+            return {
+                "available": True,
+                "position_unit": "ticks",
+                "velocity_unit": "ticks/s",
+                "torque_enabled": False,
+                "joints": [{
+                    "name": "servo_2",
+                    "semantic_name": "Servo 2",
+                    "servo_id": 2,
+                    "position": 833.0,
+                    "velocity": 0.0,
+                    "raw_position": 833,
+                    "communication_ok": True,
+                    "voltage_v": 11.9,
+                    "temperature_c": 32.0,
+                    "hardware_error_flags": 1,
+                    "hardware_errors": ["voltage"],
+                }],
+                "warnings": [
+                    "servo_2 (servo 2) hardware warning 0x01: voltage"
+                ],
+                "errors": [],
+                "diagnostics": {
+                    "operation_count": 3,
+                    "scan_miss_count": 30,
+                    "serial_packet_error_count": 0,
+                },
+                "provider": {
+                    "package": "blacknode-drivers",
+                    "component": "feetech",
+                },
+                "report": "Raw read-only scan found servo ID 2.",
+            }
+
+        target = {
+            "id": "local-usb-raw",
+            "name": "Raw servos · COM4",
+            "kind": "local_usb",
+            "available": True,
+            "raw_mode": True,
+            "hardware_id": "SERIAL-42",
+            "port": "COM4",
+            "hardware": {"recommended": {"path": "COM4"}},
+        }
+        with patch.dict(
+            server._NODE_REGISTRY,
+            {"RobotRawMonitor": raw_monitor},
+        ):
+            snapshot = server._local_robot_monitor_snapshot(target)
+
+        self.assertTrue(snapshot["available"])
+        payload = snapshot["payload"]
+        self.assertTrue(payload["raw_mode"])
+        self.assertFalse(payload["calibrated"])
+        self.assertEqual(payload["position_unit"], "ticks")
+        self.assertEqual(payload["joints"][0]["raw_position"], 833)
+        self.assertEqual(payload["bus"]["scan_miss_count"], 30)
+        self.assertEqual(
+            payload["faults"][0]["details"]["joint"],
+            "servo_2",
+        )
+
+    def test_local_usb_monitor_maps_provider_diagnostics(self):
+        def control(_ctx):
+            return {
+                "data_ready": True,
+                "command_ok": True,
+                "torque_enabled": False,
+                "pose": {
+                    "shoulder_pan": -7.56,
+                    "shoulder_lift": -106.79,
+                },
+                "warnings": [
+                    "shoulder_lift (servo 2) hardware warning 0x01: voltage"
+                ],
+                "servos": {
+                    "shoulder_pan": {
+                        "servo_id": 1,
+                        "communication_ok": True,
+                        "ticks": 1962,
+                        "position_deg": -7.56,
+                        "torque_enabled": False,
+                        "voltage_v": 11.9,
+                        "temperature_c": 35.0,
+                        "servo_status": 0,
+                        "hardware_error_flags": 0,
+                        "hardware_errors": [],
+                    },
+                    "shoulder_lift": {
+                        "servo_id": 2,
+                        "communication_ok": True,
+                        "ticks": 833,
+                        "position_deg": -106.79,
+                        "torque_enabled": False,
+                        "voltage_v": 11.9,
+                        "temperature_c": 32.0,
+                        "servo_status": 1,
+                        "hardware_error_flags": 1,
+                        "hardware_errors": ["voltage"],
+                    },
+                },
+                "diagnostics": {
+                    "operation_count": 3,
+                    "serial_packet_error_count": 0,
+                },
+                "report": "Live local USB telemetry.",
+            }
+
+        target = {
+            "id": "local-usb-abc",
+            "name": "Workshop arm · COM4",
+            "kind": "local_usb",
+            "available": True,
+            "profile_id": "workshop_arm",
+            "hardware_id": "SERIAL-42",
+            "port": "COM4",
+            "profile": {
+                "id": "workshop_arm",
+                "display_name": "Workshop arm",
+                "joints": [{
+                    "id": "shoulder_pan",
+                    "display_name": "Shoulder pan",
+                    "servo_id": 1,
+                    "safe_min_deg": -110.0,
+                    "safe_max_deg": 110.0,
+                }, {
+                    "id": "shoulder_lift",
+                    "display_name": "Shoulder lift",
+                    "servo_id": 2,
+                    "safe_min_deg": -110.0,
+                    "safe_max_deg": 110.0,
+                }],
+            },
+            "hardware": {"recommended": {"path": "COM4"}},
+            "calibration": {
+                "profile_id": "workshop_arm",
+                "hardware_id": "SERIAL-42",
+            },
+        }
+        with patch.dict(
+            server._NODE_REGISTRY,
+            {"RobotCalibrationControl": control},
+        ):
+            snapshot = server._local_robot_monitor_snapshot(target)
+
+        self.assertTrue(snapshot["available"])
+        self.assertFalse(snapshot["stale"])
+        payload = snapshot["payload"]
+        self.assertFalse(payload["torque_enabled"])
+        self.assertEqual(len(payload["faults"]), 1)
+        self.assertEqual(
+            payload["faults"][0]["details"]["joint"],
+            "shoulder_lift",
+        )
+        healthy_joint = next(
+            item for item in payload["joints"]
+            if item["name"] == "shoulder_pan"
+        )
+        self.assertEqual(healthy_joint["hardware_error_flags"], 0)
+        self.assertEqual(healthy_joint["hardware_errors"], [])
+        joint = next(
+            item for item in payload["joints"]
+            if item["name"] == "shoulder_lift"
+        )
+        self.assertEqual(joint["servo_id"], 2)
+        self.assertEqual(joint["raw_position"], 833)
+        self.assertEqual(joint["voltage_v"], 11.9)
+        self.assertEqual(joint["temperature_c"], 32.0)
+        self.assertEqual(joint["hardware_error_flags"], 1)
+        self.assertEqual(joint["hardware_errors"], ["voltage"])
+        self.assertEqual(payload["bus"]["serial_packet_error_count"], 0)
+
+    def test_local_usb_monitor_serializes_reads_and_keeps_last_good_pose(self):
+        device_id = "local-usb-stable"
+        target = {"id": device_id}
+        good = {
+            "type": "robot_telemetry",
+            "robot_id": device_id,
+            "available": True,
+            "stale": False,
+            "payload": {
+                "connected": True,
+                "joints": [{"name": "shoulder", "position": 12.5}],
+            },
+        }
+        failed = {
+            "type": "robot_telemetry",
+            "robot_id": device_id,
+            "available": False,
+            "stale": True,
+            "message": "serial port is temporarily busy",
+        }
+        with server._robot_monitor_cache_lock:
+            server._robot_monitor_snapshot_cache.pop(device_id, None)
+            server._robot_monitor_device_locks.pop(device_id, None)
+        try:
+            with (
+                patch.object(
+                    server,
+                    "_local_robot_monitor_target",
+                    return_value=target,
+                ),
+                patch.object(
+                    server,
+                    "_local_robot_monitor_snapshot",
+                    return_value=good,
+                ) as snapshot,
+            ):
+                first = server._device_monitor_snapshot(device_id)
+                second = server._device_monitor_snapshot(device_id)
+
+            self.assertTrue(first["available"])
+            self.assertEqual(second["payload"]["joints"][0]["position"], 12.5)
+            snapshot.assert_called_once_with(target)
+
+            with server._robot_monitor_cache_lock:
+                server._robot_monitor_snapshot_cache[device_id]["sampled_at"] = 0.0
+            with (
+                patch.object(
+                    server,
+                    "_local_robot_monitor_target",
+                    return_value=target,
+                ),
+                patch.object(
+                    server,
+                    "_local_robot_monitor_snapshot",
+                    return_value=failed,
+                ),
+            ):
+                retry = server._device_monitor_snapshot(device_id)
+
+            self.assertTrue(retry["available"])
+            self.assertTrue(retry["stale"])
+            self.assertEqual(
+                retry["payload"]["joints"][0]["position"],
+                12.5,
+            )
+            self.assertIn("keeping the last good", retry["message"])
+            self.assertIn("temporarily busy", retry["transient_error"])
+        finally:
+            with server._robot_monitor_cache_lock:
+                server._robot_monitor_snapshot_cache.pop(device_id, None)
+                server._robot_monitor_device_locks.pop(device_id, None)
 
     def test_deployment_monitor_preserves_semantic_joint_servo_ids(self):
         payload = server._monitor_payload_from_device_state({
@@ -5123,14 +5684,63 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "servo_ids": {"shoulder_lift": 2},
                 "raw_positions": {"shoulder_lift": 2190},
                 "calibrated": True,
+                "bus": {
+                    "operation_count": 20,
+                    "timeout_count": 0,
+                    "serial_packet_error_count": 0,
+                    "hardware_error_flags": {"shoulder_lift": 1},
+                    "hardware_errors": {"shoulder_lift": ["voltage"]},
+                    "servo_status": {"shoulder_lift": 1},
+                    "voltages_v": {"shoulder_lift": 11.9},
+                },
             },
+            "temperatures_c": {"shoulder_lift": 32.0},
+            "voltage_v": 11.9,
         })
 
         joint = payload["joints"][0]
         self.assertEqual(joint["name"], "shoulder_lift")
         self.assertEqual(joint["servo_id"], 2)
         self.assertEqual(joint["raw_position"], 2190)
+        self.assertTrue(joint["communication_ok"])
+        self.assertEqual(joint["temperature_c"], 32.0)
+        self.assertEqual(joint["voltage_v"], 11.9)
+        self.assertEqual(joint["hardware_error_flags"], 1)
+        self.assertEqual(joint["hardware_errors"], ["voltage"])
+        self.assertEqual(joint["servo_status"], 1)
+        self.assertEqual(payload["bus"]["timeout_count"], 0)
         self.assertTrue(payload["calibrated"])
+
+    def test_monitor_metadata_merges_status_summary_with_live_calibration(self):
+        payload = server._monitor_payload_with_status_metadata(
+            {
+                "calibrated": False,
+                "calibration": {
+                    "profile_id": "",
+                    "topology": {"1": "shoulder_pan", "2": "shoulder_lift"},
+                },
+            },
+            {
+                "calibrated": True,
+                "calibration": {
+                    "name": "Workshop arm",
+                    "profile_id": "so_arm101_v002",
+                    "hardware_id": "SERIAL-42",
+                },
+            },
+        )
+
+        self.assertTrue(payload["calibrated"])
+        self.assertEqual(payload["calibration"]["name"], "Workshop arm")
+        self.assertEqual(payload["calibration"]["profile_id"], "so_arm101_v002")
+        self.assertEqual(payload["calibration"]["hardware_id"], "SERIAL-42")
+        self.assertEqual(payload["calibration"]["joint_count"], 2)
+
+        unknown = server._monitor_payload_with_status_metadata(
+            {"calibration": {"profile_id": "so_arm101_v002"}},
+            {},
+        )
+        self.assertNotIn("calibrated", unknown)
 
     def test_old_device_service_reports_calibration_upgrade_action(self):
         response = io.BytesIO(b'{"ok": false, "error": "not found"}')

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -20,6 +20,16 @@ import server  # noqa: E402
 
 
 class EditorRuntimeTests(unittest.TestCase):
+    def test_robot_calibration_runtime_is_managed_through_generic_node(self):
+        self.assertEqual(
+            server._RUNTIME_MODULES["robot_calibration_control"],
+            "blacknode.pkg.blacknode_robot.calibration_control",
+        )
+        self.assertEqual(
+            server._RUNTIME_REGISTRY_ANCHORS["robot_calibration_control"],
+            "RobotCalibrationControl",
+        )
+
     def test_isaac_runtime_is_managed_through_registered_bridge_state(self):
         self.assertEqual(server._RUNTIME_MODULES["isaac"], "blacknode.pkg.blacknode_isaac.runtime")
         self.assertEqual(server._RUNTIME_REGISTRY_ANCHORS["isaac"], "IsaacPolicyBridge")
@@ -225,6 +235,169 @@ class EditorRuntimeTests(unittest.TestCase):
             prepare_cook.assert_not_called()
         finally:
             server._session.node_meta.pop("recorder-control-test", None)
+
+    def test_connected_servo_command_routes_only_through_live_motion_control(self):
+        servo_id = "servo-control-test"
+        motion_id = "motion-control-test"
+        server._session.node_meta[servo_id] = {
+            "id": servo_id,
+            "type": "RobotServo",
+            "params": {"servo_id": 2, "joint_name": "shoulder_lift"},
+        }
+        server._session.node_meta[motion_id] = {
+            "id": motion_id,
+            "type": "ROS2JointSliders",
+            "params": {"run_id": "arm-live"},
+        }
+        edge = {
+            "from": servo_id,
+            "from_port": "command",
+            "to": motion_id,
+            "to_port": "command",
+        }
+        server._session.graph._edges.append(edge)
+        command = {
+            "kind": "blacknode.joint-command-request",
+            "schema_version": 1,
+            "joint_name": "shoulder_lift",
+            "servo_id": 2,
+            "position_rad": 0.25,
+            "issued_at": 123.0,
+            "requires_motion_authorization": True,
+        }
+        routed = []
+
+        def move(run_id, request):
+            routed.append((run_id, request))
+            return {"ok": True, "commanded": True, "report": "moved shoulder_lift"}
+
+        try:
+            with patch.object(server, "_runtime_callable", return_value=move):
+                response = TestClient(server.app).post(
+                    f"/nodes/{motion_id}/control",
+                    json={
+                        "action": "joint-command",
+                        "payload": {"source_node_id": servo_id, "command": command},
+                    },
+                )
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.json()["outputs"]["commanded"])
+            self.assertEqual(routed, [("arm-live", command)])
+
+            server._session.graph._edges.remove(edge)
+            disconnected = TestClient(server.app).post(
+                f"/nodes/{motion_id}/control",
+                json={
+                    "action": "joint-command",
+                    "payload": {"source_node_id": servo_id, "command": command},
+                },
+            )
+            self.assertEqual(disconnected.status_code, 409)
+        finally:
+            server._session.node_meta.pop(servo_id, None)
+            server._session.node_meta.pop(motion_id, None)
+            if edge in server._session.graph._edges:
+                server._session.graph._edges.remove(edge)
+            for key in [key for key in server._session.graph._cache if key[0] == motion_id]:
+                server._session.graph._cache.pop(key, None)
+
+    def test_robot_servo_arms_and_commands_directly_from_its_own_control(self):
+        node_id = "standalone-servo-test"
+        server._session.node_meta[node_id] = {
+            "id": node_id,
+            "type": "RobotServo",
+            "params": {
+                "robot_id": "local-usb-test-arm",
+                "profile_id": "test_arm",
+                "servo_id": 2,
+                "joint_name": "shoulder_lift",
+            },
+        }
+        command = {
+            "kind": "blacknode.joint-command-request",
+            "schema_version": 1,
+            "joint_name": "shoulder_lift",
+            "servo_id": 2,
+            "position_rad": 0.25,
+            "issued_at": 123.0,
+            "requires_motion_authorization": True,
+        }
+        calls = []
+
+        def arm(run_id, context):
+            calls.append(("arm", run_id, context))
+            return {"ok": True, "armed": True, "report": "armed"}
+
+        def move(run_id, request):
+            calls.append(("move", run_id, request))
+            return {
+                "ok": True,
+                "armed": True,
+                "commanded": True,
+                "report": "moved shoulder_lift",
+            }
+
+        def disarm(run_id):
+            calls.append(("disarm", run_id))
+            return {"ok": True, "armed": False, "report": "disarmed"}
+
+        functions = {
+            "arm_servo_motion": arm,
+            "command_servo_motion": move,
+            "disarm_servo_motion": disarm,
+        }
+
+        def runtime_callable(_label, _module, function_name):
+            return functions.get(function_name)
+
+        target = {
+            "available": True,
+            "raw_mode": False,
+            "hardware_id": "usb:test-arm",
+            "hardware": {"recommended": {"path": "COM7"}},
+            "profile": {"id": "test_arm", "joints": []},
+            "calibration": {
+                "profile_id": "test_arm",
+                "hardware_id": "usb:test-arm",
+                "joints": {},
+            },
+        }
+        try:
+            with (
+                patch.object(server, "_runtime_callable", side_effect=runtime_callable),
+                patch.object(server, "_local_robot_monitor_target", return_value=target),
+            ):
+                client = TestClient(server.app)
+                armed = client.post(
+                    f"/nodes/{node_id}/control",
+                    json={
+                        "action": "arm",
+                        "payload": {
+                            "robot_id": "local-usb-test-arm",
+                            "profile_id": "test_arm",
+                        },
+                    },
+                )
+                moved = client.post(
+                    f"/nodes/{node_id}/control",
+                    json={"action": "joint-command", "payload": {"command": command}},
+                )
+                disarmed = client.post(
+                    f"/nodes/{node_id}/control",
+                    json={"action": "disarm"},
+                )
+
+            self.assertEqual(armed.status_code, 200)
+            self.assertTrue(armed.json()["outputs"]["armed"])
+            self.assertEqual(moved.status_code, 200)
+            self.assertTrue(moved.json()["outputs"]["commanded"])
+            self.assertEqual(disarmed.status_code, 200)
+            self.assertFalse(disarmed.json()["outputs"]["armed"])
+            self.assertEqual(calls[0][0:2], ("arm", f"robot-servo:{node_id}"))
+            self.assertEqual(calls[1], ("move", f"robot-servo:{node_id}", command))
+            self.assertEqual(calls[2], ("disarm", f"robot-servo:{node_id}"))
+        finally:
+            server._session.node_meta.pop(node_id, None)
 
     def test_act_training_control_reports_progress_and_stops_without_cooking_graph(self):
         node_id = "training-control-test"

--- a/tests/test_editor_template_packages.py
+++ b/tests/test_editor_template_packages.py
@@ -147,6 +147,26 @@ def test_nested_adapter_endpoints_preserve_component_ownership():
     enable.assert_called_once_with("blacknode-drivers", "feetech", "ros2")
 
 
+def test_component_endpoint_routes_compact_adapter_reference():
+    info = SimpleNamespace(to_dict=lambda: {
+        "name": "blacknode-drivers",
+        "enabled_components": ["feetech"],
+        "enabled_adapters": ["feetech/ros2"],
+    })
+    with patch.object(
+        server,
+        "bn_ensure_adapter_enabled",
+        return_value=info,
+    ) as enable:
+        response = TestClient(server.app).post(
+            "/packages/blacknode-drivers/components/feetech%40ros2/enable"
+        )
+
+    assert response.status_code == 200
+    assert response.json()["package"]["enabled_adapters"] == ["feetech/ros2"]
+    enable.assert_called_once_with("blacknode-drivers", "feetech", "ros2")
+
+
 def test_template_list_groups_core_and_package_templates(tmp_path: Path):
     core_dir = tmp_path / "core"
     robot_dir = tmp_path / "robot" / "templates"

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -131,11 +131,13 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert drivers["components"]["feetech"]["node_types"] == [
         "FeetechBusConfig",
         "FeetechBusProbe",
+        "FeetechCalibrationProvider",
     ]
     assert set(drivers["components"]) == {"feetech"}
     assert drivers["components"]["feetech"]["adapters"]["ros2"]["default"] is False
     assert payload["nodes"]["FeetechROS2Adapter"]["package"] == "blacknode-drivers"
     assert payload["nodes"]["FeetechBusProbe"]["package"] == "blacknode-drivers"
+    assert payload["nodes"]["FeetechCalibrationProvider"]["package"] == "blacknode-drivers"
     assert "CUDAKernelLab" not in payload["nodes"]
     assert "CUDACustomKernel" not in payload["nodes"]
     assert payload["nodes"]["ROS2TopicList"]["package"] == "blacknode-ros2"
@@ -144,6 +146,8 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["RobotDiscovery"]["package"] == "blacknode-robot"
     assert payload["nodes"]["RobotMonitor"]["package"] == "blacknode-robot"
     assert payload["nodes"]["RobotCapabilityInspect"]["package"] == "blacknode-robot"
+    assert payload["nodes"]["RobotCalibrationControl"]["package"] == "blacknode-robot"
+    assert payload["nodes"]["RobotCalibrationMockProvider"]["package"] == "blacknode-robot"
     assert payload["nodes"]["HardwareCapabilities"]["package"] == "blacknode-robot"
     assert payload["nodes"]["RobotServo"]["package"] == "blacknode-robot"
     assert payload["nodes"]["EpisodeRecorder"] == {
@@ -171,6 +175,10 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["BaseSafetyGate"]["package"] == "blacknode-motion"
     assert payload["nodes"]["Camera"]["package"] == "blacknode-perception"
     assert payload["nodes"]["CameraStream"]["package"] == "blacknode-perception"
+    assert payload["nodes"]["DepthCamera"]["package"] == "blacknode-perception"
+    assert payload["nodes"]["DepthCameraDeviceSelect"]["package"] == "blacknode-perception"
+    assert payload["nodes"]["DepthCameraTestProvider"]["package"] == "blacknode-perception"
+    assert payload["nodes"]["DepthObstacleWarning"]["package"] == "blacknode-perception"
     assert payload["nodes"]["ACTTraining"] == {
         "package": "blacknode-training",
         "git_url": "https://github.com/temiroff/blacknode-training.git",
@@ -341,3 +349,46 @@ def test_workflow_adapter_requirement_adds_missing_official_package():
     assert result["code"] == "missing_packages"
     assert result["missing_packages"][0]["name"] == "blacknode-drivers"
     assert result["missing_adapters"][0]["reason"] == "package is not installed"
+
+
+def test_compact_adapter_misplaced_as_component_is_normalized():
+    workflow = _workflow("FeetechROS2Adapter")
+    workflow["metadata"]["required_components"] = [
+        "blacknode-drivers/feetech@ros2",
+    ]
+    installed = {
+        "blacknode-drivers": {
+            "ok": True,
+            "version": "0.1.0",
+            "components": {
+                "feetech": {
+                    "enabled": True,
+                    "adapters": {"ros2": {"enabled": False}},
+                },
+            },
+        },
+    }
+
+    assert template_component_requirements(workflow) == [{
+        "package": "blacknode-drivers",
+        "component": "feetech",
+        "version": "",
+        "git_url": "https://github.com/temiroff/blacknode-drivers.git",
+    }]
+    assert template_adapter_requirements(workflow) == [{
+        "package": "blacknode-drivers",
+        "component": "feetech",
+        "adapter": "ros2",
+        "version": "",
+        "git_url": "https://github.com/temiroff/blacknode-drivers.git",
+    }]
+
+    result = resolve_workflow_dependencies(
+        workflow,
+        available_node_types={"FeetechROS2Adapter", "NestedNode"},
+        installed_packages=installed,
+    )
+
+    assert result["code"] == "missing_adapters"
+    assert result["missing_components"] == []
+    assert result["missing_adapters"][0]["reason"] == "adapter is disabled"


### PR DESCRIPTION
## What changed

- expands device inspection, package lifecycle, and provider-authoring support
- improves Robot Monitor and RobotServo profile selection, telemetry diagnostics, layout stability, and direct on-node servo control
- adds compute-device inspection UI and templates
- updates the Blacknode development skill with shared node-radius and provider rules

## Why

Robot setup and diagnosis needed a consistent editor-first path for local USB hardware, saved profiles, calibration identity, provider health, and safe motion.

## Validation

- 507 core tests passed (8 skipped)
- editor production build passed
- diff and credential-pattern checks passed

Physical USB motion was not exercised by automation.