### PR TITLE
Route ROS2 streams through device Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Blacknode installs and pairs the Runtime from the editor. The SSH password is
 used only for the current request and is not saved. Inspection, installation,
 and robot discovery do not arm or move the robot.
 
+To stream a device ROS 2 topic into the editor, connect
+`ComputeDevice.device` to `ROS2.device`, set the topic, and start the node.
+
 Other pairing paths:
 
 - Choose **Local computer** to deploy on the editor computer.

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -615,6 +615,41 @@ class RuntimeDeviceClient(HardwareDeviceClient):
     def ros2_diagnostics(self) -> dict[str, Any]:
         return self._request("GET", "/diagnostics/ros2", timeout=90.0)
 
+    def ros2_topic_status(self, stream_id: str) -> dict[str, Any]:
+        return self._request("GET", self._ros2_topic_endpoint(stream_id), timeout=5.0)
+
+    def start_ros2_topic(
+        self,
+        stream_id: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"{self._ros2_topic_endpoint(stream_id)}/start",
+            payload=payload,
+            timeout=max(30.0, float(payload.get("timeout") or 10.0) + 15.0),
+        )
+
+    def read_ros2_topic_once(
+        self,
+        stream_id: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"{self._ros2_topic_endpoint(stream_id)}/once",
+            payload=payload,
+            timeout=max(30.0, float(payload.get("timeout") or 10.0) + 15.0),
+        )
+
+    def stop_ros2_topic(self, stream_id: str) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"{self._ros2_topic_endpoint(stream_id)}/stop",
+            payload={},
+            timeout=30.0,
+        )
+
     def get_service(self, service_id: str) -> dict[str, Any]:
         return self._request("GET", self._service_endpoint(service_id), timeout=30.0)
 
@@ -667,6 +702,13 @@ class RuntimeDeviceClient(HardwareDeviceClient):
         if not clean_id:
             raise DeviceRegistryError("Managed service ID is required.")
         return f"/services/{urllib.parse.quote(clean_id, safe='')}"
+
+    @staticmethod
+    def _ros2_topic_endpoint(stream_id: str) -> str:
+        clean_id = str(stream_id or "").strip()
+        if not clean_id:
+            raise DeviceRegistryError("ROS 2 topic stream ID is required.")
+        return f"/ros2/topics/{urllib.parse.quote(clean_id, safe='')}"
 
 
 class DeviceRegistry:

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -662,6 +662,222 @@ _RUNTIME_CALLABLE_ALIASES = {
     ("ros2_live", "stop_runtime_services"): "stop_leader_follower_services",
 }
 
