### PR TITLE
Fix managed snapshot Runtime updates

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,10 +3,10 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "d0dff2d8f9023fdde0e4613f55ac64af0a8b159c"
+    "commit": "916dfd6de0b15f4a7deb7db3078f6c955ed540c4"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "c3bfe64c89167ea7a00d14adb05b1cab20e7ce09"
+    "commit": "dbe134d73f7c4dee6f06ea30d768177acca867bd"
   }
 }

--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -2210,7 +2210,19 @@ runtime_port="$3"
 token_source="$4"
 remove_old_port="$5"
 bundle_path="$6"
+runtime_source_commit="$7"
+core_source_commit="$8"
 [[ "$bundle_path" != "-" ]] || bundle_path=""
+[[ "$runtime_source_commit" != "-" ]] || runtime_source_commit=""
+[[ "$core_source_commit" != "-" ]] || core_source_commit=""
+[[ -z "$runtime_source_commit" || "$runtime_source_commit" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "Invalid Runtime source commit."
+  exit 2
+}
+[[ -z "$core_source_commit" || "$core_source_commit" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "Invalid Blacknode source commit."
+  exit 2
+}
 [[ "$instance" == "default" || "$instance" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || {
   echo "Invalid Blacknode runtime instance."
   exit 2
@@ -2598,7 +2610,8 @@ if [[ "$action" != "runtime_only" && "$action" != "replace_runtime" ]] \
 fi
 python3 - "$stack_root/install.json" "$instance" "$runtime_dir" "$hardware_dir" \
   "$service_name" "$action" "$firewall_source" "$hardware_preserved" \
-  "$core_dir" "$python_dir" "$delivery_mode" <<'PY'
+  "$core_dir" "$python_dir" "$delivery_mode" "$runtime_source_commit" \
+  "$core_source_commit" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -2623,6 +2636,8 @@ manifest_path.write_text(json.dumps({
     "core_dir": sys.argv[9] if sys.argv[11] == "pc_assisted" else "",
     "python_dir": sys.argv[10] if sys.argv[11] == "pc_assisted" else "",
     "delivery_mode": sys.argv[11],
+    "runtime_commit": sys.argv[12],
+    "core_commit": sys.argv[13],
 }, indent=2) + "\\n", encoding="utf-8")
 PY
 install_complete=true
@@ -2680,7 +2695,9 @@ progress 96 "Verifying the runtime service"
             (
                 f"bash {remote_script_path} "
                 f"{clean_action} {selected_instance} {runtime_port} {remote_token_path} "
-                f"{1 if remove_old_port else 0} {remote_bundle_path or '-'}"
+                f"{1 if remove_old_port else 0} {remote_bundle_path or '-'} "
+                f"{runtime_bundle.runtime_commit if runtime_bundle is not None else '-'} "
+                f"{runtime_bundle.core_commit if runtime_bundle is not None else '-'}"
             ),
             stdin_text=_sudo_input(password),
             timeout=900.0,
@@ -2718,6 +2735,12 @@ progress 96 "Verifying the runtime service"
             ),
             "python_version": (
                 runtime_bundle.python_version if runtime_bundle is not None else ""
+            ),
+            "runtime_commit": (
+                runtime_bundle.runtime_commit if runtime_bundle is not None else ""
+            ),
+            "core_commit": (
+                runtime_bundle.core_commit if runtime_bundle is not None else ""
             ),
             "stack_mode": (
                 "isolated"
@@ -3588,12 +3611,21 @@ def resolve_hardware(port, expected_device_id):
     return unit, Path(directory), resolution_error
 
 def inspect(kind, repository, service, port, directory, state_override=""):
+    source_mode = (
+        "git"
+        if (directory / ".git").is_dir()
+        else "snapshot"
+        if (directory / "pyproject.toml").is_file()
+        else "missing"
+    )
     component = {{
         "kind": kind,
         "service_name": service or "blacknode-hardware-awaiting-device",
         "port": int(port),
         "installed": {{"version": package_version(directory), "commit": ""}},
         "latest": {{"version": "unknown", "commit": ""}},
+        "source_mode": source_mode,
+        "update_strategy": "replace" if source_mode == "snapshot" else "fast_forward",
         "update_available": False,
         "can_update": False,
         "migration_required": False,
@@ -3606,43 +3638,63 @@ def inspect(kind, repository, service, port, directory, state_override=""):
         "error": "",
     }}
     try:
-        if not (directory / ".git").is_dir():
-            raise RuntimeError(f"{{repository}} is not an updateable Git checkout.")
-        origin = command(["git", "-C", str(directory), "remote", "get-url", "origin"])
-        origin_url = origin.stdout.strip()
-        normalized = origin_url.lower().rstrip("/")
-        if normalized.endswith(".git"):
-            normalized = normalized[:-4]
-        trusted_origin = bool(re.search(
-            rf"(?:github\.com[:/])temiroff/{{re.escape(repository)}}$",
-            normalized,
-        ))
-        legacy_hardware_origin = bool(
-            repository == "blacknode-robot"
-            and re.search(
-                r"(?:github\.com[:/])temiroff/blacknode-hardware$",
+        if source_mode == "missing":
+            raise RuntimeError(f"{{repository}} package files are not installed.")
+        legacy_hardware_origin = False
+        latest_origin_url = f"https://github.com/temiroff/{{repository}}.git"
+        current_commit = ""
+        if source_mode == "git":
+            origin = command([
+                "git", "-C", str(directory), "remote", "get-url", "origin"
+            ])
+            origin_url = origin.stdout.strip()
+            normalized = origin_url.lower().rstrip("/")
+            if normalized.endswith(".git"):
+                normalized = normalized[:-4]
+            trusted_origin = bool(re.search(
+                rf"(?:github\.com[:/])temiroff/{{re.escape(repository)}}$",
                 normalized,
+            ))
+            legacy_hardware_origin = bool(
+                repository == "blacknode-robot"
+                and re.search(
+                    r"(?:github\.com[:/])temiroff/blacknode-hardware$",
+                    normalized,
+                )
             )
-        )
-        if not trusted_origin and not legacy_hardware_origin:
-            raise RuntimeError(
-                f"origin is not the trusted temiroff/{{repository}} repository"
+            if not trusted_origin and not legacy_hardware_origin:
+                raise RuntimeError(
+                    f"origin is not the trusted temiroff/{{repository}} repository"
+                )
+            latest_origin_url = (
+                "https://github.com/temiroff/blacknode-robot.git"
+                if legacy_hardware_origin
+                else origin_url
             )
+            current = command(["git", "-C", str(directory), "rev-parse", "HEAD"])
+            if current.returncode:
+                raise RuntimeError(
+                    current.stderr.strip() or "could not read installed commit"
+                )
+            current_commit = current.stdout.strip()
+            component["installed"]["commit"] = current_commit[:12]
+            dirty = command([
+                "git", "-C", str(directory), "status", "--porcelain",
+                "--untracked-files=normal",
+            ])
+            component["dirty"] = bool(dirty.stdout.strip())
+        else:
+            try:
+                installation = json.loads(
+                    (directory.parent / "install.json").read_text(encoding="utf-8")
+                )
+                commit_key = "runtime_commit" if kind == "runtime" else "hardware_commit"
+                current_commit = str(installation.get(commit_key) or "")
+                component["installed"]["commit"] = current_commit[:12]
+            except (OSError, ValueError, AttributeError):
+                pass
         component["migration_required"] = legacy_hardware_origin
-        latest_origin_url = (
-            "https://github.com/temiroff/blacknode-robot.git"
-            if legacy_hardware_origin
-            else origin_url
-        )
-        current = command(["git", "-C", str(directory), "rev-parse", "HEAD"])
-        if current.returncode:
-            raise RuntimeError(current.stderr.strip() or "could not read installed commit")
-        component["installed"]["commit"] = current.stdout.strip()[:12]
-        dirty = command([
-            "git", "-C", str(directory), "status", "--porcelain", "--untracked-files=normal"
-        ])
-        component["dirty"] = bool(dirty.stdout.strip())
-        if legacy_hardware_origin:
+        if legacy_hardware_origin or source_mode == "snapshot":
             remote_head = command(
                 ["git", "ls-remote", "--symref", latest_origin_url, "HEAD"],
                 timeout=45,
@@ -3658,7 +3710,7 @@ def inspect(kind, repository, service, port, directory, state_override=""):
             if remote_head.returncode or not upstream_ref.startswith("refs/heads/"):
                 raise RuntimeError(
                     remote_head.stderr.strip()
-                    or "could not resolve the blacknode-robot default branch"
+                    or f"could not resolve the {{repository}} default branch"
                 )
         else:
             branch = command([
@@ -3681,30 +3733,42 @@ def inspect(kind, repository, service, port, directory, state_override=""):
             )
         latest_commit = latest.stdout.split()[0]
         component["latest"]["commit"] = latest_commit[:12]
-        component["update_available"] = (
-            legacy_hardware_origin or current.stdout.strip() != latest_commit
-        )
-        if not component["update_available"]:
-            component["latest"]["version"] = component["installed"]["version"]
-        else:
+        if source_mode == "git":
             local_latest = command([
                 "git", "-C", str(directory), "show",
                 f"{{latest_commit}}:pyproject.toml",
             ])
             if not local_latest.returncode:
                 component["latest"]["version"] = project_version(local_latest.stdout)
-            if component["latest"]["version"] == "unknown":
-                raw_url = (
-                    f"https://raw.githubusercontent.com/temiroff/{{repository}}/"
-                    f"{{latest_commit}}/pyproject.toml"
-                )
-                try:
-                    with urllib.request.urlopen(raw_url, timeout=15) as response:
-                        component["latest"]["version"] = project_version(
-                            response.read().decode("utf-8")
-                        )
-                except Exception:
-                    pass
+        if component["latest"]["version"] == "unknown":
+            raw_url = (
+                f"https://raw.githubusercontent.com/temiroff/{{repository}}/"
+                f"{{latest_commit}}/pyproject.toml"
+            )
+            try:
+                with urllib.request.urlopen(raw_url, timeout=15) as response:
+                    component["latest"]["version"] = project_version(
+                        response.read().decode("utf-8")
+                    )
+            except Exception:
+                pass
+        if (
+            component["latest"]["version"] == "unknown"
+            and current_commit
+            and current_commit == latest_commit
+        ):
+            component["latest"]["version"] = component["installed"]["version"]
+        component["update_available"] = bool(
+            legacy_hardware_origin
+            or (current_commit and current_commit != latest_commit)
+            or (
+                not current_commit
+                and component["latest"]["version"] != "unknown"
+                and component["installed"]["version"] != "unknown"
+                and component["latest"]["version"]
+                != component["installed"]["version"]
+            )
+        )
         component["can_update"] = (
             not component["dirty"] and not legacy_hardware_origin
         )

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -4998,12 +4998,15 @@ def _update_device_host_payload(
     controlled_robots: list[str] = []
     warnings: list[str] = []
     runtime_api_unavailable = False
+    runtime_manifest_before: dict[str, Any] | None = None
     report(5, "Stopping running deployments")
     if not host.get("paused"):
         last_runtime_error = ""
         for attempt in range(3):
             try:
                 runtime_client = _device_registry.host_client(host_id)
+                if runtime_manifest_before is None:
+                    runtime_manifest_before = runtime_client.manifest()
                 for deployment in runtime_client.list_deployments().get("deployments") or []:
                     if (
                         isinstance(deployment, dict)
@@ -5064,26 +5067,123 @@ def _update_device_host_payload(
                 action="pause",
             )
             runtime_paused_for_fallback = True
-        update = update_managed_services(
-            host=str(managed.get("ssh_host") or ""),
-            port=int(managed.get("ssh_port") or 22),
-            username=str(managed.get("ssh_username") or ""),
-            password=req.password,
-            host_fingerprint=str(managed.get("host_fingerprint") or ""),
-            instance_id=str(managed.get("instance_id") or "default"),
-            runtime_port=int(managed.get("runtime_port") or 0),
-            hardware_ports=selected_hardware_ports,
-            hardware_device_ids={
-                hardware_port: hardware_device_ids.get(hardware_port, "")
-                for hardware_port in selected_hardware_ports
-            },
-            include_runtime=include_runtime,
-            stack_mode=str(managed.get("stack_mode") or "runtime_only"),
-            progress=lambda value: report(
-                15 + int(int(value.get("progress") or 0) * 0.75),
-                str(value.get("message") or "Updating managed services"),
-            ),
+        replace_runtime_snapshot = bool(
+            include_runtime
+            and str(managed.get("delivery_mode") or "") == "pc_assisted"
         )
+        if replace_runtime_snapshot:
+            report(15, "Preparing the latest Runtime bundle on this computer")
+            installed = install_runtime(
+                host=str(managed.get("ssh_host") or ""),
+                port=int(managed.get("ssh_port") or 22),
+                username=str(managed.get("ssh_username") or ""),
+                password=req.password,
+                host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                action="replace_runtime",
+                instance_id=str(managed.get("instance_id") or "default"),
+                progress=lambda value: report(
+                    15 + int(int(value.get("progress") or 0) * 0.6),
+                    str(value.get("message") or "Replacing Runtime snapshot"),
+                ),
+            )
+            runtime_host = str(managed.get("ssh_host") or "").strip()
+            runtime_host = f"[{runtime_host}]" if ":" in runtime_host else runtime_host
+            runtime_url = f"http://{runtime_host}:{int(installed['runtime_port'])}"
+            runtime_token = str(installed["runtime_token"])
+            replacement_manifest = RuntimeDeviceClient(
+                runtime_url,
+                runtime_token,
+            ).manifest()
+            replacement_management = dict(managed)
+            replacement_management.update({
+                "host_fingerprint": installed["host_fingerprint"],
+                "instance_id": installed["instance_id"],
+                "runtime_port": installed["runtime_port"],
+                "service_name": installed["service_name"],
+                "install_root": installed.get("install_root", ""),
+                "runtime_dir": installed["runtime_dir"],
+                "packages_dir": installed.get("packages_dir", ""),
+                "firewall_source": installed.get("firewall_source", ""),
+                "delivery_mode": installed.get("delivery_mode", "pc_assisted"),
+                "core_dir": installed.get("core_dir", ""),
+                "python_dir": installed.get("python_dir", ""),
+                "python_version": installed.get("python_version", ""),
+                "stack_mode": installed.get("stack_mode", "runtime_only"),
+                "hardware_dir": installed.get("hardware_dir", ""),
+            })
+            _device_registry.pair_host(
+                name=str(host.get("name") or "Compute device"),
+                runtime_url=runtime_url,
+                runtime_token=runtime_token,
+                manifest=replacement_manifest,
+                managed_runtime=replacement_management,
+            )
+            before_version = str(
+                (runtime_manifest_before or {}).get("runtime_version") or "unknown"
+            )
+            after_version = str(
+                replacement_manifest.get("runtime_version") or "unknown"
+            )
+            update = {
+                "ok": True,
+                "components": [{
+                    "kind": "runtime",
+                    "service_name": str(installed.get("service_name") or ""),
+                    "port": int(installed.get("runtime_port") or 0),
+                    "before": {"version": before_version, "commit": ""},
+                    "after": {
+                        "version": after_version,
+                        "commit": str(installed.get("runtime_commit") or "")[:12],
+                    },
+                    "changed": before_version != after_version,
+                    "state": "active",
+                    "source_mode": "snapshot",
+                }],
+                "host_fingerprint": installed["host_fingerprint"],
+            }
+            if selected_hardware_ports:
+                hardware_update = update_managed_services(
+                    host=str(managed.get("ssh_host") or ""),
+                    port=int(managed.get("ssh_port") or 22),
+                    username=str(managed.get("ssh_username") or ""),
+                    password=req.password,
+                    host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                    instance_id=str(managed.get("instance_id") or "default"),
+                    runtime_port=int(installed.get("runtime_port") or 0),
+                    hardware_ports=selected_hardware_ports,
+                    hardware_device_ids={
+                        hardware_port: hardware_device_ids.get(hardware_port, "")
+                        for hardware_port in selected_hardware_ports
+                    },
+                    include_runtime=False,
+                    stack_mode=str(managed.get("stack_mode") or "runtime_only"),
+                    progress=lambda value: report(
+                        75 + int(int(value.get("progress") or 0) * 0.15),
+                        str(value.get("message") or "Updating Robot Hardware"),
+                    ),
+                )
+                update["components"].extend(hardware_update.get("components") or [])
+        else:
+            update = update_managed_services(
+                host=str(managed.get("ssh_host") or ""),
+                port=int(managed.get("ssh_port") or 22),
+                username=str(managed.get("ssh_username") or ""),
+                password=req.password,
+                host_fingerprint=str(managed.get("host_fingerprint") or ""),
+                instance_id=str(managed.get("instance_id") or "default"),
+                runtime_port=int(managed.get("runtime_port") or 0),
+                hardware_ports=selected_hardware_ports,
+                hardware_device_ids={
+                    hardware_port: hardware_device_ids.get(hardware_port, "")
+                    for hardware_port in selected_hardware_ports
+                },
+                include_runtime=include_runtime,
+                stack_mode=str(managed.get("stack_mode") or "runtime_only"),
+                progress=lambda value: report(
+                    15 + int(int(value.get("progress") or 0) * 0.75),
+                    str(value.get("message") or "Updating managed services"),
+                ),
+            )
     except Exception:
         if runtime_paused_for_fallback:
             try:
@@ -5141,7 +5241,7 @@ def _update_device_host_payload(
 
     if include_runtime:
         extension_specs, extension_warnings = _runtime_extension_update_specs(
-            runtime_manifest
+            runtime_manifest_before or runtime_manifest
         )
         warnings.extend(extension_warnings)
         if extension_specs:

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -718,6 +718,8 @@ export interface ManagedServiceUpdateCheckResult {
       reported_version?: string
       update_available: boolean
       can_update: boolean
+      source_mode?: 'git' | 'snapshot' | 'missing'
+      update_strategy?: 'fast_forward' | 'replace'
       migration_required?: boolean
       dirty: boolean
       state: string

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -670,7 +670,15 @@ export default function DevicesPanel({
       ?.state?.status?.software_version
     || selectedDevice?.robots.find(robot => robot.software_version)?.software_version
   )
-  const selectedHardwareVersionLabel = selectedHardwareVersion
+  const selectedHardwarePackageInstalled = selectedDeviceManagedLocally
+    ? selectedDeviceState?.runtime?.hardware?.installed !== false
+    : Boolean(
+        selectedDevice?.managed_runtime?.hardware_dir
+        || selectedDevice?.robots.length,
+      )
+  const selectedHardwareVersionLabel = !selectedHardwarePackageInstalled
+    ? 'Not installed'
+    : selectedHardwareVersion
     ? `v${selectedHardwareVersion}`
     : 'version not reported'
   const selectedHardwarePackageState = selectedDeviceState?.loading
@@ -875,7 +883,9 @@ export default function DevicesPanel({
           : '')
     : ''
   const hardwareLatestVersionError = updateCheckReport
-    ? checkedHardwareInstallation?.error
+    ? !selectedHardwarePackageInstalled
+      ? ''
+      : checkedHardwareInstallation?.error
       || (!hardwareLatestVersion && checkedHardwareComponents.length === 0
         ? selectedDevice?.robots.length
           ? 'No attached Robot service was included in the update check.'
@@ -2007,6 +2017,7 @@ export default function DevicesPanel({
         ...previous,
         [device.id]: { progress: 100, message: result.summary },
       }))
+      await refreshDevice(device)
     } catch (reason) {
       const message = reason instanceof Error ? reason.message : String(reason)
       setActionProgress(previous => ({
@@ -3881,23 +3892,18 @@ export default function DevicesPanel({
                         ? `${selectedDevice.robots.length} Hardware service${
                             selectedDevice.robots.length === 1 ? '' : 's'
                           } on ${runtimeHostname(selectedDevice.runtime_url)}`
-                        : 'Robot package installed · no robot service configured yet'}
+                        : selectedDevice.managed_runtime.hardware_dir
+                          ? 'Robot package installed · no robot service configured yet'
+                          : 'Robot package not installed · no robot service attached'}
                     state={selectedHardwarePackageState}
                     currentVersion={hardwareCurrentVersion}
                     latestVersion={hardwareLatestVersion}
-                    latestChecked={Boolean(updateCheckReport)}
+                    latestChecked={Boolean(updateCheckReport) && selectedHardwarePackageInstalled}
                     latestError={hardwareLatestVersionError}
                     migrationRequired={Boolean(
                       checkedHardwareInstallation?.migration_required,
                     )}
-                    installed={
-                      selectedDeviceManagedLocally
-                        ? selectedDeviceState?.runtime?.hardware?.installed !== false
-                        : Boolean(
-                            selectedDevice.managed_runtime.hardware_dir
-                            || selectedDevice.robots.length,
-                          )
-                    }
+                    installed={selectedHardwarePackageInstalled}
                     updateAvailable={checkedHardwareHasUpdate}
                     busy={busy}
                     onCheckLatest={() => void checkDeviceSoftware(selectedDevice)}
@@ -3918,11 +3924,17 @@ export default function DevicesPanel({
                         : void restartRemotePackage(selectedDevice, 'hardware')
                     )}
                     onUpdate={() => void updateDevice(selectedDevice, 'hardware', 'update')}
+                    updateEnabled={
+                      selectedDeviceManagedLocally || selectedHardwarePackageInstalled
+                    }
                     onReinstall={() => void updateDevice(
                       selectedDevice,
                       'hardware',
                       'reinstall',
                     )}
+                    reinstallEnabled={
+                      selectedDeviceManagedLocally || selectedHardwarePackageInstalled
+                    }
                     deleteEnabled={selectedDeviceManagedLocally}
                     onDelete={() => {
                       if (selectedDeviceManagedLocally) {
@@ -5199,6 +5211,8 @@ function SoftwarePackageSummaryCard({
   onCheckLatest,
   runStopEnabled = true,
   restartEnabled = true,
+  updateEnabled = true,
+  reinstallEnabled = true,
   deleteEnabled = true,
   onRunStop,
   onRestart,
@@ -5221,6 +5235,8 @@ function SoftwarePackageSummaryCard({
   onCheckLatest: () => void
   runStopEnabled?: boolean
   restartEnabled?: boolean
+  updateEnabled?: boolean
+  reinstallEnabled?: boolean
   deleteEnabled?: boolean
   onRunStop: (action: 'run' | 'stop') => void
   onRestart: () => void
@@ -5283,7 +5299,9 @@ function SoftwarePackageSummaryCard({
             >
               <small>Latest</small>
               <b>
-                {latestVersion ?? (latestChecked ? 'Unavailable' : 'Not checked')}
+                {!installed
+                  ? 'Not installed'
+                  : latestVersion ?? (latestChecked ? 'Unavailable' : 'Not checked')}
               </b>
             </span>
           </div>
@@ -5296,7 +5314,11 @@ function SoftwarePackageSummaryCard({
       <code title={path}>{path}</code>
       {detail && <small>{detail}</small>}
       <div className="bn-local-package-version-action">
-        {latestError ? (
+        {!installed ? (
+          <div className="bn-local-package-version-current">
+            Package not installed
+          </div>
+        ) : latestError ? (
           <div className="bn-local-package-version-unavailable" role="alert">
             <strong>
               {migrationRequired ? 'Package migration required' : 'Latest version unavailable'}
@@ -5351,7 +5373,7 @@ function SoftwarePackageSummaryCard({
         <button
           type="button"
           className={`bn-device-action-button${updateAvailable ? ' is-primary' : ''}`}
-          disabled={busy}
+          disabled={busy || !updateEnabled}
           onClick={onUpdate}
         >
           Update
@@ -5359,7 +5381,7 @@ function SoftwarePackageSummaryCard({
         <button
           type="button"
           className="bn-device-action-button"
-          disabled={busy}
+          disabled={busy || !reinstallEnabled}
           onClick={onReinstall}
         >
           Reinstall
@@ -5385,7 +5407,7 @@ function SoftwarePackageSummaryCard({
         <button
           type="button"
           className={`bn-device-action-button${updateAvailable ? ' is-primary' : ''}`}
-          disabled={busy}
+          disabled={busy || !updateEnabled}
           onClick={onUpdate}
         >
           Update
@@ -5407,7 +5429,11 @@ function SoftwarePackageSummaryCard({
             >
               Restart
             </button>
-            <button type="button" disabled={busy} onClick={onReinstall}>
+            <button
+              type="button"
+              disabled={busy || !reinstallEnabled}
+              onClick={onReinstall}
+            >
               Reinstall
             </button>
             <button

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -55,6 +55,7 @@ class _HardwareService:
         *,
         status_overrides: dict | None = None,
         runtime_features: list[str] | None = None,
+        runtime_version: str = "0.1.0",
         torque_readback_available: bool = True,
     ) -> None:
         self.token = token
@@ -94,6 +95,7 @@ class _HardwareService:
             "ros2_diagnostics_v1",
             "managed_ros2_services_v1",
         ]
+        self.runtime_version = runtime_version
         self.ros2_diagnostics_payload = {
             "ok": True,
             "available": True,
@@ -154,7 +156,7 @@ class _HardwareService:
             return _JsonResponse({
                 "service": "blacknode-runtime",
                 "protocol_version": 1,
-                "runtime_version": "0.1.0",
+                "runtime_version": self.runtime_version,
                 "device_id": "alex-desktop",
                 "features": self.runtime_features,
                 "python": {"version": "3.12.3"},
@@ -1256,11 +1258,14 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertEqual(result["firewall_source"], "192.168.1.20")
         self.assertEqual(result["delivery_mode"], "pc_assisted")
         self.assertEqual(result["python_version"], "3.11.14")
+        self.assertEqual(result["runtime_commit"], "a" * 40)
+        self.assertEqual(result["core_commit"], "b" * 40)
         self.assertEqual(
             result["python_dir"],
             "~/Blacknode/devices/default/python",
         )
         self.assertIn("runtime_only default 8766", commands[0])
+        self.assertIn(f"{'a' * 40} {'b' * 40}", commands[0])
 
     def test_default_isolated_stack_uninstall_streams_remote_cleanup_progress(self):
         uploaded = []
@@ -1573,6 +1578,9 @@ class EditorDeviceApiTests(unittest.TestCase):
         remote_python = commands[0].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
         self.assertNotIn("import tomllib", remote_python)
         self.assertNotIn(".removesuffix(", remote_python)
+        self.assertNotIn("is not an updateable Git checkout", remote_python)
+        self.assertIn('"snapshot"', remote_python)
+        self.assertIn('"update_strategy": "replace"', remote_python)
         compile(remote_python, "<managed-update-check>", "exec")
         ast.parse(remote_python, feature_version=(3, 7))
         parsed = ast.parse(remote_python)
@@ -4329,6 +4337,109 @@ class EditorDeviceApiTests(unittest.TestCase):
         )
         self.assertIn("workflow package", result["summary"])
         self.assertNotIn("ssh-password", response.text)
+
+    def test_pc_assisted_runtime_update_replaces_snapshot_and_repairs_pairing(self):
+        runtime = _HardwareService(
+            "old-runtime-token",
+            runtime_version="0.4.0",
+        )
+        host = server._device_registry.pair_host(
+            name="Jetson",
+            runtime_url="http://192.168.1.171:8766",
+            runtime_token=runtime.token,
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "runtime_version": "0.4.0",
+                "device_id": "ubuntu",
+            },
+            managed_runtime={
+                "ssh_host": "192.168.1.171",
+                "ssh_port": 22,
+                "ssh_username": "ubuntu",
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "default",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime.service",
+                "install_root": "~/Blacknode/devices/default",
+                "runtime_dir": "~/Blacknode/devices/default/runtime",
+                "packages_dir": "~/Blacknode/devices/default/runtime/packages",
+                "delivery_mode": "pc_assisted",
+                "core_dir": "~/Blacknode/devices/default/core",
+                "python_dir": "~/Blacknode/devices/default/python",
+                "stack_mode": "runtime_only",
+                "hardware_dir": "",
+            },
+        )
+
+        def replace_runtime(**kwargs):
+            self.assertEqual(kwargs["action"], "replace_runtime")
+            self.assertEqual(kwargs["instance_id"], "default")
+            runtime.token = "new-runtime-token"
+            runtime.runtime_version = "0.4.1"
+            return {
+                "ok": True,
+                "runtime_token": runtime.token,
+                "host_fingerprint": "SHA256:trusted-device-key",
+                "instance_id": "default",
+                "runtime_port": 8766,
+                "service_name": "blacknode-runtime.service",
+                "install_root": "~/Blacknode/devices/default",
+                "runtime_dir": "~/Blacknode/devices/default/runtime",
+                "packages_dir": "~/Blacknode/devices/default/runtime/packages",
+                "firewall_source": "192.168.1.20",
+                "delivery_mode": "pc_assisted",
+                "core_dir": "~/Blacknode/devices/default/core",
+                "python_dir": "~/Blacknode/devices/default/python",
+                "python_version": "3.11.15",
+                "runtime_commit": "9" * 40,
+                "core_commit": "8" * 40,
+                "stack_mode": "runtime_only",
+                "hardware_dir": "",
+            }
+
+        with (
+            patch(
+                "device_registry.urllib.request.urlopen",
+                side_effect=runtime,
+            ),
+            patch.object(server, "install_runtime", side_effect=replace_runtime) as install,
+            patch.object(server, "update_managed_services") as fast_forward,
+            patch.object(
+                server,
+                "_runtime_extension_update_specs",
+                return_value=([], []),
+            ),
+        ):
+            result = server._update_device_host_payload(
+                host["id"],
+                server.UpdateManagedDeviceReq(
+                    password="ssh-password",
+                    scope="runtime",
+                    operation="update",
+                ),
+            )
+            repaired_manifest = server._device_registry.host_client(
+                host["id"]
+            ).manifest()
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["runtime"]["runtime_version"], "0.4.1")
+        self.assertEqual(
+            result["update"]["components"][0]["source_mode"],
+            "snapshot",
+        )
+        self.assertEqual(
+            result["update"]["components"][0]["before"]["version"],
+            "0.4.0",
+        )
+        self.assertEqual(
+            result["update"]["components"][0]["after"]["version"],
+            "0.4.1",
+        )
+        install.assert_called_once()
+        fast_forward.assert_not_called()
+        self.assertEqual(repaired_manifest["runtime_version"], "0.4.1")
 
     def test_managed_runtime_update_falls_back_to_verified_ssh_when_api_times_out(self):
         host = server._device_registry.pair_host(


### PR DESCRIPTION
## What changed
- recognize PC-assisted Runtime snapshots as installed managed software
- compare snapshot versions with the trusted Runtime repository
- update snapshots by replacing the managed Runtime bundle and repairing its pairing token
- preserve and refresh installed workflow packages after replacement
- refresh live Runtime state after checking versions
- show an absent Robot package as not installed instead of a failed version check
- pin the device bundle to Runtime 0.4.1

## Root cause
PC-assisted Jetson installs are verified source snapshots and intentionally contain no `.git` directory. The update checker treated every Runtime directory as a Git checkout and incorrectly combined that source-layout error with live service reachability.

## Validation
- `.venv/Scripts/python.exe -m unittest discover -s tests` (`526 passed`, `8 skipped`)
- `.venv/Scripts/python.exe -m pytest tests/test_editor_devices.py` (`136 passed`)
- `npm run build`