### PR TITLE
Fix managed Runtime port re-pairing

### DIFF
--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -378,6 +378,26 @@ def _host_id(runtime_url: str) -> str:
     return f"{label}-{digest}"
 
 
+def _managed_runtime_identity(
+    record: dict[str, Any] | None,
+) -> tuple[str, int, str, str, str] | None:
+    """Return the stable SSH + instance identity for one managed Runtime."""
+    management = (record or {}).get("managed_runtime")
+    if not isinstance(management, dict):
+        return None
+    ssh_host = str(management.get("ssh_host") or "").strip().casefold()
+    ssh_username = str(management.get("ssh_username") or "").strip()
+    fingerprint = str(management.get("host_fingerprint") or "").strip()
+    instance_id = str(management.get("instance_id") or "default").strip()
+    try:
+        ssh_port = int(management.get("ssh_port") or 22)
+    except (TypeError, ValueError):
+        return None
+    if not ssh_host or not ssh_username or not fingerprint or not instance_id:
+        return None
+    return ssh_host, ssh_port, ssh_username, fingerprint, instance_id
+
+
 class HardwareDeviceClient:
     """Talk to one hardware service while keeping its bearer token server-side."""
 
@@ -912,6 +932,7 @@ class DeviceRegistry:
         runtime_token: str,
         manifest: dict[str, Any],
         managed_runtime: dict[str, Any] | None = None,
+        host_id: str | None = None,
     ) -> dict[str, Any]:
         clean_url = normalize_base_url(runtime_url)
         clean_token = str(runtime_token or "").strip()
@@ -928,12 +949,39 @@ class DeviceRegistry:
         with self._lock:
             hosts, records = self._load_payload()
             hosts, _changed = self._materialize_hosts(hosts, records)
-            existing = next(
+            requested = hosts.get(str(host_id or "")) if host_id else None
+            if host_id and requested is None:
+                raise DeviceRegistryError("Compute device was not found.")
+            url_match = next(
                 (item for item in hosts.values() if item.get("runtime_url") == clean_url),
                 None,
             )
+            requested_management = (
+                {"managed_runtime": managed_runtime}
+                if isinstance(managed_runtime, dict)
+                else None
+            )
+            stable_identity = _managed_runtime_identity(requested_management)
+            identity_matches = (
+                [
+                    item
+                    for item in hosts.values()
+                    if stable_identity is not None
+                    and _managed_runtime_identity(item) == stable_identity
+                ]
+                if managed_runtime
+                else []
+            )
+            existing = requested
+            if existing is None and identity_matches:
+                existing = min(
+                    identity_matches,
+                    key=lambda item: str(item.get("created_at") or ""),
+                )
+            if existing is None:
+                existing = url_match
             if existing is None and managed_runtime:
-                requested_identity = (
+                inspection_identity = (
                     str(managed_runtime.get("ssh_host") or "").strip(),
                     int(managed_runtime.get("ssh_port") or 22),
                     str(managed_runtime.get("ssh_username") or "").strip(),
@@ -970,10 +1018,28 @@ class DeviceRegistry:
                                 or ""
                             ).strip(),
                         )
-                        == requested_identity
+                        == inspection_identity
                     ),
                     None,
                 )
+            duplicate_ids: set[str] = set()
+            for item in hosts.values():
+                item_id = str(item.get("id") or "")
+                if not item_id or item is existing:
+                    continue
+                if item is url_match or (
+                    stable_identity is not None
+                    and _managed_runtime_identity(item) == stable_identity
+                ):
+                    if (
+                        stable_identity is None
+                        or _managed_runtime_identity(item) != stable_identity
+                    ):
+                        raise DeviceRegistryError(
+                            "That Runtime URL is already paired to a different "
+                            "managed device. Remove the conflicting device first."
+                        )
+                    duplicate_ids.add(item_id)
             now = _iso_now()
             host_id = existing["id"] if existing else _host_id(clean_url)
             created_at = existing.get("created_at") if existing else now
