### PR TITLE
docs: add Newton package to overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ never starts a physical or compute action automatically.
 
 Blacknode core owns the graph, editor, runtime, replay, exports, package system,
 and control APIs. Extension packages add robot providers, ROS 2, perception,
-CUDA, datasets, training, and other focused capabilities.
+CUDA, datasets, training, simulation, and other focused capabilities. The
+[Newton package](https://github.com/temiroff/blacknode-newton) adds Newton
+physics workflows, synchronized 3D viewing, ROS bridging, and replay.
 
 Install packages from **Packages** in the editor. The same operation is
 available from the CLI:


### PR DESCRIPTION
## What changed

- Added the Newton package to the main Blacknode overview.
- Linked the package repository and summarized its physics, viewing, ROS bridge, and replay capabilities.

## Why

Make Newton discoverable from the main README while keeping the overview concise.

## Checks

- `git diff --check`
- README Markdown and link validation