### PR TITLE
Fix paired-device ROS2 streaming

### DIFF
--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -766,6 +766,20 @@ class DeviceRegistry:
     def runtime_client(self, device_id: str) -> RuntimeDeviceClient:
         with self._lock:
             hosts, records = self._load_payload()
+            hosts, changed = self._materialize_hosts(hosts, records)
+            if changed:
+                self._save_payload(hosts, records)
+            direct_host = hosts.get(device_id)
+            if direct_host is not None:
+                if direct_host.get("inspection_only"):
+                    raise DeviceRegistryError(
+                        "This compute device is registered for read-only inspection. "
+                        "Install or pair Blacknode Runtime before using runtime APIs."
+                    )
+                return RuntimeDeviceClient(
+                    direct_host["runtime_url"],
+                    direct_host["runtime_token"],
+                )
             record = records.get(device_id)
             if record is None:
                 raise KeyError(device_id)

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -2715,6 +2715,12 @@ _RUNTIME_STATUS_KEYS = ("cookResult", "cookError", "cooking", "cookPort")
 
 
 def _status_value(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {str(key): _status_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_status_value(item) for item in value]
     try:
         return json.loads(json.dumps(value, default=str))
     except Exception:
@@ -3276,6 +3282,7 @@ def _cook_trace(
             })
 
             fn = _NODE_REGISTRY[node_def["type"]]
+            ctx.update(getattr(_session.graph, "_runtime_context", {}))
             ctx["__graph__"] = _session.graph
             ctx["__node_id__"] = current_id
             ctx["__run_logger__"] = logger
@@ -3618,7 +3625,7 @@ def console_exec(req: ConsoleExecReq):
 
 @app.get("/runtime/status")
 def runtime_status():
-    return _runtime_status()
+    return _status_value(_runtime_status())
 
 
 @app.get("/api/dataset/media/{token}")