@@ -1043,12 +1109,18 @@ class DeviceRegistry:
             if management:
                 host["managed_runtime"] = management
             hosts[host_id] = host
+            for duplicate_id in duplicate_ids:
+                hosts.pop(duplicate_id, None)
             for record in records.values():
                 record_runtime_url = str(
                     record.get("runtime_url")
                     or default_runtime_url(record["base_url"])
                 )
-                if record_runtime_url == clean_url:
+                if (
+                    record_runtime_url == clean_url
+                    or str(record.get("host_id") or "") == host_id
+                    or str(record.get("host_id") or "") in duplicate_ids
+                ):
                     record["host_id"] = host_id
                     record["runtime_url"] = clean_url
                     record["runtime_token"] = clean_token

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -5117,6 +5117,7 @@ def _update_device_host_payload(
                 runtime_token=runtime_token,
                 manifest=replacement_manifest,
                 managed_runtime=replacement_management,
+                host_id=host_id,
             )
             before_version = str(
                 (runtime_manifest_before or {}).get("runtime_version") or "unknown"

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -4371,6 +4371,17 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "hardware_dir": "",
             },
         )
+        saved = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        duplicate = json.loads(json.dumps(saved["hosts"][host["id"]]))
+        duplicate["id"] = "legacy-duplicate"
+        duplicate["runtime_url"] = "http://192.168.1.171:8767"
+        duplicate["managed_runtime"]["runtime_port"] = 8767
+        duplicate["created_at"] = "2026-08-03T14:12:10-07:00"
+        saved["hosts"][duplicate["id"]] = duplicate
+        self.registry_path.write_text(
+            json.dumps(saved, indent=2) + "\n",
+            encoding="utf-8",
+        )
 
         def replace_runtime(**kwargs):
             self.assertEqual(kwargs["action"], "replace_runtime")
@@ -4382,7 +4393,7 @@ class EditorDeviceApiTests(unittest.TestCase):
                 "runtime_token": runtime.token,
                 "host_fingerprint": "SHA256:trusted-device-key",
                 "instance_id": "default",
-                "runtime_port": 8766,
+                "runtime_port": 8767,
                 "service_name": "blacknode-runtime.service",
                 "install_root": "~/Blacknode/devices/default",
                 "runtime_dir": "~/Blacknode/devices/default/runtime",
@@ -4440,6 +4451,17 @@ class EditorDeviceApiTests(unittest.TestCase):
         install.assert_called_once()
         fast_forward.assert_not_called()
         self.assertEqual(repaired_manifest["runtime_version"], "0.4.1")
+        repaired_hosts = self.client.get("/device-hosts").json()["devices"]
+        self.assertEqual(len(repaired_hosts), 1)
+        self.assertEqual(repaired_hosts[0]["id"], host["id"])
+        self.assertEqual(
+            repaired_hosts[0]["runtime_url"],
+            "http://192.168.1.171:8767",
+        )
+        self.assertEqual(
+            repaired_hosts[0]["managed_runtime"]["runtime_port"],
+            8767,
+        )
 
     def test_managed_runtime_update_falls_back_to_verified_ssh_when_api_times_out(self):
         host = server._device_registry.pair_host(


### PR DESCRIPTION
## What changed

- keep a managed Runtime attached to the selected compute-device record when reinstalling it on a different port
- identify managed Runtime instances by verified SSH host, account, host key, and instance ID
- merge stale duplicate records and move attached robot records to the surviving compute device

## Root cause

The Jetson had two local records for the same `default` Runtime service: the original record pointed to port 8766 while the updated service was healthy on port 8767. Re-pairing selected the record by URL, then verification retried the original host ID and reported a connection refusal.

## Impact

Runtime snapshot updates can change or rediscover the managed port without leaving the editor pointed at a stale endpoint. Existing duplicate records are reconciled during pairing.

## Validation

- `python -m unittest discover -s tests -p test_editor_devices.py` (136 passed)
- `PYTHONPATH=python python -m unittest discover -s tests` (526 passed, 8 skipped)
- live Jetson manifest verified as Blacknode Runtime v0.4.1 on port 8767