+_remote_ros2_lock = threading.RLock()
+_remote_ros2_runs: dict[str, dict[str, Any]] = {}
+
+
+def _remote_ros2_service_id(node_id: str) -> str:
+    clean = re.sub(r"[^a-z0-9-]+", "-", str(node_id or "").lower()).strip("-")
+    return f"editor-{clean}"[:64] or "editor-ros2"
+
+
+def _remote_ros2_error_outputs(
+    request: dict[str, Any],
+    error: str,
+) -> dict[str, Any]:
+    device_id = str(request.get("device_id") or "")
+    topic = str(request.get("topic") or "")
+    stream_id = f"device:{device_id}:topic-subscriber:{topic}"
+    return {
+        "running": False,
+        "message": {},
+        "messages": [],
+        "stream": {
+            "kind": "blacknode.message-stream",
+            "schema_version": 1,
+            "stream_id": stream_id,
+            "protocol": "ros2",
+            "state": "unavailable",
+            "managed": True,
+            "topic": topic,
+            "message_type": str(request.get("message_type") or ""),
+            "backend": f"remote:{device_id}",
+            "device_id": device_id,
+        },
+        "status": {
+            "kind": "blacknode.stream-status",
+            "schema_version": 1,
+            "stream_id": stream_id,
+            "state": "unavailable",
+            "available": False,
+            "worker_alive": False,
+            "source_fresh": False,
+            "received": 0,
+            "last_message_time_ns": 0,
+            "age_seconds": None,
+            "stale_after_seconds": float(request.get("stale_after_seconds") or 2.0),
+            "device_id": device_id,
+            "error": error,
+        },
+        "received": 0,
+        "backend": f"remote:{device_id}",
+        "report": f"ROS2 unavailable on {device_id}: {error}",
+    }
+
+
+def _remote_ros2_outputs(
+    request: dict[str, Any],
+    response: dict[str, Any],
+) -> dict[str, Any]:
+    raw = response.get("outputs") if isinstance(response.get("outputs"), dict) else {}
+    outputs = copy.deepcopy(raw)
+    device_id = str(request.get("device_id") or "")
+    backend = f"remote:{device_id}"
+    outputs["backend"] = backend
+    stream = outputs.get("stream") if isinstance(outputs.get("stream"), dict) else {}
+    remote_stream_id = (
+        f"device:{device_id}:topic-subscriber:{str(request.get('topic') or '')}"
+    )
+    stream.update(backend=backend, device_id=device_id, stream_id=remote_stream_id)
+    outputs["stream"] = stream
+    status = outputs.get("status") if isinstance(outputs.get("status"), dict) else {}
+    status.update(device_id=device_id, stream_id=remote_stream_id)
+    outputs["status"] = status
+    report = str(outputs.get("report") or "").strip()
+    outputs["report"] = f"{report} · device {device_id}" if report else f"ROS2 device {device_id}"
+    return outputs
+
+
+def _ensure_remote_ros2_ready(client: RuntimeDeviceClient) -> None:
+    manifest = client.manifest()
+    features = {str(item) for item in (manifest.get("features") or [])}
+    if "remote_ros2_topic_stream_v1" not in features:
+        raise DeviceRegistryError(
+            "Update Blacknode Runtime to 0.4.1 or newer from Devices → Software."
+        )
+    remote_packages = {
+        str(item.get("name") or ""): str(item.get("version") or "")
+        for item in (manifest.get("packages") or [])
+        if isinstance(item, dict)
+    }
+    workflow = {
+        "kind": "blacknode.workflow",
+        "schema_version": 1,
+        "metadata": {
+            "required_packages": ["blacknode-ros2"],
+            "required_components": [
+                "blacknode-ros2/core",
+                "blacknode-ros2/topics",
+            ],
+        },
+        "node_meta": {"ros2": {"type": "ROS2"}},
+        "edges": [],
+    }
+    specs = _workflow_target_package_specs(workflow)
+    ros2_spec = next(
+        (item for item in specs if item.get("name") == "blacknode-ros2"),
+        None,
+    )
+    if not ros2_spec or not ros2_spec.get("git_url"):
+        raise DeviceRegistryError(
+            "The editor cannot resolve the trusted blacknode-ros2 package source."
+        )
+    required_version = str(ros2_spec.get("version") or "")
+    registered_nodes = {str(item) for item in (manifest.get("node_types") or [])}
+    needs_sync = (
+        "blacknode-ros2" not in remote_packages
+        or (required_version and remote_packages.get("blacknode-ros2") != required_version)
+        or "ROS2" not in registered_nodes
+    )
+    if needs_sync:
+        result = client.sync_packages([ros2_spec])
+        if not result.get("ok", True):
+            raise DeviceRegistryError(
+                str(result.get("error") or "Could not install blacknode-ros2 on the device.")
+            )
+
+
+def _remote_ros2_action(request: dict[str, Any]) -> dict[str, Any]:
+    node_id = str(request.get("node_id") or "").strip()
+    device_id = str(request.get("device_id") or "").strip()
+    action = str(request.get("action") or "status").strip().lower()
+    if not node_id or not device_id:
+        raise RuntimeError("ROS2 remote execution requires a node and paired device")
+    service_id = _remote_ros2_service_id(node_id)
+    payload = {
+        key: request.get(key)
+        for key in (
+            "topic",
+            "message_type",
+            "node_name",
+            "history",
+            "timeout",
+            "stale_after_seconds",
+        )
+    }
+    client = _device_registry.runtime_client(device_id)
+    try:
+        if action == "start":
+            _ensure_remote_ros2_ready(client)
+            response = client.start_ros2_topic(service_id, payload)
+            with _remote_ros2_lock:
+                _remote_ros2_runs[node_id] = dict(request)
+        elif action == "once":
+            _ensure_remote_ros2_ready(client)
+            response = client.read_ros2_topic_once(service_id, payload)
+        elif action == "stop":
+            response = client.stop_ros2_topic(service_id)
+            with _remote_ros2_lock:
+                _remote_ros2_runs.pop(node_id, None)
+        elif action == "status":
+            response = client.ros2_topic_status(service_id)
+        else:
+            raise RuntimeError(f"unknown ROS2 action {action!r}")
+    except DeviceRegistryError as exc:
+        detail = str(exc)
+        if "HTTP 404" in detail or "not found" in detail.casefold():
+            detail = (
+                "This device Runtime does not support remote ROS2 topic streams. "
+                "Update Blacknode Runtime to 0.4.1 or newer."
+            )
+        return {"id": service_id, "outputs": _remote_ros2_error_outputs(request, detail)}
+    return {"id": service_id, "outputs": _remote_ros2_outputs(request, response)}
+
+
+def _remote_ros2_runtime_status() -> dict[str, Any]:
+    with _remote_ros2_lock:
+        runs = [(node_id, dict(item)) for node_id, item in _remote_ros2_runs.items()]
+    node_outputs = []
+    for node_id, request in runs:
+        status_request = {**request, "node_id": node_id, "action": "status"}
+        result = _remote_ros2_action(status_request)
+        node_outputs.append({
+            "node_type": "ROS2",
+            "node_id": node_id,
+            "run_id": str(result.get("id") or _remote_ros2_service_id(node_id)),
+            "outputs": dict(result.get("outputs") or {}),
+        })
+    return {
+        "ok": all(
+            str(item.get("outputs", {}).get("status", {}).get("state") or "") != "error"
+            for item in node_outputs
+        ),
+        "active": bool(runs),
+        "streams": [],
+        "managed_runs": [],
+        "node_outputs": node_outputs,
+        "detached_count": 0,
+    }
+
+
+def _stop_remote_ros2_services() -> dict[str, Any]:
+    with _remote_ros2_lock:
+        runs = [(node_id, dict(item)) for node_id, item in _remote_ros2_runs.items()]
+    errors = []
+    for node_id, request in runs:
+        try:
+            _remote_ros2_action({**request, "node_id": node_id, "action": "stop"})
+        except Exception as exc:
+            errors.append(str(exc))
+    with _remote_ros2_lock:
+        _remote_ros2_runs.clear()
+    return {
+        "ok": not errors,
+        "stopped": {"streams": len(runs)},
+        "errors": errors,
+        "report": f"stopped {len(runs)} remote ROS2 stream(s)",
+    }
+
 
 def _runtime_module(module_name: str):
     module = sys.modules.get(module_name)