@@ -10996,6 +11003,9 @@ def _subgraph_cook_trace(
         inner._cache = {}
         inner._dirty = set(inner_meta.keys())
         inner._nodes = {}
+        inner._runtime_context = dict(
+            getattr(_session.graph, "_runtime_context", {})
+        )
         for nid, meta in inner_meta.items():
             entry = {"type": meta["type"], "params": dict(meta.get("params", {}))}
             if "subgraph" in meta:
@@ -11058,6 +11068,7 @@ def _subgraph_cook_trace(
                     result = _session.graph._cook_subnet(current_id, current_port, ctx)
                 else:
                     fn = _NODE_REGISTRY[node_def["type"]]
+                    ctx.update(getattr(_session.graph, "_runtime_context", {}))
                     ctx["__graph__"] = _session.graph
                     ctx["__node_id__"] = current_id
                     ctx["__run_logger__"] = logger
@@ -11193,6 +11204,7 @@ def _subgraph_cook_trace(
                     result = inner._cook_subnet(current_id, current_port, ctx)
                 else:
                     fn = _NODE_REGISTRY[node_def["type"]]
+                    ctx.update(getattr(inner, "_runtime_context", {}))
                     ctx["__graph__"] = inner
                     ctx["__node_id__"] = current_id
                     result = fn(ctx)

--- a/tests/test_compute_device_inspection.py
+++ b/tests/test_compute_device_inspection.py
@@ -102,6 +102,29 @@ class ComputeDeviceInspectionTests(unittest.TestCase):
             "read-only inspection",
         ):
             registry.host_client(device["id"])
+        with self.assertRaisesRegex(
+            device_registry.DeviceRegistryError,
+            "read-only inspection",
+        ):
+            registry.runtime_client(device["id"])
+
+    def test_runtime_client_accepts_compute_device_id(self):
+        registry = server._device_registry
+        device = registry.pair_host(
+            name="Jetson",
+            runtime_url="http://192.168.55.1:8766",
+            runtime_token="runtime-secret-value-that-is-long-enough",
+            manifest={
+                "service": "blacknode-runtime",
+                "protocol_version": 1,
+                "device_id": "jetson-device",
+            },
+        )
+
+        client = registry.runtime_client(device["id"])
+
+        self.assertEqual(client.base_url, "http://192.168.55.1:8766")
+        self.assertEqual(client.token, "runtime-secret-value-that-is-long-enough")
 
     def test_live_inspection_uses_paired_runtime_without_ssh_password(self):
         registry = server._device_registry

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import unittest
@@ -20,6 +21,48 @@ import server  # noqa: E402
 
 
 class EditorRuntimeTests(unittest.TestCase):
+    def test_streamed_cook_injects_process_local_runtime_services(self):
+        node_id = "runtime-context-test"
+
+        def runtime_context_node(ctx):
+            callback = ctx.get("__runtime_callback__")
+            return {"value": callback() if callable(callback) else "missing"}
+
+        original_context = dict(server._session.graph._runtime_context)
+        server._session.node_meta[node_id] = {
+            "id": node_id,
+            "type": "RuntimeContextTest",
+            "params": {},
+        }
+        server._session.graph._nodes[node_id] = {
+            "type": "RuntimeContextTest",
+            "params": {},
+        }
+        server._session.graph._dirty.add(node_id)
+        server._session.graph.set_runtime_context(
+            __runtime_callback__=lambda: "delegated",
+        )
+        try:
+            with patch.dict(
+                server._NODE_REGISTRY,
+                {"RuntimeContextTest": runtime_context_node},
+            ):
+                events = [
+                    json.loads(line)
+                    for line in server._cook_trace(node_id, "value")
+                ]
+        finally:
+            server._session.node_meta.pop(node_id, None)
+            server._session.graph._nodes.pop(node_id, None)
+            server._session.graph._dirty.discard(node_id)
+            for cache_key in list(server._session.graph._cache):
+                if cache_key[0] == node_id:
+                    server._session.graph._cache.pop(cache_key, None)
+            server._session.graph.set_runtime_context(**original_context)
+
+        success = next(event for event in events if event.get("type") == "success")
+        self.assertEqual(success["value"], "delegated")
+
     def test_robot_calibration_runtime_is_managed_through_generic_node(self):
         self.assertEqual(
             server._RUNTIME_MODULES["robot_calibration_control"],
@@ -157,6 +200,17 @@ class EditorRuntimeTests(unittest.TestCase):
         self.assertEqual(result["managed_runs"], [{"run_id": "camera_run", "runtime": "ros2"}])
         self.assertEqual(result["detached_count"], 1)
 
+    def test_runtime_status_normalizes_nonfinite_sensor_values(self):
+        with patch.object(
+            server,
+            "_runtime_status",
+            return_value={"ranges": [1.0, float("nan"), float("inf")]},
+        ):
+            response = TestClient(server.app).get("/runtime/status")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"ranges": [1.0, None, None]})
+
     def test_remote_ros2_action_routes_through_paired_runtime_and_reports_live_outputs(self):
         calls = []
 
@@ -164,7 +218,7 @@ class EditorRuntimeTests(unittest.TestCase):
             def manifest(self):
                 return {
                     "features": ["remote_ros2_topic_stream_v1"],
-                    "packages": [{"name": "blacknode-ros2", "version": "0.5.16"}],
+                    "packages": [{"name": "blacknode-ros2", "version": "0.5.18"}],
                     "node_types": ["ROS2"],
                 }
 


### PR DESCRIPTION
## What changed

- inject editor process-local runtime services into streamed top-level and subnet cooks
- allow Runtime clients to resolve compute-device IDs as well as attached robot IDs
- normalize non-finite sensor values before returning Runtime status to the browser
- update the ROS package preflight expectation to v0.5.18

## Root cause

The visual editor's streamed cook path bypassed `Graph.cook()` and omitted the remote ROS callback. Once delegated, the compute host ID was incorrectly looked up only as a robot. Finally, valid LaserScan `NaN`/infinite ranges caused strict browser JSON serialization to fail.

## Impact

A generic `ComputeDevice → ROS2` graph can start and monitor a ROS topic on a paired Jetson and stream structured messages into the editor.

## Validation

- full core suite: 529 passed, 8 skipped
- live Jetson ROS Humble `/scan`: ready, worker alive, source fresh, 109 messages received during verification
- `blacknode-ros2` v0.5.18 package suite: 101 passed, 4 skipped