### PR TITLE
Fix Jetson managed version checks

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -2858,14 +2858,27 @@ hardware_repo="$legacy_hardware_dir"
 
 package_version() {
   python3 - "$1" <<'PY'
+import re
 import sys
-import tomllib
 from pathlib import Path
 
 path = Path(sys.argv[1]) / "pyproject.toml"
 try:
-    payload = tomllib.loads(path.read_text(encoding="utf-8"))
-    print(str((payload.get("project") or {}).get("version") or "unknown"))
+    text = path.read_text(encoding="utf-8")
+    project = False
+    version = "unknown"
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            project = line == "[project]"
+            continue
+        if not project or not line or line.startswith("#"):
+            continue
+        match = re.match(r'''version\s*=\s*(["'])(.*?)\1(?:\s*#.*)?$''', line)
+        if match:
+            version = match.group(2)
+            break
+    print(version)
 except Exception:
     print("unknown")
 PY
@@ -2884,7 +2897,9 @@ validate_checkout() {
 import re
 import sys
 
-origin = sys.argv[1].strip().lower().removesuffix(".git").rstrip("/")
+origin = sys.argv[1].strip().lower().rstrip("/")
+if origin.endswith(".git"):
+    origin = origin[:-4]
 repository = sys.argv[2].strip().lower()
 if not re.search(rf"(?:github\.com[:/])temiroff/{re.escape(repository)}$", origin):
     raise SystemExit(
@@ -3384,7 +3399,6 @@ import json
 import re
 import subprocess
 import sys
-import tomllib
 import urllib.request
 from pathlib import Path
 
@@ -3420,11 +3434,18 @@ def command(args, timeout=30):
         return subprocess.CompletedProcess(args, 124, "", str(exc))
 
 def project_version(text):
-    try:
-        payload = tomllib.loads(text)
-        return str((payload.get("project") or {{}}).get("version") or "unknown")
-    except Exception:
-        return "unknown"
+    project = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            project = line == "[project]"
+            continue
+        if not project or not line or line.startswith("#"):
+            continue
+        match = re.match(r'''version\s*=\s*(["'])(.*?)\1(?:\s*#.*)?$''', line)
+        if match:
+            return match.group(2)
+    return "unknown"
 
 def package_version(directory):
     try:
@@ -3589,7 +3610,9 @@ def inspect(kind, repository, service, port, directory, state_override=""):
             raise RuntimeError(f"{{repository}} is not an updateable Git checkout.")
         origin = command(["git", "-C", str(directory), "remote", "get-url", "origin"])
         origin_url = origin.stdout.strip()
-        normalized = origin_url.lower().removesuffix(".git").rstrip("/")
+        normalized = origin_url.lower().rstrip("/")
+        if normalized.endswith(".git"):
+            normalized = normalized[:-4]
         trusted_origin = bool(re.search(
             rf"(?:github\.com[:/])temiroff/{{re.escape(repository)}}$",
             normalized,

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import base64
 import io
 import json
@@ -1490,6 +1491,8 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn('enabled_matches+=("$unit")', uploaded[0])
         self.assertIn('"/etc/systemd/system/$unit"', uploaded[0])
         self.assertIn("Discovered units:", uploaded[0])
+        self.assertNotIn("import tomllib", uploaded[0])
+        self.assertNotIn(".removesuffix(", uploaded[0])
         self.assertIn(
             "Repair Hardware did not create exactly one persistent service",
             uploaded[0],
@@ -1568,7 +1571,35 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn('"show",', commands[0])
         self.assertIn("Repair Hardware will reconcile", commands[0])
         remote_python = commands[0].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+        self.assertNotIn("import tomllib", remote_python)
+        self.assertNotIn(".removesuffix(", remote_python)
         compile(remote_python, "<managed-update-check>", "exec")
+        ast.parse(remote_python, feature_version=(3, 7))
+        parsed = ast.parse(remote_python)
+        project_version = next(
+            node
+            for node in parsed.body
+            if isinstance(node, ast.FunctionDef) and node.name == "project_version"
+        )
+        namespace = {"re": re}
+        exec(
+            compile(
+                ast.fix_missing_locations(ast.Module(
+                    body=[project_version],
+                    type_ignores=[],
+                )),
+                "<managed-update-version-parser>",
+                "exec",
+            ),
+            namespace,
+        )
+        self.assertEqual(
+            namespace["project_version"](
+                "[build-system]\nrequires = []\n\n"
+                "[project]\nname = 'blacknode-runtime'\nversion = '0.4.1'\n"
+            ),
+            "0.4.1",
+        )
 
     def test_workflow_requirements_are_normalized_and_exposed_by_graph(self):
         original_metadata = dict(server._session.metadata)


### PR DESCRIPTION
## What changed
- make managed Runtime version inspection work on Python 3.7+
- remove the Python 3.11-only `tomllib` dependency from remote scripts
- remove the Python 3.9-only `str.removesuffix` calls
- add regression coverage for the fallback project-version parser

## Why
Jetson devices commonly use Python 3.8, causing **Check updates** to fail before it could report the installed Runtime version.

## Validation
- `.venv/Scripts/python.exe -m unittest discover -s tests` (`525 passed`, `8 skipped`)
- focused managed-update tests (`4 passed`)