@@ -726,6 +942,7 @@ def _runtime_status() -> dict[str, Any]:
         label: _runtime_module_status(label, module_name)
         for label, module_name in _RUNTIME_MODULES.items()
     }
+    modules["remote_ros2"] = _remote_ros2_runtime_status()
     streams: list[dict[str, Any]] = []
     cv2_streams: list[dict[str, Any]] = []
     reasoning_streams: list[dict[str, Any]] = []
@@ -784,6 +1001,7 @@ def _stop_runtime_services() -> dict[str, Any]:
         label: _stop_runtime_module(label, module_name)
         for label, module_name in _RUNTIME_MODULES.items()
     }
+    modules["remote_ros2"] = _stop_remote_ros2_services()
     stopped = {"streams": 0, "managed_runs": 0, "detached": 0, "cv2_streams": 0, "reasoning_streams": 0}
     for result in modules.values():
         raw_stopped = result.get("stopped") if isinstance(result.get("stopped"), dict) else {}
@@ -3936,6 +4154,9 @@ def _device_host_live_inspection(host_id: str) -> dict[str, Any]:
 
 def _refresh_live_compute_device_params() -> None:
     """Inject ephemeral live state immediately before an editor cook."""
+    _session.graph.set_runtime_context(
+        __remote_ros2_action__=_remote_ros2_action,
+    )
     for node in _session.graph._nodes.values():
         if str(node.get("type") or "") != "ComputeDevice":
             continue

--- a/python/blacknode/graph.py
+++ b/python/blacknode/graph.py
@@ -67,6 +67,11 @@ class Graph:
         self._edges: list[dict] = []       # {from, from_port, to, to_port}
         self._cache: dict[tuple, Any] = {}
         self._dirty: set[str] = set()
+        self._runtime_context: dict[str, Any] = {}
+
+    def set_runtime_context(self, **values: Any) -> None:
+        """Supply process-local services to nodes without persisting them."""
+        self._runtime_context = dict(values)
 
     # ── Building ──────────────────────────────────────────────────────────────
 
@@ -134,6 +139,7 @@ class Graph:
             return self._cache[cache_key]
 
         fn = _NODE_REGISTRY[node_def["type"]]
+        ctx.update(getattr(self, "_runtime_context", {}))
         ctx["__graph__"] = self
         ctx["__node_id__"] = node_id
         result = fn(ctx)
@@ -168,6 +174,7 @@ class Graph:
         inner._cache = {}
         inner._dirty = set(inner_meta.keys())
         inner._nodes = {}
+        inner._runtime_context = dict(getattr(self, "_runtime_context", {}))
         for nid, m in inner_meta.items():
             entry = {"type": m["type"], "params": dict(m.get("params", {}))}
             if "subgraph" in m:

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -157,6 +157,97 @@ class EditorRuntimeTests(unittest.TestCase):
         self.assertEqual(result["managed_runs"], [{"run_id": "camera_run", "runtime": "ros2"}])
         self.assertEqual(result["detached_count"], 1)
 
