### PR TITLE
Sync Feetech driver catalog

### DIFF
--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -293,7 +293,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "node_types": [
                         "FeetechBusConfig",
                         "FeetechBusProbe",
-                        "FeetechCalibrationProvider"
+                        "FeetechCalibrationProvider",
+                        "FeetechRawMonitorProvider"
                     ],
                     "adapters": {
                         "ros2": {
@@ -326,6 +327,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "FeetechBusConfig",
                 "FeetechBusProbe",
                 "FeetechCalibrationProvider",
+                "FeetechRawMonitorProvider",
                 "FeetechROS2Adapter"
             ]
         },

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -133,6 +133,7 @@ def test_core_index_maps_official_node_types_to_git_packages():
         "FeetechBusConfig",
         "FeetechBusProbe",
         "FeetechCalibrationProvider",
+        "FeetechRawMonitorProvider",
     ]
     assert set(drivers["components"]) == {"feetech"}
     assert drivers["components"]["feetech"]["adapters"]["ros2"]["default"] is False


### PR DESCRIPTION
## Summary
- include `FeetechRawMonitorProvider` in the official driver component and package indexes
- update the package-index contract test

## Verification
- package-index tests (8 passed)
- `blacknode packages validate-catalog packages/blacknode-drivers`