### PR TITLE
Integrate generic ROS2 topic stream

### DIFF
--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -963,9 +963,14 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const topicPublisherActive = data.type === 'ROS2TopicPublisher' && data.portResults?.running === true
   const topicPublisherName = String(data.params?.node_name ?? '').trim().replace(/^\/+/, '')
   const topicPublisherTopic = String(data.params?.topic ?? '/chatter').trim() || '/chatter'
-  const topicSubscriberActive = data.type === 'ROS2TopicSubscriber' && data.portResults?.running === true
-  const topicSubscriberName = String(data.params?.node_name ?? 'blacknode_subscriber').trim().replace(/^\/+/, '')
-  const topicSubscriberTopic = String(data.params?.topic ?? '/chatter').trim() || '/chatter'
+  const topicSubscriberActive = (data.type === 'ROS2TopicSubscriber' || data.type === 'ROS2')
+    && data.portResults?.running === true
+  const topicSubscriberName = String(
+    data.params?.node_name ?? (data.type === 'ROS2' ? 'blacknode_ros2_topic' : 'blacknode_subscriber')
+  ).trim().replace(/^\/+/, '')
+  const topicSubscriberTopic = String(
+    data.params?.topic ?? (data.type === 'ROS2' ? '/scan' : '/chatter')
+  ).trim() || (data.type === 'ROS2' ? '/scan' : '/chatter')
 
   // Ordered by urgency: a running process outranks a waiting one, which
   // outranks a passive "this result is stale" note.

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -690,6 +690,7 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
   if (data.type === 'ROS2Run'
     || data.type === 'ROS2TopicPublisher'
     || data.type === 'ROS2TopicSubscriber'
+    || data.type === 'ROS2'
     || data.type === 'ROS2PythonNode') {
     return {
       ...base,
@@ -1628,7 +1629,7 @@ export const useStore = create<Store>((set, get) => ({
         const streamId = owned('stream_id')
         const runId = node.data.type === 'ROS2TopicPublisher'
           ? `topic-publisher:${owned('topic') || '/chatter'}`
-          : node.data.type === 'ROS2TopicSubscriber'
+          : node.data.type === 'ROS2TopicSubscriber' || node.data.type === 'ROS2'
             ? `topic-subscriber:${owned('topic') || '/chatter'}`
             : owned('run_id')
         // node_id is exact: the runtime records which node started the work.
@@ -1680,7 +1681,7 @@ export const useStore = create<Store>((set, get) => ({
       const managedRuns = Array.isArray(status.managed_runs) ? status.managed_runs : []
       set(s => ({
         nodes: propagateLiveTerminalValues(s.nodes.map(node => {
-          const runId = node.data.type === 'ROS2TopicSubscriber'
+          const runId = node.data.type === 'ROS2TopicSubscriber' || node.data.type === 'ROS2'
             ? `topic-subscriber:${String(node.data.params?.topic ?? node.data.input_defaults?.topic ?? '/chatter')}`
             : String(node.data.params?.run_id ?? node.data.input_defaults?.run_id ?? 'robot_teach')
           const item = items.find(raw => {
@@ -3608,6 +3609,7 @@ export const useStore = create<Store>((set, get) => ({
           n.data.type === 'ROS2PythonNode' ||
           n.data.type === 'ROS2TopicPublisher' ||
           n.data.type === 'ROS2TopicSubscriber' ||
+          n.data.type === 'ROS2' ||
           n.data.type === 'ROS2Launch'
         )
         return {

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -417,6 +417,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "name": "topics",
                     "default": True,
                     "node_types": [
+                        "ROS2",
                         "ROS2TopicEcho",
                         "ROS2TopicList",
                         "ROS2TopicPublisher",
@@ -470,6 +471,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "git_url": "https://github.com/temiroff/blacknode-ros2.git",
             "description": "ROS 2 integration primitives: graph discovery, topics, services, processes, and native/rosbridge transports.",
             "node_types": [
+                "ROS2",
                 "ROS2BridgeEcho",
                 "ROS2BridgePublish",
                 "ROS2GraphExplorer",

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -161,6 +161,7 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["FeetechCalibrationProvider"]["package"] == "blacknode-drivers"
     assert "CUDAKernelLab" not in payload["nodes"]
     assert "CUDACustomKernel" not in payload["nodes"]
+    assert payload["nodes"]["ROS2"]["package"] == "blacknode-ros2"
     assert payload["nodes"]["ROS2TopicList"]["package"] == "blacknode-ros2"
     assert payload["nodes"]["ROS2TopicPublisher"]["package"] == "blacknode-ros2"
     assert payload["nodes"]["ROS2TopicSubscriber"]["package"] == "blacknode-ros2"


### PR DESCRIPTION
## Summary
- expose the generic `ROS2` node through the curated package index
- integrate managed run state and controls in the editor
- preserve compatibility with `ROS2TopicSubscriber`

## Verification
- Python suite: 522 passed, 8 skipped
- focused integration tests: 13 passed
- editor production build passed