+    def test_remote_ros2_action_routes_through_paired_runtime_and_reports_live_outputs(self):
+        calls = []
+
+        class FakeRuntimeClient:
+            def manifest(self):
+                return {
+                    "features": ["remote_ros2_topic_stream_v1"],
+                    "packages": [{"name": "blacknode-ros2", "version": "0.5.16"}],
+                    "node_types": ["ROS2"],
+                }
+
+            def start_ros2_topic(self, stream_id, payload):
+                calls.append(("start", stream_id, payload))
+                return {"outputs": {
+                    "running": True,
+                    "message": {"ranges": [1.0]},
+                    "messages": [{"ranges": [1.0]}],
+                    "stream": {"kind": "blacknode.message-stream", "topic": "/scan"},
+                    "status": {"kind": "blacknode.stream-status", "state": "ready"},
+                    "received": 1,
+                    "backend": "native",
+                    "report": "streaming",
+                }}
+
+            def ros2_topic_status(self, stream_id):
+                calls.append(("status", stream_id))
+                return {"outputs": {
+                    "running": True,
+                    "message": {"ranges": [2.0]},
+                    "messages": [{"ranges": [2.0]}],
+                    "stream": {"kind": "blacknode.message-stream", "topic": "/scan"},
+                    "status": {"kind": "blacknode.stream-status", "state": "ready"},
+                    "received": 2,
+                    "backend": "native",
+                    "report": "streaming",
+                }}
+
+            def stop_ros2_topic(self, stream_id):
+                calls.append(("stop", stream_id))
+                return {"outputs": {"running": False, "stream": {}, "status": {}, "report": "stopped"}}
+
+        registry = SimpleNamespace(runtime_client=lambda device_id: FakeRuntimeClient())
+        request = {
+            "node_id": "scan-node",
+            "device_id": "jetson",
+            "action": "start",
+            "topic": "/scan",
+            "message_type": "sensor_msgs/msg/LaserScan",
+            "node_name": "blacknode_scan",
+            "history": 10,
+            "timeout": 10.0,
+            "stale_after_seconds": 1.0,
+        }
+        server._remote_ros2_runs.clear()
+        try:
+            with patch.object(server, "_device_registry", registry):
+                started = server._remote_ros2_action(request)
+                runtime = server._remote_ros2_runtime_status()
+                stopped = server._remote_ros2_action({**request, "action": "stop"})
+
+            self.assertTrue(started["outputs"]["running"])
+            self.assertEqual(started["outputs"]["backend"], "remote:jetson")
+            self.assertEqual(started["outputs"]["stream"]["device_id"], "jetson")
+            self.assertEqual(runtime["node_outputs"][0]["node_id"], "scan-node")
+            self.assertEqual(runtime["node_outputs"][0]["outputs"]["received"], 2)
+            self.assertFalse(stopped["outputs"]["running"])
+            self.assertEqual([call[0] for call in calls], ["start", "status", "stop"])
+        finally:
+            server._remote_ros2_runs.clear()
+
+    def test_remote_ros2_preflight_syncs_missing_device_package(self):
+        synced = []
+
+        class FakeRuntimeClient:
+            def manifest(self):
+                return {
+                    "features": ["remote_ros2_topic_stream_v1"],
+                    "packages": [{"name": "blacknode-runtime", "version": "0.4.1"}],
+                    "node_types": [],
+                }
+
+            def sync_packages(self, specs):
+                synced.extend(specs)
+                return {"ok": True}
+
+        server._ensure_remote_ros2_ready(FakeRuntimeClient())
+
+        self.assertEqual([item["name"] for item in synced], ["blacknode-ros2"])
+        self.assertEqual(synced[0]["components"], ["core", "topics"])
+        self.assertTrue(synced[0]["update"])
+
     def test_stop_runtime_services_aggregates_package_runtime_modules(self):
         def fake_stop(label, _module_name):
             if label == "ros2":

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -20,6 +20,18 @@ class GraphCookTests(unittest.TestCase):
         self.assertEqual(graph.cook(node, "value"), 1)
         self.assertEqual(graph.cook(node, "value"), 2)
 
+    def test_runtime_context_reaches_nodes_without_serializing(self):
+        @bn.node(inputs=[], outputs=["value:Text"], name="RuntimeContextProbe")
+        def probe(ctx: dict) -> dict:
+            return {"value": ctx["__probe__"]()}
+
+        graph = bn.Graph()
+        graph.set_runtime_context(__probe__=lambda: "live service")
+        node = graph.node("RuntimeContextProbe")
+
+        self.assertEqual(graph.cook(node, "value"), "live service")
+        self.assertNotIn("runtime_context", graph.to_dict())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- inject process-local Runtime services into graph cooks without persistence
- route ROS2 stream lifecycle through paired authenticated devices
- poll remote live outputs into the home editor
- preflight and sync the required blacknode-ros2 device package on explicit start

## Verification
- full Python suite: 525 passed, 8 skipped
- editor production build passed