### PR TITLE
Polish SLAM viewer and package applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ manual setup, updates, restarts, recovery, and removal.
 4. Open **Deploy**, select the robot, and press **Check setup**.
 5. When the checks pass, choose **Send to robot** or **Send & run on robot**.
 
+Installed packages can also expose named on-device applications. With
+`blacknode-cuda` and `blacknode-ros2` installed on a Jetson, run the packaged
+Warp SLAM viewer directly:
+
+```bash
+blacknode run slam --device cuda:0
+```
+
 The preflight checks the exact workflow revision, target packages,
 capabilities, hardware connection, calibration, and disarmed state. Open
 **Deployments** to inspect logs, stop a run, send an update, or roll back.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -331,6 +331,12 @@ Event types include:
 - `model_call`
 - `tool_call`
 
+Installed extension packages may also declare named applications. For example,
+the CUDA package's spatial-processing component supports `blacknode run slam`
+on a ROS 2 compute device. Arguments after the application name are passed to
+the package application; workflow JSON execution keeps its structured-result
+contract unchanged.
+
 Run logs are output artifacts. They must not be saved back into workflow JSON.
 
 ## Secrets

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -50,6 +50,32 @@ no restart needed.
 Extra search folders can be added with the `BLACKNODE_PACKAGE_PATH`
 environment variable (separated by the platform path separator).
 
+### Named package applications
+
+An extension package can publish a managed terminal application alongside its
+nodes and templates:
+
+```toml
+[applications.slam]
+module = "standalone_slam"
+callable = "main"
+component = "spatial-processing"
+description = "Run local Warp SLAM and its packaged viewer."
+```
+
+The module is resolved through the package's stable `blacknode.pkg` namespace.
+Its callable receives the remaining command-line arguments and returns an exit
+code. Operators can then run it by name:
+
+```bash
+blacknode run slam --device cuda:0
+```
+
+Application names must be unambiguous across installed packages. An application
+bound to a disabled component reports the component that must be enabled.
+Workflow files retain the existing `blacknode run workflow.json` behavior and
+reject application-only arguments.
+
 ## Updating packages
 
 For a managed device, open **Devices**, select the device, and press

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -2317,6 +2317,45 @@ def control_node(node_id: str, req: NodeControlReq):
             _session.graph._cache[(node_id, port)] = value
         _session.graph._dirty.discard(node_id)
         return {"ok": True, "node_id": node_id, "outputs": outputs}
+    if meta.get("type") in {"Viewer", "SLAM"}:
+        action = str(req.action or "").strip().lower()
+        if action not in {"status", "clear", "pause", "resume", "stop"}:
+            raise HTTPException(400, "Viewer and SLAM direct controls support status, clear, pause, resume, or stop")
+        params = dict(meta.get("params") or {})
+        if meta.get("type") == "Viewer":
+            runtime_id = str(params.get("viewer_id") or "viewer").strip() or "viewer"
+            function_name = {
+                "status": "viewer_status",
+                "clear": "clear_viewer",
+                "pause": "pause_viewer",
+                "resume": "resume_viewer",
+                "stop": "stop_viewer",
+            }[action]
+            control_fn = _runtime_callable("viewer", _RUNTIME_MODULES["viewer"], function_name)
+            if control_fn is None:
+                raise HTTPException(503, "blacknode-cuda Viewer runtime is not loaded")
+            outputs = dict(control_fn(runtime_id))
+        else:
+            runtime_id = str(params.get("slam_id") or "slam").strip() or "slam"
+            function_name = {
+                "status": "slam_status",
+                "clear": "clear_slam",
+                "pause": "set_mapping",
+                "resume": "set_mapping",
+                "stop": "stop_slam",
+            }[action]
+            control_fn = _runtime_callable("slam", _RUNTIME_MODULES["slam"], function_name)
+            if control_fn is None:
+                raise HTTPException(503, "blacknode-cuda SLAM runtime is not loaded")
+            outputs = dict(
+                control_fn(runtime_id)
+                if action in {"status", "clear", "stop"}
+                else control_fn(runtime_id, action == "resume")
+            )
+        for port, value in outputs.items():
+            _session.graph._cache[(node_id, port)] = value
+        _session.graph._dirty.discard(node_id)
+        return {"ok": True, "node_id": node_id, "outputs": outputs}
     if meta.get("type") == "Robot":
         if req.action != "ping":
             raise HTTPException(400, "Robot supports the ping control")

--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -1221,9 +1221,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -1260,9 +1260,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -1280,7 +1280,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/editor/package.json
+++ b/editor/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:slam-viewer": "tsc && vite build --config vite.standalone-slam.config.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -207,6 +207,7 @@ export default function App() {
   const [exportingTarget, setExportingTarget] = useState('')
   const [importingFile, setImportingFile] = useState(false)
   const [runtimeStopPending, setRuntimeStopPending] = useState(false)
+  const [activeRunMode, setActiveRunMode] = useState<'once' | 'live' | null>(null)
   const [refreshingCanvas, setRefreshingCanvas] = useState(false)
   const [openingUsd, setOpeningUsd] = useState(false)
   const [usdPickerInitialPath, setUsdPickerInitialPath] = useState<string | null>(null)
@@ -1430,11 +1431,17 @@ export default function App() {
         },
       }))
     }
-    await cookNode(targets[0].id, targets[0].port, targets, effectiveMode)
+    setActiveRunMode(effectiveMode)
+    try {
+      await cookNode(targets[0].id, targets[0].port, targets, effectiveMode)
+    } finally {
+      setActiveRunMode(current => current === effectiveMode ? null : current)
+    }
   }, [cookNode, edges, fitCurrentCanvas, nodes])
 
   const handleResetRun = useCallback(() => {
     stopCook()
+    setActiveRunMode(null)
     window.dispatchEvent(new CustomEvent('blacknode:notice', {
       detail: {
         kind: 'info',
@@ -1466,6 +1473,7 @@ export default function App() {
       }))
     } finally {
       setRuntimeStopPending(false)
+      setActiveRunMode(null)
     }
   }, [runtimeStopPending, stopRuntimeServices])
 
@@ -1541,14 +1549,15 @@ export default function App() {
   const waitingControllerCount = Math.max(0, controllerRunningCount - controllerCount - blockedControllerCount)
   const manualMoveCount = nodes.filter(n => n.data.type === 'ROS2ManualMove' && n.data.portResults?.live === true).length
   const liveDashboardCount = nodes.filter(n => n.data.type === 'ROS2MotionDashboard' && n.data.portResults?.live === true).length
-  const liveOutputCount = nodes.filter(n => (
-    (n.data.type === 'Output' || n.data.type === 'OutputImage') && n.data.portResults?.live === true
+  const visualizerRunCount = nodes.filter(n => (
+    (n.data.type === 'Viewer' || n.data.type === 'SLAM')
+    && n.data.portResults?.running === true
   )).length
   const liveCapableCount = nodes.filter(n => n.data.live_capable).length
   const runOnceNodeCount = Math.max(0, nodes.length - liveCapableCount)
-  const activelyUpdatingCount = liveStreamCount + managedRunCount + simulationRunCount + controllerCount + manualMoveCount + liveDashboardCount + liveOutputCount
-  const lastRunNodeCount = Math.max(0, nodes.length - activelyUpdatingCount - blockedControllerCount - waitingControllerCount)
-  const runtimeActive = liveStreamCount > 0 || managedRunCount > 0 || simulationRunCount > 0 || controllerRunningCount > 0 || manualMoveCount > 0
+  const runtimeActive = liveStreamCount > 0 || managedRunCount > 0 || simulationRunCount > 0 || controllerRunningCount > 0 || manualMoveCount > 0 || liveDashboardCount > 0 || visualizerRunCount > 0
+  const liveRunActive = (cookActive && activeRunMode === 'live') || runtimeActive
+  const onceRunActive = cookActive && activeRunMode !== 'live'
   const visibleEdges = useMemo(() => {
     const nodesById = new Map(nodes.map(node => [node.id, node]))
     return edges.map(edge => {
@@ -1693,41 +1702,28 @@ export default function App() {
               <span className="bn-topbar-group-label">Run</span>
               <button
                 className="bn-top-button bn-top-run-button"
-                onClick={() => (cookActive ? stopCook() : void handleRunGraph('once'))}
-                disabled={!serverOk || (!cookActive && nodes.length === 0)}
-                title={cookActive ? 'Stop the current evaluation' : 'Evaluate the graph once. Live-capable nodes return one snapshot and do not keep streaming.'}
+                onClick={() => (onceRunActive ? stopCook() : void handleRunGraph('once'))}
+                disabled={!serverOk || liveRunActive || (!onceRunActive && nodes.length === 0)}
+                title={onceRunActive ? 'Stop the current one-time evaluation' : 'Evaluate the graph once. Live-capable nodes return one snapshot and do not keep streaming.'}
               >
-                {cookActive ? '■ Stop run' : '▶ Run once'}
+                {onceRunActive ? '■ Stop once' : '▶ Run once'}
               </button>
 
               <button
-                className="bn-top-button bn-top-run-button"
-                onClick={() => void handleRunGraph('live')}
-                disabled={!serverOk || cookActive || nodes.length === 0}
-                title={liveCapableCount > 0
+                className={`bn-top-button bn-top-run-button bn-top-live-button${liveRunActive ? ' is-stop-live' : ' is-start-live'}`}
+                onClick={() => (liveRunActive ? void handleStopRuntime() : void handleRunGraph('live'))}
+                disabled={!serverOk || runtimeStopPending || onceRunActive || (!liveRunActive && nodes.length === 0)}
+                title={liveRunActive
+                  ? 'Stop the live graph and its managed runtime services.'
+                  : liveCapableCount > 0
                   ? `Start ${liveCapableCount} live-capable node${liveCapableCount === 1 ? '' : 's'}; evaluate the other ${runOnceNodeCount} node${runOnceNodeCount === 1 ? '' : 's'} once.`
                   : 'No live-capable nodes are present; this will run the graph once.'}
               >
-                ● Go live
+                {runtimeStopPending ? 'Stopping live…' : liveRunActive ? '■ Stop live' : '● Go live'}
               </button>
 
-              {runtimeActive && (
-                <button
-                  className="bn-top-button bn-top-streaming-button"
-                  onClick={() => void handleStopRuntime()}
-                  disabled={!serverOk || runtimeStopPending}
-                  title={`Graph is mixed: ${liveCapableCount} live-capable node${liveCapableCount === 1 ? '' : 's'} and ${runOnceNodeCount} run-once node${runOnceNodeCount === 1 ? '' : 's'}. Stop active streams and ROS 2 processes.`}
-                >
-                  <span className="bn-top-live-dot" />
-                  <span>{runtimeStopPending
-                    ? 'Stopping...'
-                    : `LIVE · ${activelyUpdatingCount} updating${blockedControllerCount ? ` · ${blockedControllerCount} blocked` : ''}${waitingControllerCount ? ` · ${waitingControllerCount} waiting` : ''} · ${lastRunNodeCount} last-run`}</span>
-                  <span className="bn-top-streaming-stop">Stop</span>
-                </button>
-              )}
-
               <button
-                className="bn-top-button"
+                className="bn-top-button bn-top-reset-button"
                 onClick={handleResetRun}
                 title="Stop active work and clear any stuck running state"
               >
@@ -2604,12 +2600,11 @@ export default function App() {
             selectNode(node.id)
             setNodeMenu({ x: e.clientX, y: e.clientY, nodeId: node.id })
           }}
-          // Wheel zoom is a canvas invariant, including while the pointer is
-          // over a node. Use a deliberately unused suppression class so a
-          // custom node cannot accidentally reintroduce React Flow's default
-          // `nowheel` zoom dead zone.
+          // Only dedicated embedded viewers capture the wheel for their own
+          // camera. Everywhere else—including other nodes—the wheel continues
+          // to zoom the React Flow graph.
           zoomOnScroll={true}
-          noWheelClassName="bn-canvas-wheel-suppression-disabled"
+          noWheelClassName="bn-viewer-wheel-capture"
           minZoom={0.05}
           fitView
           fitViewOptions={{ padding: 0.24, maxZoom: 1 }}

--- a/editor/src/StandaloneSlam.tsx
+++ b/editor/src/StandaloneSlam.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState, type CSSProperties } from 'react'
+import PointCloudViewer from './components/PointCloudViewer'
+
+interface SlamState {
+  running?: boolean
+  live?: boolean
+  scene?: unknown
+  status?: { state?: string; error?: string }
+  report?: string
+}
+
+type ControlAction = 'start' | 'clear' | 'pause' | 'resume' | 'stop'
+
+function actionStyle(kind: 'start' | 'stop', disabled: boolean): CSSProperties {
+  const active = kind === 'start' ? 'var(--ok)' : 'var(--err)'
+  return {
+    height: 29,
+    padding: '0 11px',
+    border: `1px solid color-mix(in srgb, ${active} 72%, transparent)`,
+    borderRadius: 6,
+    background: `color-mix(in srgb, ${active} 20%, var(--panel))`,
+    color: active,
+    fontFamily: 'var(--font-mono)',
+    fontSize: 11,
+    fontWeight: 700,
+    cursor: disabled ? 'default' : 'pointer',
+    opacity: disabled ? 0.45 : 1,
+  }
+}
+
+export default function StandaloneSlam() {
+  const [state, setState] = useState<SlamState>({})
+  const [pending, setPending] = useState<ControlAction | ''>('')
+  const [connectionError, setConnectionError] = useState('')
+
+  const refresh = useCallback(async () => {
+    try {
+      const response = await fetch('/api/state', { cache: 'no-store' })
+      if (!response.ok) throw new Error(`viewer state returned HTTP ${response.status}`)
+      setState(await response.json() as SlamState)
+      setConnectionError('')
+    } catch (error) {
+      setConnectionError(error instanceof Error ? error.message : String(error))
+    }
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = 'dark'
+    void refresh()
+    const timer = window.setInterval(() => { void refresh() }, 100)
+    return () => window.clearInterval(timer)
+  }, [refresh])
+
+  const control = useCallback(async (action: ControlAction) => {
+    if (pending) return
+    setPending(action)
+    try {
+      const response = await fetch(`/api/control/${action}`, { method: 'POST' })
+      if (!response.ok) throw new Error(`control returned HTTP ${response.status}`)
+      setState(await response.json() as SlamState)
+      setConnectionError('')
+    } catch (error) {
+      setConnectionError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setPending('')
+    }
+  }, [pending])
+
+  const scene = (state.scene && typeof state.scene === 'object' ? state.scene : {}) as {
+    history_paused?: boolean
+  }
+  const statusState = connectionError ? 'disconnected' : String(state.status?.state || (state.running ? 'waiting' : 'stopped'))
+  const statusColor = connectionError || statusState === 'error'
+    ? 'var(--err)'
+    : state.live
+      ? 'var(--ok)'
+      : 'var(--warn)'
+
+  return (
+    <main className="bn-standalone-slam">
+      <header className="bn-standalone-slam__header">
+        <div className="bn-standalone-slam__brand">
+          <img src="/blacknode-logo-dark.png" alt="Blacknode" />
+          <div>
+            <strong>Warp SLAM</strong>
+            <span>Jetson standalone viewer</span>
+          </div>
+        </div>
+        <div className="bn-standalone-slam__status" style={{ color: statusColor }}>
+          <i style={{ background: statusColor }} />
+          {statusState.toUpperCase()}
+          <span>{connectionError || state.status?.error || state.report || ''}</span>
+        </div>
+        <div className="bn-standalone-slam__actions">
+          <button
+            type="button"
+            disabled={Boolean(pending) || Boolean(state.running)}
+            style={actionStyle('start', Boolean(pending) || Boolean(state.running))}
+            onClick={() => { void control('start') }}
+          >
+            {pending === 'start' ? 'Starting…' : 'Go live'}
+          </button>
+          <button
+            type="button"
+            disabled={Boolean(pending) || !state.running}
+            style={actionStyle('stop', Boolean(pending) || !state.running)}
+            onClick={() => { void control('stop') }}
+          >
+            {pending === 'stop' ? 'Stopping…' : 'Stop live'}
+          </button>
+        </div>
+      </header>
+      <section className="bn-standalone-slam__viewer">
+        <PointCloudViewer
+          scene={state.scene}
+          onClear={() => { void control('clear') }}
+          onAccumulationToggle={() => { void control(scene.history_paused ? 'resume' : 'pause') }}
+          clearPending={pending === 'clear'}
+          accumulationPending={pending === 'pause' || pending === 'resume'}
+        />
+      </section>
+    </main>
+  )
+}

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -348,6 +348,55 @@ function PortRow({
   )
 }
 
+function ViewerInputStrip({
+  nodeId,
+  ports,
+  inputTypes,
+  connectedPorts,
+}: {
+  nodeId: string
+  ports: string[]
+  inputTypes: Record<string, string>
+  connectedPorts: Set<string>
+}) {
+  return (
+    <div className="bn-viewer-input-strip" aria-label="Viewer input connections">
+      {ports.map(port => {
+        const type = inputTypes[port] ?? 'Any'
+        const color = portColor(type)
+        const visualColor = portVisualColor(type)
+        const connected = connectedPorts.has(port)
+        const label = portDisplayName(port, 'input')
+        return (
+          <div
+            key={port}
+            className={`bn-viewer-input-anchor${connected ? ' is-connected' : ''}`}
+            title={`${label} · ${type}`}
+          >
+            <Handle
+              type="target"
+              position={Position.Left}
+              id={port}
+              aria-label={`${label} input, ${type}`}
+              onMouseEnter={() => window.dispatchEvent(new CustomEvent('blacknode:port-hover', {
+                detail: { nodeId, port, dir: 'input' },
+              }))}
+              onMouseLeave={() => window.dispatchEvent(new CustomEvent('blacknode:port-hover', {
+                detail: null,
+              }))}
+              style={{
+                background: color,
+                borderColor: color,
+                boxShadow: connected ? `0 0 8px ${visualColor}` : undefined,
+              }}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
 const isImageSrc = (v: unknown): v is string =>
   typeof v === 'string' && (v.startsWith('data:image/') || /^https?:\/\//i.test(v))
 
@@ -982,6 +1031,9 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     viewerScene && typeof viewerScene === 'object'
     && (viewerScene as Record<string, unknown>).history_paused === true,
   )
+  const connectedViewerInputs = new Set(
+    visibleInputs.filter(port => edges.some(edge => edge.target === id && edge.targetHandle === port)),
+  )
 
   // Ordered by urgency: a running process outranks a waiting one, which
   // outranks a passive "this result is stale" note.
@@ -1299,14 +1351,8 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const onStopViewer = async () => {
     setViewerStopPending(true)
     try {
-      await updateParam(id, 'action', 'stop')
-      await cookNode(id, 'report')
+      await controlNode(id, 'stop')
     } finally {
-      try {
-        await updateParam(id, 'action', 'status')
-      } catch {
-        // The Viewer is already stopped; leave the visual control responsive.
-      }
       setViewerStopPending(false)
     }
   }
@@ -1314,14 +1360,8 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const onClearViewer = async () => {
     setViewerClearPending(true)
     try {
-      await updateParam(id, 'action', 'clear')
-      await cookNode(id, 'report')
+      await controlNode(id, 'clear')
     } finally {
-      try {
-        await updateParam(id, 'action', 'status')
-      } catch {
-        // Keep the history control responsive if the node was removed mid-action.
-      }
       setViewerClearPending(false)
     }
   }
@@ -1329,14 +1369,8 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const onToggleViewerAccumulation = async () => {
     setViewerAccumulationPending(true)
     try {
-      await updateParam(id, 'action', viewerHistoryPaused ? 'resume' : 'pause')
-      await cookNode(id, 'report')
+      await controlNode(id, viewerHistoryPaused ? 'resume' : 'pause')
     } finally {
-      try {
-        await updateParam(id, 'action', 'status')
-      } catch {
-        // Keep the accumulation control responsive if the node was removed.
-      }
       setViewerAccumulationPending(false)
     }
   }
@@ -1554,8 +1588,19 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     if (!el) return
     const observer = new ResizeObserver(() => updateNodeInternals(id))
     observer.observe(el)
-    return () => observer.disconnect()
-  }, [id, updateNodeInternals])
+    const viewerRegion = isViewer
+      ? el.querySelector('[data-bn-viewer-canvas-region]')
+      : null
+    if (viewerRegion) observer.observe(viewerRegion)
+    // Measure once after the nested canvas and its handles have completed
+    // layout. This makes the wire endpoint use the visible knob center on the
+    // first frame, not the viewer's earlier placeholder geometry.
+    const frame = window.requestAnimationFrame(() => updateNodeInternals(id))
+    return () => {
+      window.cancelAnimationFrame(frame)
+      observer.disconnect()
+    }
+  }, [id, isViewer, updateNodeInternals])
 
   useEffect(() => {
     if (!isACTTraining || !trainingRunning) return
@@ -1586,15 +1631,15 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       style={{
         width: '100%',
         height: '100%',
-        minWidth: 160,
-        minHeight: 60,
+        minWidth: isViewer ? 360 : 160,
+        minHeight: isViewer ? 300 : 60,
         display: 'flex',
         flexDirection: 'column',
       }}
     >
       <NodeResizer
-        minWidth={160}
-        minHeight={60}
+        minWidth={isViewer ? 360 : 160}
+        minHeight={isViewer ? 300 : 60}
         isVisible={selected}
         lineStyle={{ borderColor: color }}
         handleStyle={{ background: color, borderColor: color, width: 8, height: 8, borderRadius: 2 }}
@@ -1741,6 +1786,20 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
         </button>
       </div>
 
+      {isViewer && visibleOutputs.length > 0 && (
+        <div className="bn-viewer-hidden-output-anchors" aria-hidden="true">
+          {visibleOutputs.map(out => (
+            <Handle
+              key={out}
+              type="source"
+              position={Position.Right}
+              id={out}
+              style={{ opacity: 0, pointerEvents: 'none' }}
+            />
+          ))}
+        </div>
+      )}
+
       {hasVisualHoverPreview && hoverPreviewImage && (
         <div className="bn-node-hover-preview" role="status" aria-label={`${data.type} preview`}>
           <div className="bn-node-hover-preview-head">
@@ -1762,7 +1821,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
         </div>
       )}
 
-      {nodeStats.length > 0 && (
+      {!isViewer && nodeStats.length > 0 && (
         <div className="bn-node-stat-strip" aria-label={`${data.type} runtime statistics`}>
           {nodeStats.slice(0, 4).map(stat => (
             <span key={stat.label} className={stat.tone ? `is-${stat.tone}` : undefined}>
@@ -2468,16 +2527,6 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
 
       {isDatasetBrowser && <DatasetBrowserPanel id={id} data={data} />}
 
-      {isViewer && (
-        <PointCloudViewer
-          scene={data.portResults?.scene}
-          onClear={() => { void onClearViewer() }}
-          onAccumulationToggle={() => { void onToggleViewerAccumulation() }}
-          clearPending={viewerClearPending}
-          accumulationPending={viewerAccumulationPending}
-        />
-      )}
-
       {isDatasetCreate && (
         <div style={{
           margin: '7px 9px 3px', padding: 8, borderRadius: 7,
@@ -2603,11 +2652,31 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       )}
       </div>
 
+      {/* The viewer is a direct flex child so React Flow's resized node height
+          reaches the canvas instead of being consumed by the parameter area. */}
+      {isViewer && (
+        <PointCloudViewer
+          scene={data.portResults?.scene}
+          inputRail={(
+            <ViewerInputStrip
+              nodeId={id}
+              ports={visibleInputs}
+              inputTypes={Object.fromEntries(visibleInputs.map(port => [port, effectivePortType(port, 'input')]))}
+              connectedPorts={connectedViewerInputs}
+            />
+          )}
+          onClear={() => { void onClearViewer() }}
+          onAccumulationToggle={() => { void onToggleViewerAccumulation() }}
+          clearPending={viewerClearPending}
+          accumulationPending={viewerAccumulationPending}
+        />
+      )}
+
       {/* ports */}
       <div className="bn-node-ports" style={{
-        flex: showImageResult ? '0 0 auto' : 1,
+        flex: (isViewer || showImageResult) ? '0 0 auto' : 1,
         padding: '6px 0',
-        display: 'flex',
+        display: isViewer ? 'none' : 'flex',
         flexDirection: 'column',
         minHeight: 0,
       }}>

--- a/editor/src/components/PointCloudViewer.tsx
+++ b/editor/src/components/PointCloudViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 
 interface ViewerScene {
   kind?: string
@@ -10,12 +10,43 @@ interface ViewerScene {
   colors?: unknown
   current_points?: unknown
   current_colors?: unknown
+  floor_points?: unknown
+  floor_colors?: unknown
+  occupied_points?: unknown
+  occupied_colors?: unknown
   point_count?: number
   current_point_count?: number
   accumulated_scan_count?: number
   display_count?: number
   device?: string
   kernel_ms?: number
+  floor_point_count?: number
+  floor_display_count?: number
+  occupied_point_count?: number
+  occupied_display_count?: number
+  map_render_mode?: string
+  occupancy?: {
+    backend?: string
+    device?: string
+    kernel_ms?: number
+    encode_ms?: number
+    rays?: number
+    grid_cells?: number
+    grid_width?: number
+    grid_height?: number
+    free_cells?: number
+    display_cells?: number
+    occupied_cells?: number
+    occupied_display_cells?: number
+    display_limited?: boolean
+    resolution_m?: number
+    world_min_x?: number
+    world_min_y?: number
+    fixed_origin?: boolean
+    encoding?: string
+    data?: string
+    revision?: number
+  }
   sensor?: { x_m?: number; y_m?: number; yaw_rad?: number }
   robot?: { length_m?: number; width_m?: number; height_m?: number }
   scan?: {
@@ -30,14 +61,21 @@ interface ViewerScene {
   history_paused?: boolean
   pose_source?: string
   registration?: { tf_path?: string[] }
-  trajectory?: unknown
   loop_closures?: unknown
   slam?: {
     match_score?: number
+    tracking_accepted?: boolean
+    stationary_odometry_locked?: boolean
+    scan_motion_override?: boolean
+    tracking_correction_limited?: boolean
+    map_update_rejected?: boolean
+    deskewed?: boolean
     keyframes?: number
     constraints?: number
     loop_closures?: number
     map_resolution_m?: number
+    matching_backend?: string
+    matching_kernel_ms?: number
   }
   animation?: {
     enabled?: boolean
@@ -57,19 +95,41 @@ interface CameraState {
   pitch: number
 }
 
+interface GridFrame {
+  x: number
+  y: number
+  yaw: number
+}
+
 interface Viewport {
   width: number
   height: number
   ratio: number
 }
 
+interface OccupancyTextureData {
+  width: number
+  height: number
+  states: Uint8Array
+}
+
+const TOP_VIEW_YAW = Math.PI / 2
+
 const DEFAULT_CAMERA: CameraState = {
   zoom: 1,
   panX: 0,
-  panY: 22,
-  yaw: -0.35,
-  pitch: 0.62,
+  panY: 0,
+  yaw: TOP_VIEW_YAW,
+  pitch: 0,
 }
+
+const ROBOT_LOGO_ROTATION_RAD = -Math.PI / 2
+const ROBOT_LOGO_SOURCE = { x: 78, y: 48, width: 352, height: 415 } as const
+const ROBOT_LOGO_FOOTPRINT_SCALE = 0.58
+const ROBOT_FOOTPRINT_VISUAL_SCALE = 0.88
+const ROBOT_FIT_RADIUS_MULTIPLIER = 1.65
+const MIN_CAMERA_ZOOM = 0.1
+const MAX_CAMERA_ZOOM = 120
 
 function numericRows(value: unknown): number[][] {
   if (!Array.isArray(value)) return []
@@ -99,6 +159,124 @@ function shader(gl: WebGLRenderingContext, kind: number, source: string): WebGLS
     throw new Error(detail)
   }
   return result
+}
+
+function decodeOccupancyTexture(
+  encoding: unknown,
+  data: unknown,
+  widthValue: unknown,
+  heightValue: unknown,
+): OccupancyTextureData | null {
+  if (encoding !== 'u2-base64' || typeof data !== 'string' || !data) return null
+  const width = Math.max(0, Math.round(finite(widthValue)))
+  const height = Math.max(0, Math.round(finite(heightValue)))
+  const cellCount = width * height
+  if (!cellCount) return null
+  try {
+    const packed = window.atob(data)
+    if (packed.length < Math.ceil(cellCount / 4)) return null
+    const states = new Uint8Array(cellCount)
+    for (let index = 0; index < cellCount; index += 1) {
+      const value = (packed.charCodeAt(index >> 2) >> ((index & 3) * 2)) & 3
+      states[index] = value === 1 ? 127 : value === 2 ? 255 : 0
+    }
+    return { width, height, states }
+  } catch {
+    return null
+  }
+}
+
+function drawOccupancyTexture(
+  gl: WebGLRenderingContext,
+  bounds: number[][],
+  textureData: OccupancyTextureData,
+  showFreeSpace: boolean,
+  viewport: Viewport,
+  camera: CameraState,
+  pixelsPerMeter: number,
+): () => void {
+  let vertex: WebGLShader | null = null
+  let fragment: WebGLShader | null = null
+  let program: WebGLProgram | null = null
+  const positionBuffer = gl.createBuffer()
+  const textureCoordinateBuffer = gl.createBuffer()
+  const texture = gl.createTexture()
+  try {
+    vertex = shader(gl, gl.VERTEX_SHADER, `
+      attribute vec2 a_position;
+      attribute vec2 a_texcoord;
+      varying vec2 v_texcoord;
+      void main() {
+        gl_Position = vec4(a_position, 0.0, 1.0);
+        v_texcoord = a_texcoord;
+      }
+    `)
+    fragment = shader(gl, gl.FRAGMENT_SHADER, `
+      precision mediump float;
+      uniform sampler2D u_grid;
+      uniform float u_show_free;
+      varying vec2 v_texcoord;
+      void main() {
+        float state = texture2D(u_grid, v_texcoord).r;
+        if (state < 0.25 || (state < 0.75 && u_show_free < 0.5)) discard;
+        vec3 color = state < 0.75
+          ? vec3(0.18, 0.68, 0.36)
+          : vec3(0.78, 0.88, 0.94);
+        gl_FragColor = vec4(color, 1.0);
+      }
+    `)
+    program = gl.createProgram()
+    if (!program || !positionBuffer || !textureCoordinateBuffer || !texture) throw new Error('occupancy texture resources unavailable')
+    gl.attachShader(program, vertex)
+    gl.attachShader(program, fragment)
+    gl.linkProgram(program)
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) throw new Error('occupancy texture program link failed')
+    gl.useProgram(program)
+    gl.uniform1f(gl.getUniformLocation(program, 'u_show_free'), showFreeSpace ? 1 : 0)
+
+    const positions = new Float32Array(bounds.length * 2)
+    bounds.forEach((point, index) => {
+      const [screenX, screenY] = worldToScreen(point[0], point[1], finite(point[2]), viewport, camera, pixelsPerMeter)
+      positions[index * 2] = (screenX / viewport.width) * 2 - 1
+      positions[index * 2 + 1] = 1 - (screenY / viewport.height) * 2
+    })
+    const textureCoordinates = new Float32Array([
+      0, 0, 1, 0, 1, 1,
+      0, 0, 1, 1, 0, 1,
+    ])
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer)
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW)
+    const positionLocation = gl.getAttribLocation(program, 'a_position')
+    gl.enableVertexAttribArray(positionLocation)
+    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0)
+    gl.bindBuffer(gl.ARRAY_BUFFER, textureCoordinateBuffer)
+    gl.bufferData(gl.ARRAY_BUFFER, textureCoordinates, gl.STATIC_DRAW)
+    const textureCoordinateLocation = gl.getAttribLocation(program, 'a_texcoord')
+    gl.enableVertexAttribArray(textureCoordinateLocation)
+    gl.vertexAttribPointer(textureCoordinateLocation, 2, gl.FLOAT, false, 0, 0)
+    gl.bindTexture(gl.TEXTURE_2D, texture)
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+    gl.texImage2D(
+      gl.TEXTURE_2D, 0, gl.LUMINANCE,
+      textureData.width, textureData.height, 0,
+      gl.LUMINANCE, gl.UNSIGNED_BYTE, textureData.states,
+    )
+    gl.drawArrays(gl.TRIANGLES, 0, bounds.length)
+  } catch {
+    // Keep the live point cloud usable if a browser cannot allocate the map texture.
+  }
+  return () => {
+    if (positionBuffer) gl.deleteBuffer(positionBuffer)
+    if (textureCoordinateBuffer) gl.deleteBuffer(textureCoordinateBuffer)
+    if (texture) gl.deleteTexture(texture)
+    if (program) gl.deleteProgram(program)
+    if (vertex) gl.deleteShader(vertex)
+    if (fragment) gl.deleteShader(fragment)
+  }
 }
 
 function worldToScreen(
@@ -133,6 +311,29 @@ function meterLabel(value: number): string {
   return `${Number(value.toFixed(2))}m`
 }
 
+function roundedPolygonPath(
+  context: CanvasRenderingContext2D,
+  points: number[][],
+  radius: number,
+): void {
+  if (points.length < 3) return
+  points.forEach((point, index) => {
+    const previous = points[(index - 1 + points.length) % points.length]
+    const next = points[(index + 1) % points.length]
+    const previousLength = Math.max(0.001, Math.hypot(previous[0] - point[0], previous[1] - point[1]))
+    const nextLength = Math.max(0.001, Math.hypot(next[0] - point[0], next[1] - point[1]))
+    const appliedRadius = Math.min(radius, previousLength * 0.46, nextLength * 0.46)
+    const startX = point[0] + (previous[0] - point[0]) / previousLength * appliedRadius
+    const startY = point[1] + (previous[1] - point[1]) / previousLength * appliedRadius
+    const endX = point[0] + (next[0] - point[0]) / nextLength * appliedRadius
+    const endY = point[1] + (next[1] - point[1]) / nextLength * appliedRadius
+    if (index === 0) context.moveTo(startX, startY)
+    else context.lineTo(startX, startY)
+    context.quadraticCurveTo(point[0], point[1], endX, endY)
+  })
+  context.closePath()
+}
+
 function controlStyle(active = false): React.CSSProperties {
   return {
     minWidth: 28,
@@ -150,19 +351,30 @@ function controlStyle(active = false): React.CSSProperties {
 
 export default function PointCloudViewer({
   scene,
+  inputRail,
   onClear,
   onAccumulationToggle,
   clearPending = false,
   accumulationPending = false,
 }: {
   scene: unknown
+  inputRail?: ReactNode
   onClear?: () => void
   onAccumulationToggle?: () => void
   clearPending?: boolean
   accumulationPending?: boolean
 }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const occupancyCanvasRef = useRef<HTMLCanvasElement | null>(null)
   const overlayRef = useRef<HTMLCanvasElement | null>(null)
+  const occupancyRasterRef = useRef<{
+    texture: OccupancyTextureData
+    showFreeSpace: boolean
+    sensorX: number
+    sensorY: number
+    gradientDistance: number
+    canvas: HTMLCanvasElement
+  } | null>(null)
   const dragRef = useRef<{
     x: number
     y: number
@@ -170,28 +382,65 @@ export default function PointCloudViewer({
     camera: CameraState
   } | null>(null)
   const [camera, setCamera] = useState<CameraState>(DEFAULT_CAMERA)
+  const [gridFrame, setGridFrame] = useState<GridFrame>({ x: 0, y: 0, yaw: 0 })
+  const [showAxes, setShowAxes] = useState(false)
+  const [showFreeSpace, setShowFreeSpace] = useState(true)
+  const robotLogoRef = useRef<HTMLImageElement | null>(null)
+  const [robotLogoReady, setRobotLogoReady] = useState(false)
+  const clearViewRadiusFloorRef = useRef(0)
+  const initialResetPendingRef = useRef(true)
   const [viewport, setViewport] = useState<Viewport>({ width: 1, height: 360, ratio: 1 })
   const parsed = (scene && typeof scene === 'object' ? scene : {}) as ViewerScene
   const points = useMemo(() => numericRows(parsed.points), [parsed.points])
   const colors = useMemo(() => numericRows(parsed.colors), [parsed.colors])
   const currentPoints = useMemo(() => numericRows(parsed.current_points), [parsed.current_points])
   const currentColors = useMemo(() => numericRows(parsed.current_colors), [parsed.current_colors])
-  const renderedPoints = useMemo(
-    () => [...points, ...currentPoints],
-    [currentPoints, points],
+  const floorPoints = useMemo(() => numericRows(parsed.floor_points), [parsed.floor_points])
+  const floorColors = useMemo(() => numericRows(parsed.floor_colors), [parsed.floor_colors])
+  const occupiedPoints = useMemo(() => numericRows(parsed.occupied_points), [parsed.occupied_points])
+  const occupiedColors = useMemo(() => numericRows(parsed.occupied_colors), [parsed.occupied_colors])
+  const visibleFloorPoints = useMemo(
+    () => showFreeSpace ? floorPoints : [],
+    [floorPoints, showFreeSpace],
   )
-  const trajectory = useMemo(() => numericRows(parsed.trajectory), [parsed.trajectory])
-  const loopClosures = useMemo(() => (
-    Array.isArray(parsed.loop_closures)
-      ? parsed.loop_closures.flatMap(value => {
-          if (!value || typeof value !== 'object') return []
-          const record = value as { from?: unknown; to?: unknown }
-          const from = numericRows([record.from])[0]
-          const to = numericRows([record.to])[0]
-          return from && to ? [[from, to] as [number[], number[]]] : []
-        })
-      : []
-  ), [parsed.loop_closures])
+  const renderedPoints = useMemo(
+    () => [...visibleFloorPoints, ...occupiedPoints, ...points, ...currentPoints],
+    [currentPoints, occupiedPoints, points, visibleFloorPoints],
+  )
+  const occupancyBackground = useMemo(() => {
+    if (parsed.occupancy?.fixed_origin !== true) return []
+    const width = Math.max(0, Math.round(finite(parsed.occupancy.grid_width)))
+    const height = Math.max(0, Math.round(finite(parsed.occupancy.grid_height)))
+    const resolution = Math.max(0, finite(parsed.occupancy.resolution_m))
+    const minimumX = Number(parsed.occupancy.world_min_x)
+    const minimumY = Number(parsed.occupancy.world_min_y)
+    if (!width || !height || !resolution || !Number.isFinite(minimumX) || !Number.isFinite(minimumY)) return []
+    const maximumX = minimumX + width * resolution
+    const maximumY = minimumY + height * resolution
+    return [
+      [minimumX, minimumY, -0.03], [maximumX, minimumY, -0.03], [maximumX, maximumY, -0.03],
+      [minimumX, minimumY, -0.03], [maximumX, maximumY, -0.03], [minimumX, maximumY, -0.03],
+    ]
+  }, [
+    parsed.occupancy?.fixed_origin,
+    parsed.occupancy?.grid_height,
+    parsed.occupancy?.grid_width,
+    parsed.occupancy?.resolution_m,
+    parsed.occupancy?.world_min_x,
+    parsed.occupancy?.world_min_y,
+  ])
+  const occupancyTexture = useMemo(() => decodeOccupancyTexture(
+    parsed.occupancy?.encoding,
+    parsed.occupancy?.data,
+    parsed.occupancy?.grid_width,
+    parsed.occupancy?.grid_height,
+  ), [
+    parsed.occupancy?.data,
+    parsed.occupancy?.encoding,
+    parsed.occupancy?.grid_height,
+    parsed.occupancy?.grid_width,
+    parsed.occupancy?.revision,
+  ])
   const [animationClock, setAnimationClock] = useState(0)
   const scanStartedRef = useRef(0)
   const sensor = useMemo(() => ({
@@ -203,8 +452,12 @@ export default function PointCloudViewer({
   const animationEnabled = parsed.animation?.enabled !== false
   const hasCurrentPoints = currentPoints.length > 0
   const pulseHz = clamp(finite(parsed.animation?.pulse_hz, 1), 0.05, 30)
+  const scanPeriodMs = 1000 / pulseHz
+  const replayDurationMs = Math.max(scanPeriodMs, 700)
   const scanAngleMinimum = finite(parsed.scan?.angle_min_rad, -Math.PI)
   const scanAngleMaximum = finite(parsed.scan?.angle_max_rad, Math.PI)
+  const scanAngleIncrement = finite(parsed.scan?.angle_increment_rad)
+  const clockwiseScan = scanAngleIncrement < 0
   const scanCoverageRad = clamp(Math.abs(scanAngleMaximum - scanAngleMinimum), 0, Math.PI * 2)
   const scanCoverageDeg = scanCoverageRad * 180 / Math.PI
   const fullCircleScan = scanCoverageRad >= Math.PI * 2 - Math.PI / 180
@@ -212,27 +465,43 @@ export default function PointCloudViewer({
     fullCircleScan ? 0 : (scanAngleMinimum + scanAngleMaximum) / 2
   )
   const animationPhase = animationEnabled
-    ? ((animationClock - scanStartedRef.current) / 1000 * pulseHz + 1) % 1
+    ? clamp((animationClock - scanStartedRef.current) / replayDurationMs, 0, 1)
     : 1
+
+  useEffect(() => {
+    let cancelled = false
+    const logo = new Image()
+    logo.onload = () => {
+      if (cancelled) return
+      robotLogoRef.current = logo
+      setRobotLogoReady(true)
+    }
+    logo.src = '/blacknode-logo-dark.png'
+    return () => {
+      cancelled = true
+      robotLogoRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     if (!animationEnabled || !hasCurrentPoints) return
     let frame = 0
-    let previous = 0
-    scanStartedRef.current = performance.now()
-    setAnimationClock(scanStartedRef.current)
+    const now = performance.now()
+    const replayInProgress = scanStartedRef.current > 0
+      && now - scanStartedRef.current < replayDurationMs
+    if (!replayInProgress) scanStartedRef.current = now
+    setAnimationClock(now)
     const animate = (now: number) => {
-      if (now - previous >= 30) {
-        previous = now
-        setAnimationClock(now)
+      setAnimationClock(now)
+      if (now - scanStartedRef.current < replayDurationMs) {
+        frame = window.requestAnimationFrame(animate)
       }
-      frame = window.requestAnimationFrame(animate)
     }
     frame = window.requestAnimationFrame(animate)
     return () => window.cancelAnimationFrame(frame)
-  }, [animationEnabled, hasCurrentPoints])
+  }, [animationEnabled, hasCurrentPoints, parsed.sequence, replayDurationMs])
 
-  const viewRadius = useMemo(() => {
+  const automaticViewRadius = useMemo(() => {
     const pointRadius = renderedPoints.reduce(
       (largest, point) => Math.max(largest, Math.hypot(point[0], point[1])),
       0,
@@ -240,12 +509,58 @@ export default function PointCloudViewer({
     const configured = finite(parsed.view?.radius_m)
     return clamp(Math.max(configured, pointRadius * 1.08, Math.hypot(sensor.x, sensor.y) + 0.5), 0.5, 10_000)
   }, [parsed.view?.radius_m, renderedPoints, sensor.x, sensor.y])
-
+  // Clear changes map contents, not the camera. Capture the pre-clear metric
+  // radius while the request is pending and retain it after the empty scene is
+  // applied so removing points cannot briefly enlarge the robot on screen.
+  if (clearPending) {
+    clearViewRadiusFloorRef.current = Math.max(
+      clearViewRadiusFloorRef.current,
+      automaticViewRadius,
+    )
+  }
+  const viewRadius = Math.max(automaticViewRadius, clearViewRadiusFloorRef.current)
   const basePixelsPerMeter = Math.max(
     0.001,
     Math.min(viewport.width, viewport.height) / (viewRadius * 2.15),
   )
   const pixelsPerMeter = basePixelsPerMeter * camera.zoom
+  const resetCamera = () => {
+    clearViewRadiusFloorRef.current = 0
+    const robotLength = clamp(finite(parsed.robot?.length_m, 0.25), 0.02, 5)
+    const robotWidth = clamp(finite(parsed.robot?.width_m, 0.22), 0.02, 5)
+    const focusRadius = Math.max(0.35, Math.max(robotLength, robotWidth) * ROBOT_FIT_RADIUS_MULTIPLIER)
+    const viewportSpan = Math.max(1, Math.min(viewport.width, viewport.height))
+    const focusedPixelsPerMeter = viewportSpan / (focusRadius * 2.15)
+    const resetBasePixelsPerMeter = Math.max(
+      0.001,
+      viewportSpan / (automaticViewRadius * 2.15),
+    )
+    const zoom = clamp(
+      focusedPixelsPerMeter / resetBasePixelsPerMeter,
+      MIN_CAMERA_ZOOM,
+      MAX_CAMERA_ZOOM,
+    )
+    const appliedPixelsPerMeter = resetBasePixelsPerMeter * zoom
+    const resetYaw = TOP_VIEW_YAW - robotHeadingYaw
+    const resetYawCosine = Math.cos(resetYaw)
+    const resetYawSine = Math.sin(resetYaw)
+    const focusedSensorX = resetYawCosine * sensor.x - resetYawSine * sensor.y
+    const focusedSensorY = resetYawSine * sensor.x + resetYawCosine * sensor.y
+    setGridFrame({ x: sensor.x, y: sensor.y, yaw: robotHeadingYaw })
+    setCamera({
+      zoom,
+      yaw: resetYaw,
+      pitch: 0,
+      panX: -focusedSensorX * appliedPixelsPerMeter,
+      panY: focusedSensorY * appliedPixelsPerMeter,
+    })
+  }
+
+  useEffect(() => {
+    if (!initialResetPendingRef.current || !scene || viewport.width <= 1 || viewport.height <= 1) return
+    initialResetPendingRef.current = false
+    resetCamera()
+  }, [scene, viewport.height, viewport.width])
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -267,18 +582,113 @@ export default function PointCloudViewer({
   }, [])
 
   useEffect(() => {
+    const canvas = occupancyCanvasRef.current
+    if (!canvas) return
+    const bufferWidth = Math.max(1, Math.round(viewport.width * viewport.ratio))
+    const bufferHeight = Math.max(1, Math.round(viewport.height * viewport.ratio))
+    if (canvas.width !== bufferWidth) canvas.width = bufferWidth
+    if (canvas.height !== bufferHeight) canvas.height = bufferHeight
+    const context = canvas.getContext('2d')
+    if (!context) return
+    context.setTransform(1, 0, 0, 1, 0, 0)
+    context.clearRect(0, 0, bufferWidth, bufferHeight)
+    if (!occupancyTexture || occupancyBackground.length !== 6) return
+
+    const gradientDistance = clamp(
+      Math.max(viewport.width, viewport.height) / Math.max(1, pixelsPerMeter) * 0.55,
+      0.5,
+      Math.max(0.5, finite(parsed.view?.radius_m, viewRadius)),
+    )
+    const worldMinimumX = occupancyBackground[0][0]
+    const worldMinimumY = occupancyBackground[0][1]
+    const worldWidth = occupancyBackground[1][0] - worldMinimumX
+    const worldHeight = occupancyBackground[5][1] - worldMinimumY
+    let raster = occupancyRasterRef.current
+    if (
+      raster?.texture !== occupancyTexture
+      || raster.showFreeSpace !== showFreeSpace
+      || raster.sensorX !== sensor.x
+      || raster.sensorY !== sensor.y
+      || raster.gradientDistance !== gradientDistance
+    ) {
+      const rasterCanvas = document.createElement('canvas')
+      rasterCanvas.width = occupancyTexture.width
+      rasterCanvas.height = occupancyTexture.height
+      const rasterContext = rasterCanvas.getContext('2d')
+      if (!rasterContext) return
+      const image = rasterContext.createImageData(occupancyTexture.width, occupancyTexture.height)
+      occupancyTexture.states.forEach((state, index) => {
+        const offset = index * 4
+        if (state === 127 && showFreeSpace) {
+          const column = index % occupancyTexture.width
+          const row = Math.floor(index / occupancyTexture.width)
+          const worldX = worldMinimumX + (column + 0.5) * worldWidth / occupancyTexture.width
+          const worldY = worldMinimumY + (row + 0.5) * worldHeight / occupancyTexture.height
+          const distanceMix = clamp(Math.hypot(worldX - sensor.x, worldY - sensor.y) / gradientDistance, 0, 1)
+          const smoothMix = distanceMix * distanceMix * (3 - 2 * distanceMix)
+          image.data[offset] = Math.round(48 + (55 - 48) * smoothMix)
+          image.data[offset + 1] = Math.round(181 + (108 - 181) * smoothMix)
+          image.data[offset + 2] = Math.round(108 + (190 - 108) * smoothMix)
+          image.data[offset + 3] = Math.round(115 + (80 - 115) * smoothMix)
+        } else if (state === 255) {
+          image.data[offset] = 218
+          image.data[offset + 1] = 235
+          image.data[offset + 2] = 245
+          image.data[offset + 3] = 235
+        }
+      })
+      rasterContext.putImageData(image, 0, 0)
+      raster = {
+        texture: occupancyTexture,
+        showFreeSpace,
+        sensorX: sensor.x,
+        sensorY: sensor.y,
+        gradientDistance,
+        canvas: rasterCanvas,
+      }
+      occupancyRasterRef.current = raster
+    }
+
+    const origin = worldToScreen(
+      occupancyBackground[0][0], occupancyBackground[0][1], finite(occupancyBackground[0][2]),
+      viewport, camera, pixelsPerMeter,
+    )
+    const xEnd = worldToScreen(
+      occupancyBackground[1][0], occupancyBackground[1][1], finite(occupancyBackground[1][2]),
+      viewport, camera, pixelsPerMeter,
+    )
+    const yEnd = worldToScreen(
+      occupancyBackground[5][0], occupancyBackground[5][1], finite(occupancyBackground[5][2]),
+      viewport, camera, pixelsPerMeter,
+    )
+    context.imageSmoothingEnabled = false
+    context.globalCompositeOperation = 'screen'
+    context.setTransform(
+      viewport.ratio * (xEnd[0] - origin[0]) / occupancyTexture.width,
+      viewport.ratio * (xEnd[1] - origin[1]) / occupancyTexture.width,
+      viewport.ratio * (yEnd[0] - origin[0]) / occupancyTexture.height,
+      viewport.ratio * (yEnd[1] - origin[1]) / occupancyTexture.height,
+      viewport.ratio * origin[0],
+      viewport.ratio * origin[1],
+    )
+    context.drawImage(raster.canvas, 0, 0)
+    context.globalCompositeOperation = 'source-over'
+  }, [camera, occupancyBackground, occupancyTexture, parsed.view?.radius_m, pixelsPerMeter, sensor.x, sensor.y, showFreeSpace, viewRadius, viewport])
+
+  useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
-    const gl = canvas.getContext('webgl', { antialias: true, alpha: false })
+    const gl = canvas.getContext('webgl', { antialias: true, alpha: true })
     if (!gl) return
     const bufferWidth = Math.max(1, Math.round(viewport.width * viewport.ratio))
     const bufferHeight = Math.max(1, Math.round(viewport.height * viewport.ratio))
     if (canvas.width !== bufferWidth) canvas.width = bufferWidth
     if (canvas.height !== bufferHeight) canvas.height = bufferHeight
     gl.viewport(0, 0, bufferWidth, bufferHeight)
-    gl.clearColor(0.012, 0.022, 0.035, 1)
+    gl.clearColor(0, 0, 0, 0)
     gl.clear(gl.COLOR_BUFFER_BIT)
-    if (renderedPoints.length === 0) return
+    const vertexCount = renderedPoints.length
+    if (vertexCount === 0) return
 
     let vertex: WebGLShader | null = null
     let fragment: WebGLShader | null = null
@@ -287,19 +697,24 @@ export default function PointCloudViewer({
       vertex = shader(gl, gl.VERTEX_SHADER, `
         attribute vec2 a_position;
         attribute vec3 a_color;
+        attribute float a_size;
+        attribute float a_square;
         varying vec3 v_color;
+        varying float v_square;
         void main() {
           gl_Position = vec4(a_position, 0.0, 1.0);
-          gl_PointSize = ${Math.max(3.5, 4.5 * viewport.ratio).toFixed(2)};
+          gl_PointSize = a_size;
           v_color = a_color;
+          v_square = a_square;
         }
       `)
       fragment = shader(gl, gl.FRAGMENT_SHADER, `
         precision mediump float;
         varying vec3 v_color;
+        varying float v_square;
         void main() {
           vec2 centered = gl_PointCoord - vec2(0.5);
-          if (dot(centered, centered) > 0.25) discard;
+          if (v_square < 0.5 && dot(centered, centered) > 0.25) discard;
           gl_FragColor = vec4(v_color, 1.0);
         }
       `)
@@ -314,21 +729,41 @@ export default function PointCloudViewer({
       return
     }
 
-    const positions = new Float32Array(renderedPoints.length * 2)
-    const palette = new Float32Array(renderedPoints.length * 3)
+    const positions = new Float32Array(vertexCount * 2)
+    const palette = new Float32Array(vertexCount * 3)
+    const pointSizes = new Float32Array(vertexCount)
+    const squarePoints = new Float32Array(vertexCount)
+    const occupancyCellSize = Math.max(
+      1.25 * viewport.ratio,
+      finite(parsed.occupancy?.resolution_m, 0.05) * pixelsPerMeter * viewport.ratio * 1.45,
+    )
     renderedPoints.forEach((point, index) => {
+      const vertexIndex = index
       const [screenX, screenY] = worldToScreen(
         point[0], point[1], finite(point[2]), viewport, camera, pixelsPerMeter,
       )
-      positions[index * 2] = (screenX / viewport.width) * 2 - 1
-      positions[index * 2 + 1] = 1 - (screenY / viewport.height) * 2
-      const currentIndex = index - points.length
-      const color = currentIndex >= 0
-        ? currentColors[currentIndex] ?? [1.0, 0.82, 0.18]
-        : colors[index] ?? [0.0, 0.78, 1.0]
-      palette[index * 3] = clamp(color[0], 0, 1)
-      palette[index * 3 + 1] = clamp(color[1], 0, 1)
-      palette[index * 3 + 2] = clamp(color[2], 0, 1)
+      positions[vertexIndex * 2] = (screenX / viewport.width) * 2 - 1
+      positions[vertexIndex * 2 + 1] = 1 - (screenY / viewport.height) * 2
+      const occupancyPointCount = visibleFloorPoints.length + occupiedPoints.length
+      const mapIndex = index - occupancyPointCount
+      const currentIndex = mapIndex - points.length
+      const isFloor = index < visibleFloorPoints.length
+      const isOccupied = !isFloor && index < occupancyPointCount
+      const occupiedIndex = index - visibleFloorPoints.length
+      const color = isFloor
+        ? floorColors[index] ?? [0.18, 0.68, 0.36]
+        : isOccupied
+          ? occupiedColors[occupiedIndex] ?? [0.78, 0.88, 0.94]
+        : currentIndex >= 0
+          ? currentColors[currentIndex] ?? [0.0, 0.78, 1.0]
+          : colors[mapIndex] ?? [0.04, 0.36, 0.48]
+      palette[vertexIndex * 3] = clamp(color[0], 0, 1)
+      palette[vertexIndex * 3 + 1] = clamp(color[1], 0, 1)
+      palette[vertexIndex * 3 + 2] = clamp(color[2], 0, 1)
+      pointSizes[vertexIndex] = isFloor || isOccupied
+        ? occupancyCellSize
+        : Math.max(3.5, 4.5 * viewport.ratio)
+      squarePoints[vertexIndex] = isFloor || isOccupied ? 1 : 0
     })
 
     const positionBuffer = gl.createBuffer()
@@ -344,16 +779,32 @@ export default function PointCloudViewer({
     const colorLocation = gl.getAttribLocation(program, 'a_color')
     gl.enableVertexAttribArray(colorLocation)
     gl.vertexAttribPointer(colorLocation, 3, gl.FLOAT, false, 0, 0)
+
+    const sizeBuffer = gl.createBuffer()
+    gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuffer)
+    gl.bufferData(gl.ARRAY_BUFFER, pointSizes, gl.STATIC_DRAW)
+    const sizeLocation = gl.getAttribLocation(program, 'a_size')
+    gl.enableVertexAttribArray(sizeLocation)
+    gl.vertexAttribPointer(sizeLocation, 1, gl.FLOAT, false, 0, 0)
+
+    const squareBuffer = gl.createBuffer()
+    gl.bindBuffer(gl.ARRAY_BUFFER, squareBuffer)
+    gl.bufferData(gl.ARRAY_BUFFER, squarePoints, gl.STATIC_DRAW)
+    const squareLocation = gl.getAttribLocation(program, 'a_square')
+    gl.enableVertexAttribArray(squareLocation)
+    gl.vertexAttribPointer(squareLocation, 1, gl.FLOAT, false, 0, 0)
     gl.drawArrays(gl.POINTS, 0, renderedPoints.length)
 
     return () => {
       gl.deleteBuffer(positionBuffer)
       gl.deleteBuffer(colorBuffer)
+      gl.deleteBuffer(sizeBuffer)
+      gl.deleteBuffer(squareBuffer)
       if (program) gl.deleteProgram(program)
       if (vertex) gl.deleteShader(vertex)
       if (fragment) gl.deleteShader(fragment)
     }
-  }, [camera, colors, currentColors, pixelsPerMeter, points.length, renderedPoints, viewport])
+  }, [camera, colors, currentColors, floorColors, occupiedColors, occupiedPoints.length, parsed.occupancy?.resolution_m, pixelsPerMeter, points.length, renderedPoints, viewport, visibleFloorPoints.length])
 
   useEffect(() => {
     const overlay = overlayRef.current
@@ -369,6 +820,16 @@ export default function PointCloudViewer({
     context.lineWidth = 1
     context.font = '11px ui-monospace, SFMono-Regular, Menlo, monospace'
 
+    const gridHeadingCosine = Math.cos(gridFrame.yaw)
+    const gridHeadingSine = Math.sin(gridFrame.yaw)
+    const gridFrameToScreen = (forward: number, lateral: number, z: number) => worldToScreen(
+      gridFrame.x + gridHeadingCosine * forward - gridHeadingSine * lateral,
+      gridFrame.y + gridHeadingSine * forward + gridHeadingCosine * lateral,
+      z,
+      viewport,
+      camera,
+      pixelsPerMeter,
+    )
     const spacing = gridSpacing(pixelsPerMeter)
     const reach = Math.min(
       10_000,
@@ -379,10 +840,10 @@ export default function PointCloudViewer({
     context.beginPath()
     for (let index = -steps; index <= steps; index += 1) {
       const value = index * spacing
-      const [x1, y1] = worldToScreen(value, -reach, 0, viewport, camera, pixelsPerMeter)
-      const [x2, y2] = worldToScreen(value, reach, 0, viewport, camera, pixelsPerMeter)
-      const [x3, y3] = worldToScreen(-reach, value, 0, viewport, camera, pixelsPerMeter)
-      const [x4, y4] = worldToScreen(reach, value, 0, viewport, camera, pixelsPerMeter)
+      const [x1, y1] = gridFrameToScreen(value, -reach, 0)
+      const [x2, y2] = gridFrameToScreen(value, reach, 0)
+      const [x3, y3] = gridFrameToScreen(-reach, value, 0)
+      const [x4, y4] = gridFrameToScreen(reach, value, 0)
       context.moveTo(x1, y1)
       context.lineTo(x2, y2)
       context.moveTo(x3, y3)
@@ -390,76 +851,51 @@ export default function PointCloudViewer({
     }
     context.stroke()
 
-    if (trajectory.length > 1) {
-      context.strokeStyle = 'rgba(116, 231, 165, 0.88)'
-      context.lineWidth = 2
-      context.beginPath()
-      trajectory.forEach((point, index) => {
-        const projected = worldToScreen(
-          point[0], point[1], finite(point[2]), viewport, camera, pixelsPerMeter,
-        )
-        if (index === 0) context.moveTo(projected[0], projected[1])
-        else context.lineTo(projected[0], projected[1])
-      })
-      context.stroke()
-    }
-    if (loopClosures.length > 0) {
-      context.setLineDash([4, 4])
-      context.strokeStyle = 'rgba(224, 105, 255, 0.9)'
-      context.lineWidth = 1.5
-      context.beginPath()
-      loopClosures.forEach(([from, to]) => {
-        const start = worldToScreen(from[0], from[1], finite(from[2]), viewport, camera, pixelsPerMeter)
-        const end = worldToScreen(to[0], to[1], finite(to[2]), viewport, camera, pixelsPerMeter)
+    if (showAxes) {
+      const drawAxis = (endX: number, endY: number, endZ: number, color: string) => {
+        const start = gridFrameToScreen(-endX, -endY, -endZ)
+        const end = gridFrameToScreen(endX, endY, endZ)
+        context.strokeStyle = color
+        context.lineWidth = 1.5
+        context.beginPath()
         context.moveTo(start[0], start[1])
         context.lineTo(end[0], end[1])
-      })
-      context.stroke()
-      context.setLineDash([])
-    }
-
-    const drawAxis = (endX: number, endY: number, endZ: number, color: string) => {
-      const start = worldToScreen(-endX, -endY, -endZ, viewport, camera, pixelsPerMeter)
-      const end = worldToScreen(endX, endY, endZ, viewport, camera, pixelsPerMeter)
-      context.strokeStyle = color
-      context.lineWidth = 1.5
-      context.beginPath()
-      context.moveTo(start[0], start[1])
-      context.lineTo(end[0], end[1])
-      context.stroke()
-    }
-    drawAxis(reach, 0, 0, 'rgba(255, 91, 91, 0.68)')
-    drawAxis(0, reach, 0, 'rgba(83, 224, 145, 0.68)')
-    drawAxis(0, 0, Math.min(reach, viewRadius * 0.45), 'rgba(83, 154, 255, 0.78)')
-
-    context.fillStyle = 'rgba(186, 211, 228, 0.72)'
-    for (let index = -steps; index <= steps; index += 1) {
-      if (index === 0) continue
-      const value = index * spacing
-      const xTick = worldToScreen(value, 0, 0, viewport, camera, pixelsPerMeter)
-      if (xTick[0] > 12 && xTick[0] < viewport.width - 28 && xTick[1] > 12 && xTick[1] < viewport.height - 12) {
-        context.fillText(meterLabel(value), xTick[0] + 3, xTick[1] - 4)
+        context.stroke()
       }
-      const yTick = worldToScreen(0, value, 0, viewport, camera, pixelsPerMeter)
-      if (yTick[0] > 12 && yTick[0] < viewport.width - 28 && yTick[1] > 12 && yTick[1] < viewport.height - 12) {
-        context.fillText(meterLabel(value), yTick[0] + 4, yTick[1] - 3)
+      drawAxis(reach, 0, 0, 'rgba(255, 91, 91, 0.68)')
+      drawAxis(0, reach, 0, 'rgba(83, 224, 145, 0.68)')
+      drawAxis(0, 0, Math.min(reach, viewRadius * 0.45), 'rgba(83, 154, 255, 0.78)')
+
+      context.fillStyle = 'rgba(186, 211, 228, 0.72)'
+      for (let index = -steps; index <= steps; index += 1) {
+        if (index === 0) continue
+        const value = index * spacing
+        const xTick = gridFrameToScreen(value, 0, 0)
+        if (xTick[0] > 12 && xTick[0] < viewport.width - 28 && xTick[1] > 12 && xTick[1] < viewport.height - 12) {
+          context.fillText(meterLabel(value), xTick[0] + 3, xTick[1] - 4)
+        }
+        const yTick = gridFrameToScreen(0, value, 0)
+        if (yTick[0] > 12 && yTick[0] < viewport.width - 28 && yTick[1] > 12 && yTick[1] < viewport.height - 12) {
+          context.fillText(meterLabel(value), yTick[0] + 4, yTick[1] - 3)
+        }
       }
     }
 
     const sensorScreen = worldToScreen(sensor.x, sensor.y, 0, viewport, camera, pixelsPerMeter)
     const scanMinimum = sensor.yaw + scanAngleMinimum
     const scanMaximum = sensor.yaw + scanAngleMaximum
-    const counterclockwisePoints = [...currentPoints].sort((left, right) => {
+    const sweepOrderedPoints = [...currentPoints].sort((left, right) => {
       const leftAngle = Math.atan2(left[1] - sensor.y, left[0] - sensor.x)
       const rightAngle = Math.atan2(right[1] - sensor.y, right[0] - sensor.x)
-      const leftOffset = (leftAngle - scanMinimum + Math.PI * 2) % (Math.PI * 2)
-      const rightOffset = (rightAngle - scanMinimum + Math.PI * 2) % (Math.PI * 2)
+      const direction = clockwiseScan ? -1 : 1
+      const leftOffset = ((leftAngle - scanMinimum) * direction + Math.PI * 2) % (Math.PI * 2)
+      const rightOffset = ((rightAngle - scanMinimum) * direction + Math.PI * 2) % (Math.PI * 2)
       return leftOffset - rightOffset
     })
     const rayLength = Math.min(viewRadius, Math.max(spacing * 2, viewRadius * 0.82))
     if (!fullCircleScan) {
       context.setLineDash([5, 5])
-      context.strokeStyle = 'rgba(255, 198, 72, 0.62)'
+      context.strokeStyle = 'rgba(133, 162, 184, 0.42)'
       context.lineWidth = 1.3
       context.beginPath()
       for (const angle of [scanMinimum, scanMaximum]) {
@@ -481,16 +917,16 @@ export default function PointCloudViewer({
     if (animationEnabled && currentPoints.length > 0) {
       if (parsed.animation?.show_rays !== false) {
         const activeIndex = Math.min(
-          counterclockwisePoints.length - 1,
-          Math.max(0, Math.floor(animationPhase * counterclockwisePoints.length)),
+          sweepOrderedPoints.length - 1,
+          Math.max(0, Math.floor(animationPhase * sweepOrderedPoints.length)),
         )
         const trailCount = clamp(finite(parsed.animation?.ray_trail_count, 96), 1, 512)
         const trailStart = Math.max(0, activeIndex - trailCount + 1)
-        context.strokeStyle = 'rgba(42, 133, 224, 0.32)'
-        context.lineWidth = 0.8
+        context.strokeStyle = 'rgba(80, 232, 145, 0.52)'
+        context.lineWidth = 1.1
         context.beginPath()
         for (let index = trailStart; index <= activeIndex; index += 1) {
-          const hit = counterclockwisePoints[index]
+          const hit = sweepOrderedPoints[index]
           const projected = worldToScreen(
             hit[0], hit[1], finite(hit[2]), viewport, camera, pixelsPerMeter,
           )
@@ -498,17 +934,17 @@ export default function PointCloudViewer({
           context.lineTo(projected[0], projected[1])
         }
         context.stroke()
-        const activeHit = counterclockwisePoints[activeIndex]
+        const activeHit = sweepOrderedPoints[activeIndex]
         const projectedHit = worldToScreen(
           activeHit[0], activeHit[1], finite(activeHit[2]), viewport, camera, pixelsPerMeter,
         )
-        context.strokeStyle = '#ffd12f'
-        context.lineWidth = 2
+        context.strokeStyle = '#72ff9d'
+        context.lineWidth = 2.6
         context.beginPath()
         context.moveTo(sensorScreen[0], sensorScreen[1])
         context.lineTo(projectedHit[0], projectedHit[1])
         context.stroke()
-        context.fillStyle = '#fff176'
+        context.fillStyle = '#b9ffca'
         context.beginPath()
         context.arc(projectedHit[0], projectedHit[1], 4.5, 0, Math.PI * 2)
         context.fill()
@@ -517,13 +953,15 @@ export default function PointCloudViewer({
 
     const robotLength = clamp(finite(parsed.robot?.length_m, 0.25), 0.02, 5)
     const robotWidth = clamp(finite(parsed.robot?.width_m, 0.22), 0.02, 5)
+    const visualRobotLength = robotLength * ROBOT_FOOTPRINT_VISUAL_SCALE
+    const visualRobotWidth = robotWidth * ROBOT_FOOTPRINT_VISUAL_SCALE
     const headingCosine = Math.cos(robotHeadingYaw)
     const headingSine = Math.sin(robotHeadingYaw)
     const robotCorners = [
-      [robotLength / 2, robotWidth / 2],
-      [robotLength / 2, -robotWidth / 2],
-      [-robotLength / 2, -robotWidth / 2],
-      [-robotLength / 2, robotWidth / 2],
+      [visualRobotLength / 2, visualRobotWidth / 2],
+      [visualRobotLength / 2, -visualRobotWidth / 2],
+      [-visualRobotLength / 2, -visualRobotWidth / 2],
+      [-visualRobotLength / 2, visualRobotWidth / 2],
     ].map(([localX, localY]) => worldToScreen(
       sensor.x + headingCosine * localX - headingSine * localY,
       sensor.y + headingSine * localX + headingCosine * localY,
@@ -532,43 +970,85 @@ export default function PointCloudViewer({
       camera,
       pixelsPerMeter,
     ))
-    context.fillStyle = 'rgba(255, 107, 107, 0.82)'
-    context.strokeStyle = '#fff3d0'
-    context.lineWidth = 1.5
+    const shortestRobotEdge = robotCorners.reduce((shortest, corner, index) => {
+      const next = robotCorners[(index + 1) % robotCorners.length]
+      return Math.min(shortest, Math.hypot(next[0] - corner[0], next[1] - corner[1]))
+    }, Number.POSITIVE_INFINITY)
+    const robotCornerRadius = clamp(shortestRobotEdge * 0.44, 3, 14)
+    context.shadowColor = 'rgba(43, 220, 238, 0.4)'
+    context.shadowBlur = 9
+    context.fillStyle = 'rgba(30, 199, 220, 0.3)'
+    context.strokeStyle = 'rgba(124, 244, 255, 0.92)'
+    context.lineWidth = 1.6
     context.beginPath()
-    robotCorners.forEach((corner, index) => {
-      if (index === 0) context.moveTo(corner[0], corner[1])
-      else context.lineTo(corner[0], corner[1])
-    })
-    context.closePath()
+    roundedPolygonPath(context, robotCorners, robotCornerRadius)
     context.fill()
     context.stroke()
+    context.shadowBlur = 0
 
-    const forwardLength = Math.max(robotLength * 1.4, spacing * 0.8)
-    const forward = worldToScreen(
-      sensor.x + headingCosine * forwardLength,
-      sensor.y + headingSine * forwardLength,
+    const forwardUnit = worldToScreen(
+      sensor.x + headingCosine,
+      sensor.y + headingSine,
       0,
       viewport,
       camera,
       pixelsPerMeter,
     )
-    context.strokeStyle = '#ffd166'
-    context.fillStyle = '#ffd166'
-    context.lineWidth = 2
-    context.beginPath()
-    context.moveTo(sensorScreen[0], sensorScreen[1])
-    context.lineTo(forward[0], forward[1])
-    context.stroke()
-    const arrowAngle = Math.atan2(forward[1] - sensorScreen[1], forward[0] - sensorScreen[0])
-    context.beginPath()
-    context.moveTo(forward[0], forward[1])
-    context.lineTo(forward[0] - Math.cos(arrowAngle - 0.55) * 8, forward[1] - Math.sin(arrowAngle - 0.55) * 8)
-    context.lineTo(forward[0] - Math.cos(arrowAngle + 0.55) * 8, forward[1] - Math.sin(arrowAngle + 0.55) * 8)
-    context.closePath()
-    context.fill()
-    context.fillStyle = '#ffd166'
-    context.fillText('Robot forward', forward[0] + 7, forward[1] - 7)
+    const lateralUnit = worldToScreen(
+      sensor.x - headingSine,
+      sensor.y + headingCosine,
+      0,
+      viewport,
+      camera,
+      pixelsPerMeter,
+    )
+    const logo = robotLogoRef.current
+    if (logo) {
+      // Treat the B as a decal fixed to the robot plane. It shares the exact
+      // forward/lateral projection used by the footprint. Compensating for the
+      // footprint dimensions before that transform preserves the source ratio.
+      const logoWorldScale = Math.min(
+        visualRobotLength * ROBOT_LOGO_FOOTPRINT_SCALE / ROBOT_LOGO_SOURCE.height,
+        visualRobotWidth * ROBOT_LOGO_FOOTPRINT_SCALE / ROBOT_LOGO_SOURCE.width,
+      )
+      const logoWidth = ROBOT_LOGO_SOURCE.width * logoWorldScale / visualRobotWidth
+      const logoHeight = ROBOT_LOGO_SOURCE.height * logoWorldScale / visualRobotLength
+      context.save()
+      context.beginPath()
+      roundedPolygonPath(context, robotCorners, robotCornerRadius)
+      context.clip()
+      context.transform(
+        (forwardUnit[0] - sensorScreen[0]) * visualRobotLength,
+        (forwardUnit[1] - sensorScreen[1]) * visualRobotLength,
+        (lateralUnit[0] - sensorScreen[0]) * visualRobotWidth,
+        (lateralUnit[1] - sensorScreen[1]) * visualRobotWidth,
+        sensorScreen[0],
+        sensorScreen[1],
+      )
+      context.rotate(ROBOT_LOGO_ROTATION_RAD)
+      context.globalAlpha = 0.8
+      context.globalCompositeOperation = 'screen'
+      context.drawImage(
+        logo,
+        ROBOT_LOGO_SOURCE.x,
+        ROBOT_LOGO_SOURCE.y,
+        ROBOT_LOGO_SOURCE.width,
+        ROBOT_LOGO_SOURCE.height,
+        -logoWidth / 2,
+        -logoHeight / 2,
+        logoWidth,
+        logoHeight,
+      )
+      context.restore()
+    } else {
+      context.fillStyle = 'rgba(220, 252, 255, 0.9)'
+      context.font = `800 ${clamp(shortestRobotEdge * 0.66, 9, 18)}px var(--font-ui)`
+      context.textAlign = 'center'
+      context.textBaseline = 'middle'
+      context.fillText('B', sensorScreen[0], sensorScreen[1])
+      context.textAlign = 'start'
+      context.textBaseline = 'alphabetic'
+    }
 
     const scalePixels = spacing * pixelsPerMeter
     const scaleX = 16
@@ -588,17 +1068,19 @@ export default function PointCloudViewer({
     animationPhase,
     camera,
     currentPoints,
+    gridFrame,
     parsed.animation?.ray_trail_count,
     parsed.animation?.show_rays,
     parsed.robot?.length_m,
     parsed.robot?.width_m,
     parsed.scan?.angle_max_rad,
     parsed.scan?.angle_min_rad,
+    parsed.scan?.angle_increment_rad,
     pixelsPerMeter,
     robotHeadingYaw,
+    robotLogoReady,
     sensor,
-    trajectory,
-    loopClosures,
+    showAxes,
     viewRadius,
     viewport,
   ])
@@ -608,6 +1090,10 @@ export default function PointCloudViewer({
   const accumulatedScanCount = Number(parsed.accumulated_scan_count ?? (points.length ? 1 : 0))
   const displayCount = Number(parsed.display_count ?? points.length)
   const kernelMs = Number(parsed.kernel_ms ?? 0)
+  const occupancyKernelMs = Number(parsed.occupancy?.kernel_ms ?? 0)
+  const occupancyEncodeMs = Number(parsed.occupancy?.encode_ms ?? 0)
+  const freeCellCount = Number(parsed.floor_point_count ?? parsed.occupancy?.free_cells ?? floorPoints.length)
+  const occupiedCellCount = Number(parsed.occupied_point_count ?? parsed.occupancy?.occupied_cells ?? occupiedPoints.length)
   const yawDegrees = Math.round(camera.yaw * 180 / Math.PI)
   const pitchDegrees = Math.round(camera.pitch * 180 / Math.PI)
 
@@ -616,54 +1102,93 @@ export default function PointCloudViewer({
       className="nodrag"
       onMouseDown={event => event.stopPropagation()}
       style={{
-        margin: '7px 9px 3px',
-        overflow: 'hidden',
+        margin: '7px 9px 8px',
+        width: 'calc(100% - 18px)',
+        flex: '1 1 auto',
+        minHeight: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        boxSizing: 'border-box',
+        overflow: 'visible',
         border: '1px solid var(--line2)',
         borderRadius: 'var(--bn-node-inner-radius, 7px)',
-        background: '#03070d',
+        background: '#242424',
       }}
     >
       <div style={{
-        display: 'flex', alignItems: 'center', gap: 5, padding: '5px 7px',
+        display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 5, padding: '5px 7px',
         borderBottom: '1px solid var(--line)', background: 'var(--panel)',
       }}>
-        <button type="button" style={controlStyle()} title="Zoom out" onClick={() => setCamera(value => ({ ...value, zoom: clamp(value.zoom / 1.25, 0.1, 30) }))}>−</button>
-        <button type="button" style={controlStyle()} title="Zoom in" onClick={() => setCamera(value => ({ ...value, zoom: clamp(value.zoom * 1.25, 0.1, 30) }))}>+</button>
+        <button type="button" style={controlStyle()} title="Zoom out" onClick={() => setCamera(value => ({ ...value, zoom: clamp(value.zoom / 1.25, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM) }))}>−</button>
+        <button type="button" style={controlStyle()} title="Zoom in" onClick={() => setCamera(value => ({ ...value, zoom: clamp(value.zoom * 1.25, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM) }))}>+</button>
         <button type="button" style={controlStyle()} title="Orbit left" onClick={() => setCamera(value => ({ ...value, yaw: value.yaw - Math.PI / 12 }))}>↶</button>
         <button type="button" style={controlStyle()} title="Orbit right" onClick={() => setCamera(value => ({ ...value, yaw: value.yaw + Math.PI / 12 }))}>↷</button>
         <button type="button" style={controlStyle()} title="Tilt camera up" onClick={() => setCamera(value => ({ ...value, pitch: clamp(value.pitch + Math.PI / 18, -1.45, 1.45) }))}>↑</button>
         <button type="button" style={controlStyle()} title="Tilt camera down" onClick={() => setCamera(value => ({ ...value, pitch: clamp(value.pitch - Math.PI / 18, -1.45, 1.45) }))}>↓</button>
-        <button type="button" style={controlStyle(camera.pitch === 0 && camera.yaw === 0)} onClick={() => setCamera(value => ({ ...value, yaw: 0, pitch: 0 }))}>Top</button>
-        <button type="button" style={controlStyle()} onClick={() => setCamera(DEFAULT_CAMERA)}>Fit</button>
+        <button type="button" style={controlStyle(camera.pitch === 0 && camera.yaw === TOP_VIEW_YAW)} title="Top view with world +X (red axis) pointing up" onClick={() => setCamera(value => ({ ...value, yaw: TOP_VIEW_YAW, pitch: 0 }))}>Top</button>
+        <button type="button" style={controlStyle()} title="Capture and align the grid at the current robot pose, then keep the grid and map fixed" onClick={resetCamera}>Reset</button>
+        <label
+          title="Show fixed map X, Y, and Z axes with metric tick labels"
+          style={{ ...controlStyle(showAxes), display: 'inline-flex', alignItems: 'center', gap: 5, width: 'auto' }}
+        >
+          <input
+            type="checkbox"
+            checked={showAxes}
+            onChange={event => setShowAxes(event.target.checked)}
+            style={{ margin: 0, accentColor: 'var(--accent)' }}
+          />
+          Axes
+        </label>
         {onAccumulationToggle && (
           <button
             type="button"
             disabled={accumulationPending}
             style={controlStyle(!parsed.history_paused)}
-            title={parsed.history_paused ? 'Resume retaining new scan returns' : 'Show only the current sweep'}
+            title={parsed.history_paused ? 'Resume adding scan returns to the fixed world cloud' : 'Freeze the fixed world cloud while keeping the live sweep visible'}
             onClick={onAccumulationToggle}
           >
             {accumulationPending ? 'Updating…' : `Accumulate: ${parsed.history_paused ? 'Off' : 'On'}`}
           </button>
         )}
+        <button
+          type="button"
+          style={controlStyle(showFreeSpace)}
+          title={showFreeSpace ? 'Hide free-space floor fill; stored occupancy data is preserved' : 'Show free-space floor fill'}
+          onClick={() => setShowFreeSpace(value => !value)}
+        >
+          Floor: {showFreeSpace ? 'On' : 'Off'}
+        </button>
         {onClear && <button type="button" disabled={clearPending} style={controlStyle()} title="Clear accumulated scan history and switch accumulation off" onClick={onClear}>{clearPending ? 'Clearing…' : 'Clear history'}</button>}
         <span style={{ marginLeft: 'auto', color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
           {camera.zoom.toFixed(2)}× · yaw {yawDegrees}° · pitch {pitchDegrees}°
         </span>
       </div>
-      <div style={{ position: 'relative', height: 360 }}>
+      <div
+        data-bn-viewer-canvas-region
+        style={{ position: 'relative', flex: '1 1 auto', minHeight: 80 }}
+      >
+        {inputRail}
+        <canvas
+          ref={occupancyCanvasRef}
+          aria-hidden="true"
+          style={{ position: 'absolute', inset: 0, zIndex: 0, width: '100%', height: '100%', pointerEvents: 'none' }}
+        />
         <canvas
           ref={canvasRef}
+          className="bn-viewer-wheel-capture"
           aria-label="Interactive live point-cloud Viewer"
-          onContextMenu={event => event.preventDefault()}
-          onDoubleClick={() => setCamera(DEFAULT_CAMERA)}
+          onContextMenu={event => {
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onDoubleClick={resetCamera}
           onPointerDown={event => {
             event.stopPropagation()
             event.currentTarget.setPointerCapture(event.pointerId)
             dragRef.current = {
               x: event.clientX,
               y: event.clientY,
-              mode: event.button === 1 || event.button === 2 || event.shiftKey ? 'pan' : 'rotate',
+              mode: event.button === 2 ? 'rotate' : 'pan',
               camera,
             }
           }}
@@ -695,7 +1220,7 @@ export default function PointCloudViewer({
             const cursorY = event.clientY - bounds.top - viewport.height / 2
             const factor = Math.exp(-event.deltaY * 0.001)
             setCamera(value => {
-              const zoom = clamp(value.zoom * factor, 0.1, 30)
+              const zoom = clamp(value.zoom * factor, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM)
               const applied = zoom / value.zoom
               return {
                 ...value,
@@ -705,28 +1230,47 @@ export default function PointCloudViewer({
               }
             })
           }}
-          style={{ display: 'block', width: '100%', height: '100%', cursor: 'grab', touchAction: 'none' }}
+          style={{ position: 'relative', zIndex: 1, display: 'block', width: '100%', height: '100%', cursor: 'grab', touchAction: 'none' }}
         />
         <canvas
           ref={overlayRef}
           aria-hidden="true"
-          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none' }}
+          style={{ position: 'absolute', inset: 0, zIndex: 2, width: '100%', height: '100%', pointerEvents: 'none' }}
         />
         <div style={{
-          position: 'absolute', top: 8, left: 9, display: 'flex', alignItems: 'center', gap: 6,
+          position: 'absolute', zIndex: 3, top: 8, left: 9, display: 'flex', alignItems: 'center', gap: 6,
           padding: '4px 7px', borderRadius: 5, background: 'rgba(3, 10, 16, 0.78)',
           border: '1px solid rgba(86, 217, 145, 0.38)', color: '#8df0b5',
           fontFamily: 'var(--font-mono)', fontSize: 11, pointerEvents: 'none',
         }}>
           <span style={{ width: 7, height: 7, borderRadius: '50%', background: currentPoints.length ? '#56d991' : '#71808d' }} />
-          {currentPoints.length ? `CURRENT SCAN #${Number(parsed.sequence ?? 0).toLocaleString()} · CCW ${Math.round(animationPhase * 100)}%` : 'WAITING FOR SCAN'}
+          {currentPoints.length ? `CURRENT SCAN #${Number(parsed.sequence ?? 0).toLocaleString()} · ${clockwiseScan ? 'CW' : 'CCW'} ${Math.round(animationPhase * 100)}%` : 'WAITING FOR SCAN'}
         </div>
+        {parsed.occupancy?.backend === 'warp' && (
+          <div style={{
+            position: 'absolute', zIndex: 3, top: 8, right: 9, display: 'flex', alignItems: 'center', gap: 6,
+            padding: '4px 7px', borderRadius: 5, background: 'rgba(3, 10, 16, 0.82)',
+            border: `1px solid ${parsed.history_paused ? 'rgba(242, 184, 75, 0.45)' : 'rgba(79, 192, 122, 0.48)'}`,
+            color: parsed.history_paused ? '#f2c66d' : '#8df0b5',
+            fontFamily: 'var(--font-mono)', fontSize: 11, pointerEvents: 'none',
+          }}>
+            <span style={{
+              width: 7, height: 7, borderRadius: '50%',
+              background: parsed.history_paused ? '#f2b84b' : freeCellCount > 0 ? '#4fc07a' : '#71808d',
+            }} />
+            {parsed.history_paused
+              ? 'WARP MAP · FROZEN'
+              : freeCellCount > 0
+                ? `WARP MAP · FILLING ${freeCellCount.toLocaleString()} FREE · ${occupiedCellCount.toLocaleString()} WALL`
+                : 'WARP MAP · READY'}
+          </div>
+        )}
         <div style={{
-          position: 'absolute', right: 8, bottom: 7, padding: '3px 6px', borderRadius: 4,
+          position: 'absolute', zIndex: 3, right: 8, bottom: 7, padding: '3px 6px', borderRadius: 4,
           background: 'rgba(3, 10, 16, 0.72)', color: 'rgba(217, 232, 241, 0.74)',
           fontFamily: 'var(--font-mono)', fontSize: 11, pointerEvents: 'none',
         }}>
-          drag orbit · Shift/right-drag pan · wheel zoom · double-click fit
+          left-drag pan · right-drag orbit · middle-drag pan · wheel zoom · double-click reset
         </div>
       </div>
       <div style={{
@@ -735,7 +1279,7 @@ export default function PointCloudViewer({
         color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 11,
       }}>
         <span>
-          {points.length
+          {pointCount > 0
             ? `${pointCount.toLocaleString()} accumulated returns`
             : currentPoints.length ? 'Live scan; map is empty' : 'Waiting for points'}
         </span>
@@ -743,28 +1287,43 @@ export default function PointCloudViewer({
         {accumulatedScanCount > 0 && <span>{accumulatedScanCount.toLocaleString()} scans</span>}
         {displayCount > 0 && displayCount !== pointCount && <span>{displayCount.toLocaleString()} displayed</span>}
         {kernelMs > 0 && <span>{kernelMs.toFixed(3)} ms Warp</span>}
+        {parsed.occupancy?.backend === 'warp' && (
+          <span style={{ color: '#74e7a5' }}>
+            Warp occupancy {occupancyKernelMs.toFixed(3)} ms · encode {occupancyEncodeMs.toFixed(3)} ms · {Number(parsed.occupancy.rays ?? 0).toLocaleString()} rays · {freeCellCount.toLocaleString()} free · {occupiedCellCount.toLocaleString()} occupied · {Number(parsed.occupancy.grid_cells ?? 0).toLocaleString()} grid cells
+          </span>
+        )}
         {parsed.device && <span>{parsed.device}</span>}
         {parsed.frame && <span>{parsed.frame}</span>}
-        {parsed.slam && <span>{Number(parsed.slam.keyframes ?? 0).toLocaleString()} keyframes · score {finite(parsed.slam.match_score).toFixed(2)} · {Number(parsed.slam.loop_closures ?? 0).toLocaleString()} loops</span>}
-        <span>{scanCoverageDeg >= 359.5 ? '360° scan · CCW sweep' : `${scanCoverageDeg.toFixed(1)}° scan · CCW sweep`}</span>
+        {parsed.slam && <span>{Number(parsed.slam.keyframes ?? 0).toLocaleString()} keyframes · score {finite(parsed.slam.match_score).toFixed(2)} · {parsed.slam.matching_backend === 'warp' ? `Warp match ${finite(parsed.slam.matching_kernel_ms).toFixed(3)} ms` : 'CPU match'} · {parsed.slam.deskewed ? 'deskew on' : 'deskew unavailable'} · {Number(parsed.slam.loop_closures ?? 0).toLocaleString()} loops</span>}
+        <span>{scanCoverageDeg >= 359.5 ? `360° scan · ${clockwiseScan ? 'CW' : 'CCW'} paced replay` : `${scanCoverageDeg.toFixed(1)}° scan · ${clockwiseScan ? 'CW' : 'CCW'} paced replay`}</span>
         <span>3D orbit · LaserScan lies on XY plane</span>
       </div>
       <div style={{
         display: 'flex', gap: 11, flexWrap: 'wrap', padding: '0 9px 7px',
         color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 11,
       }}>
-        <span style={{ color: '#ff7b7b' }}>■ robot {Math.round(finite(parsed.robot?.length_m, 0.25) * 100)}×{Math.round(finite(parsed.robot?.width_m, 0.22) * 100)} cm</span>
-        <span style={{ color: '#ffd166' }}>→ forward / scan limits</span>
+        <span style={{ color: '#7cf4ff' }}>B robot {Math.round(finite(parsed.robot?.length_m, 0.25) * 100)}×{Math.round(finite(parsed.robot?.width_m, 0.22) * 100)} cm</span>
+        <span style={{ color: '#72ff9d' }}>— active beam</span>
+        {!fullCircleScan && <span style={{ color: '#85a2b8' }}>┄ scan limits</span>}
         <span style={{ color: '#32d8ef' }}>● filtered laser returns</span>
-        {trajectory.length > 1 && <span style={{ color: '#74e7a5' }}>— optimized trajectory</span>}
-        {loopClosures.length > 0 && <span style={{ color: '#e069ff' }}>┄ loop closure</span>}
-        <span><b style={{ color: '#ff6b6b' }}>X</b> / <b style={{ color: '#53e091' }}>Y</b> / <b style={{ color: '#539aff' }}>Z</b> axes</span>
+        {parsed.occupancy?.fixed_origin === true && <span style={{ color: '#486070' }}>■ unknown map extent</span>}
+        {parsed.map_render_mode === 'occupancy-texture' && <span style={{ color: '#74e7a5' }}>GPU map texture · all cells</span>}
+        {showFreeSpace && freeCellCount > 0 && <span style={{ color: '#4fc07a' }}>■ {freeCellCount.toLocaleString()} fixed free-floor cells</span>}
+        {occupiedCellCount > 0 && <span style={{ color: '#c7e0ef' }}>■ {occupiedCellCount.toLocaleString()} occupied wall cells</span>}
+        {showAxes && <span>map <b style={{ color: '#ff6b6b' }}>X</b> / <b style={{ color: '#53e091' }}>Y</b> / <b style={{ color: '#539aff' }}>Z</b> axes</span>}
         {parsed.history_registered === true && <span style={{ color: '#74e7a5' }}>pose-registered history · {parsed.pose_source || 'pose stream'}</span>}
         {Array.isArray(parsed.registration?.tf_path) && parsed.registration.tf_path.length > 1 && (
           <span>{parsed.registration.tf_path.join(' → ')}</span>
         )}
         {parsed.history_registered === false && <span style={{ color: '#f2b84b' }}>history is sensor-local; moving the robot requires odometry</span>}
         {parsed.history_paused === true && <span style={{ color: '#f2b84b' }}>accumulation paused</span>}
+        {parsed.slam?.tracking_accepted === false && <span style={{ color: '#f2b84b' }}>uncertain scan match rejected · odometry prior kept</span>}
+        {parsed.slam?.stationary_odometry_locked === true && <span style={{ color: '#74e7a5' }}>stationary odometry lock · dynamic returns cannot move map</span>}
+        {parsed.slam?.scan_motion_override === true && <span style={{ color: '#74e7a5' }}>whole-scene motion accepted · robot pose updated</span>}
+        {parsed.slam?.tracking_correction_limited === true && <span style={{ color: '#74e7a5' }}>large pose correction smoothed across scans</span>}
+        {parsed.slam?.map_update_rejected === true && <span style={{ color: '#f2b84b' }}>uncertain keyframe excluded from map</span>}
+        {parsed.occupancy?.fixed_origin === true && <span style={{ color: '#74e7a5' }}>fixed map grid · floor cells never follow robot pose</span>}
+        {parsed.occupancy?.display_limited === true && <span style={{ color: '#f2b84b' }}>occupancy display capped; full evidence remains on device</span>}
       </div>
     </div>
   )

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -1345,6 +1345,34 @@ html[data-theme="light"] .bn-logo-image-light {
   text-decoration: underline;
 }
 
+.bn-top-live-button.is-stop-live,
+.bn-top-live-button.is-stop-live:hover:not(:disabled) {
+  background: var(--err);
+  border-color: var(--err);
+  color: #fff;
+}
+
+.bn-top-live-button.is-start-live,
+.bn-top-live-button.is-start-live:hover:not(:disabled) {
+  background: var(--ok);
+  border-color: var(--ok);
+  color: #07110c;
+  font-weight: 700;
+}
+
+.bn-top-reset-button {
+  background: var(--warn-soft);
+  border-color: color-mix(in srgb, var(--warn) 62%, var(--line2));
+  color: var(--warn);
+  font-weight: 700;
+}
+
+.bn-top-reset-button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--warn) 18%, transparent);
+  border-color: var(--warn);
+  color: var(--warn);
+}
+
 .bn-local-package-install-available {
   display: flex;
   width: 100%;
@@ -6217,6 +6245,29 @@ html[data-ui-test="refined"] .bn-topbar-run-group .bn-top-run-button + .bn-top-r
   color: var(--tx1);
 }
 
+html[data-ui-test="refined"] .bn-topbar-run-group .bn-top-live-button.is-stop-live,
+html[data-ui-test="refined"] .bn-topbar-run-group .bn-top-live-button.is-stop-live:hover:not(:disabled) {
+  border-color: var(--err);
+  background: var(--err);
+  color: #fff;
+}
+
+html[data-ui-test="refined"] .bn-topbar-run-group .bn-top-live-button.is-start-live,
+html[data-ui-test="refined"] .bn-topbar-run-group .bn-top-live-button.is-start-live:hover:not(:disabled) {
+  border-color: var(--ok);
+  background: var(--ok);
+  color: #07110c;
+  font-weight: 700;
+}
+
+html[data-ui-test="refined"] .bn-topbar-run-group .bn-top-reset-button,
+html[data-ui-test="refined"] .bn-topbar-run-group .bn-top-reset-button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--warn) 52%, transparent);
+  background: var(--warn-soft);
+  color: var(--warn);
+  font-weight: 700;
+}
+
 html[data-ui-test="refined"] .bn-ui-test-button.is-active {
   background: color-mix(in srgb, var(--accent) 15%, var(--ui-test-surface-solid));
   color: var(--accent);
@@ -8404,6 +8455,63 @@ html[data-ui-test="refined"] .bn-package-family {
 /* ── Refined preview: category-only templates and layered node bodies ─── */
 .bn-node-parameter-area {
   display: contents;
+}
+
+/* Viewer nodes reserve their body for the visualization. Inputs remain fully
+   connectable as a compact vertical rail against the viewer's left edge. */
+.bn-viewer-input-strip {
+  position: absolute;
+  top: 12px;
+  bottom: auto;
+  left: -10px;
+  z-index: 8;
+  display: flex;
+  width: 12px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  padding: 0;
+  margin-top: 0;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
+.bn-viewer-input-anchor {
+  position: relative;
+  width: 12px;
+  height: 12px;
+  flex: 0 0 12px;
+  pointer-events: auto;
+}
+
+.bn-viewer-input-anchor .react-flow__handle {
+  top: 50%;
+  left: -5px;
+  width: 9px;
+  height: 9px;
+  border-width: 1.5px;
+  border-radius: 3px !important;
+  transform: translateY(-50%);
+}
+
+.bn-viewer-input-anchor.is-connected .react-flow__handle {
+  width: 10px;
+  height: 10px;
+}
+
+.bn-viewer-hidden-output-anchors {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.bn-viewer-hidden-output-anchors .react-flow__handle {
+  top: 50%;
+  right: 0;
+  width: 1px;
+  height: 1px;
 }
 
 html[data-ui-test="refined"] .bn-node-frame {

--- a/editor/src/standalone-slam.css
+++ b/editor/src/standalone-slam.css
@@ -1,0 +1,126 @@
+:root {
+  --panel2: #292929;
+  --bn-node-inner-radius: 9px;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+}
+
+.bn-standalone-slam {
+  width: 100%;
+  height: 100%;
+  min-width: 320px;
+  min-height: 260px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.bn-standalone-slam__header {
+  flex: 0 0 auto;
+  min-height: 54px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--line2);
+  background: var(--panel);
+}
+
+.bn-standalone-slam__brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 190px;
+}
+
+.bn-standalone-slam__brand img {
+  width: 31px;
+  height: 31px;
+  object-fit: cover;
+  object-position: 50% 50%;
+  border-radius: 8px;
+}
+
+.bn-standalone-slam__brand div {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.12;
+}
+
+.bn-standalone-slam__brand strong {
+  color: var(--tx1);
+  font-size: 13px;
+}
+
+.bn-standalone-slam__brand span {
+  margin-top: 3px;
+  color: var(--tx3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.bn-standalone-slam__status {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.bn-standalone-slam__status i {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  box-shadow: 0 0 9px currentColor;
+}
+
+.bn-standalone-slam__status span {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--tx3);
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-standalone-slam__actions {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.bn-standalone-slam__viewer {
+  min-height: 0;
+  flex: 1 1 auto;
+  display: flex;
+  padding: 2px;
+}
+
+.bn-standalone-slam__viewer > div {
+  flex: 1 1 auto !important;
+}
+
+@media (max-width: 620px) {
+  .bn-standalone-slam__header {
+    gap: 8px;
+  }
+
+  .bn-standalone-slam__brand span,
+  .bn-standalone-slam__status span {
+    display: none;
+  }
+
+  .bn-standalone-slam__brand {
+    min-width: 0;
+  }
+}

--- a/editor/src/standalone-slam.tsx
+++ b/editor/src/standalone-slam.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import StandaloneSlam from './StandaloneSlam'
+import './index.css'
+import './standalone-slam.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <StandaloneSlam />
+  </StrictMode>,
+)

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -385,7 +385,7 @@ function makeReactNode(meta: BnNodeMeta): Node<NodeData> {
     ...(meta.type === 'Dict'   ? { style: { width: 260, height: 150 } } : {}),
     ...(meta.type === 'Output' ? { style: { width: 320, height: 200 } } : {}),
     ...(meta.type === 'OutputImage' ? { style: { width: 760, height: 620 } } : {}),
-    ...(meta.type === 'Viewer' ? { style: { width: 760, height: 660 } } : {}),
+    ...((meta.type === 'Viewer' || meta.type === 'SLAM') ? { style: { width: 720, height: 720 } } : {}),
     ...(meta.type === 'DatasetBrowser' ? { style: { width: 980, height: 860 } } : {}),
     ...(hasDashboardImage ? { style: { width: 860, height: 720 } } : {}),
     ...(meta.type === 'ROS2VisualDashboard' ? { style: { width: 840, height: 760 } } : {}),
@@ -673,6 +673,22 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
       portResults: {
         ...(data.portResults ?? {}),
         live: false,
+      },
+    }
+  }
+  if (data.type === 'Viewer' || data.type === 'SLAM') {
+    const previousStatus = data.portResults?.status
+    const status = previousStatus && typeof previousStatus === 'object' && !Array.isArray(previousStatus)
+      ? previousStatus as Record<string, unknown>
+      : {}
+    return {
+      ...base,
+      portResults: {
+        ...(data.portResults ?? {}),
+        running: false,
+        live: false,
+        status: { ...status, state: 'stopped' },
+        report: `${data.type} stopped by workflow control`,
       },
     }
   }
@@ -1715,6 +1731,28 @@ export const useStore = create<Store>((set, get) => ({
             rigid_bodies: managedRun.rigid_body_positions_m ?? {},
           } : {}
           if (Object.keys(liveOutputs).length === 0 && Object.keys(managedOutputs).length === 0) {
+            if (
+              (node.data.type === 'Viewer' || node.data.type === 'SLAM')
+              && (node.data.portResults?.running === true || node.data.portResults?.live === true)
+            ) {
+              const previousStatus = node.data.portResults?.status
+              const status = previousStatus && typeof previousStatus === 'object' && !Array.isArray(previousStatus)
+                ? previousStatus as Record<string, unknown>
+                : {}
+              return {
+                ...node,
+                data: {
+                  ...node.data,
+                  cooking: false,
+                  portResults: {
+                    ...(node.data.portResults ?? {}),
+                    running: false,
+                    live: false,
+                    status: { ...status, state: 'stopped' },
+                  },
+                },
+              }
+            }
             if (node.data.type !== 'NewtonSimulation' || !node.data.portResults?.viewer_url) return node
             return {
               ...node,
@@ -3611,7 +3649,9 @@ export const useStore = create<Store>((set, get) => ({
           n.data.type === 'ROS2TopicPublisher' ||
           n.data.type === 'ROS2TopicSubscriber' ||
           n.data.type === 'ROS2' ||
-          n.data.type === 'ROS2Launch'
+          n.data.type === 'ROS2Launch' ||
+          n.data.type === 'Viewer' ||
+          n.data.type === 'SLAM'
         )
         return {
           ...n,

--- a/editor/standalone-slam/index.html
+++ b/editor/standalone-slam/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#202020" />
+    <title>Blacknode Warp SLAM</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="../src/standalone-slam.tsx"></script>
+  </body>
+</html>

--- a/editor/vite.standalone-slam.config.ts
+++ b/editor/vite.standalone-slam.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { copyFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const outputDirectory = resolve(__dirname, '../packages/blacknode-cuda/viewer')
+
+export default defineConfig({
+  root: resolve(__dirname, 'standalone-slam'),
+  publicDir: false,
+  plugins: [
+    react(),
+    {
+      name: 'blacknode-slam-viewer-logo',
+      writeBundle() {
+        copyFileSync(
+          resolve(__dirname, 'public/blacknode-logo-dark.png'),
+          resolve(outputDirectory, 'blacknode-logo-dark.png'),
+        )
+      },
+    },
+  ],
+  build: {
+    outDir: outputDirectory,
+    emptyOutDir: true,
+    sourcemap: false,
+  },
+})

--- a/python/blacknode/cli.py
+++ b/python/blacknode/cli.py
@@ -22,11 +22,13 @@ from .workflow import WorkflowRunError, export_workflow_python, load_workflow, r
 
 def main(argv: list[str] | None = None) -> int:
     parser = _parser()
-    args = parser.parse_args(argv)
+    args, extra = parser.parse_known_args(argv)
+    if args.command != "run" and extra:
+        parser.error("unrecognized arguments: " + " ".join(extra))
     if args.command == "validate":
         return _validate(args.workflow)
     if args.command == "run":
-        return _run(args.workflow, args.output)
+        return _run(args.workflow, args.output, extra)
     if args.command == "export-python":
         return _export_python(args.workflow, args.output, args.style)
     if args.command == "import-python":
@@ -535,7 +537,24 @@ def _validate(path: Path) -> int:
     return 0 if report["ok"] else 1
 
 
-def _run(path: Path, output: Path | None) -> int:
+def _run(path: Path, output: Path | None, application_args: list[str] | None = None) -> int:
+    if not path.is_file():
+        if output is not None:
+            print("--output is available for workflow files, not named applications", file=sys.stderr)
+            return 2
+        try:
+            from .packages import run_package_application
+
+            return run_package_application(str(path), application_args)
+        except (ImportError, OSError, RuntimeError, ValueError) as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    if application_args:
+        print(
+            f"Workflow file {path} does not accept application arguments: {' '.join(application_args)}",
+            file=sys.stderr,
+        )
+        return 2
     try:
         result = run_workflow(load_workflow(path))
     except (OSError, json.JSONDecodeError, WorkflowRunError, Exception) as exc:

--- a/python/blacknode/packages.py
+++ b/python/blacknode/packages.py
@@ -80,6 +80,7 @@ class PackageInfo:
     templates_dir: str = ""
     template_dirs: list[str] = field(default_factory=list)
     setup_hooks: list[str] = field(default_factory=list)
+    applications: dict[str, dict[str, Any]] = field(default_factory=dict)
     ok: bool = True
     error: str = ""
     warnings: list[str] = field(default_factory=list)  # non-fatal (e.g. missing runtime dep)
@@ -156,6 +157,67 @@ def package_template_dirs() -> list[str]:
         if info.ok
         for path in (info.template_dirs or ([info.templates_dir] if info.templates_dir else []))
     ))
+
+
+def _package_applications(value: Any) -> dict[str, dict[str, Any]]:
+    """Normalize named terminal applications declared by a package manifest."""
+    if not isinstance(value, Mapping):
+        return {}
+    applications: dict[str, dict[str, Any]] = {}
+    for raw_name, raw_config in value.items():
+        name = re.sub(r"[^a-z0-9_-]+", "-", str(raw_name).strip().lower()).strip("-")
+        config = raw_config if isinstance(raw_config, Mapping) else {}
+        module = str(config.get("module") or "").strip().strip(".")
+        callable_name = str(config.get("callable") or "main").strip()
+        if not name or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_.]*", module):
+            continue
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", callable_name):
+            continue
+        applications[name] = {
+            "name": name,
+            "module": module,
+            "callable": callable_name,
+            "description": str(config.get("description") or "").strip(),
+            "component": _component_name(config.get("component")),
+            "enabled": True,
+        }
+    return applications
+
+
+def package_application(name: str) -> tuple[PackageInfo, dict[str, Any]]:
+    """Resolve one unambiguous enabled application from installed packages."""
+    clean_name = re.sub(r"[^a-z0-9_-]+", "-", str(name or "").strip().lower()).strip("-")
+    matches = [
+        (info, dict(info.applications[clean_name]))
+        for info in _PACKAGE_REGISTRY.values()
+        if info.ok and clean_name in info.applications
+    ]
+    if not matches:
+        raise ValueError(f"No installed Blacknode application is named '{name}'.")
+    if len(matches) > 1:
+        owners = ", ".join(sorted(info.name for info, _config in matches))
+        raise ValueError(f"Application '{clean_name}' is declared by multiple packages: {owners}")
+    info, config = matches[0]
+    if not config.get("enabled", True):
+        component = str(config.get("component") or "")
+        detail = f"; enable component {info.name}/{component}" if component else ""
+        raise ValueError(f"Application '{clean_name}' is disabled{detail}.")
+    return info, config
+
+
+def run_package_application(name: str, argv: list[str] | None = None) -> int:
+    """Import and invoke a package application's CLI entrypoint."""
+    info, config = package_application(name)
+    package_module = _safe_module_name(info.name)
+    module_name = f"{_PKG_MODULE_ROOT}.{package_module}.{config['module']}"
+    module = importlib.import_module(module_name)
+    entrypoint = getattr(module, str(config["callable"]), None)
+    if not callable(entrypoint):
+        raise ValueError(
+            f"Application '{name}' entrypoint {module_name}:{config['callable']} is unavailable."
+        )
+    result = entrypoint(list(argv or []))
+    return int(result) if isinstance(result, int) else 0
 
 
 def _package_layer(value: Any) -> str:
@@ -629,6 +691,7 @@ def load_package(
     info.pip_dependencies = _string_list(deps.get("pip", []))
     info.import_dependencies = _string_list(deps.get("imports", []))
     info.docker_images = _string_list(deps.get("docker", []))
+    info.applications = _package_applications(manifest.get("applications"))
 
     overrides: dict[str, bool] = {}
     if info.component_mode:
@@ -673,6 +736,12 @@ def load_package(
             info.import_dependencies = _merge_strings(info.import_dependencies, adapter["import_dependencies"])
             info.docker_images = _merge_strings(info.docker_images, adapter["docker_images"])
             info.setup_hooks = _merge_strings(info.setup_hooks, adapter["setup_hooks"])
+
+    for application in info.applications.values():
+        component_name = str(application.get("component") or "")
+        if component_name:
+            component = info.components.get(component_name)
+            application["enabled"] = bool(component and component.get("enabled"))
 
     invalid_requirements = [
         f"{component_name}: {error}"
@@ -2461,6 +2530,7 @@ __all__ = [
     "install_prerequisites",
     "install_missing_python_dependencies",
     "installed_packages",
+    "package_application",
     "package_git_status",
     "package_statuses",
     "load_package",
@@ -2468,6 +2538,7 @@ __all__ = [
     "workflow_requirement_scope",
     "package_category_colors",
     "package_template_dirs",
+    "run_package_application",
     "packages_root",
     "remove_package",
     "reset_component",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,30 @@ class CliTests(unittest.TestCase):
             self.assertIn("node_start", _event_types(result))
             self.assertIn("node_finish", _event_types(result))
 
+    def test_run_resolves_named_package_application_and_forwards_arguments(self):
+        with patch(
+            "blacknode.packages.run_package_application",
+            return_value=0,
+        ) as run_application:
+            code = main(["run", "slam", "--device", "cuda:0", "--no-open"])
+
+        self.assertEqual(code, 0)
+        run_application.assert_called_once_with(
+            "slam",
+            ["--device", "cuda:0", "--no-open"],
+        )
+
+    def test_workflow_file_rejects_named_application_arguments(self):
+        with tempfile.TemporaryDirectory() as td:
+            workflow_path = Path(td) / "workflow.json"
+            workflow_path.write_text(json.dumps(_valid_workflow()), encoding="utf-8")
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = main(["run", str(workflow_path), "--device", "cuda:0"])
+
+        self.assertEqual(code, 2)
+        self.assertIn("does not accept application arguments", stderr.getvalue())
+
     def test_run_logs_tool_call_event(self):
         with tempfile.TemporaryDirectory() as td:
             workflow_path = Path(td) / "workflow.json"

--- a/tests/test_editor_canvas_interactions.py
+++ b/tests/test_editor_canvas_interactions.py
@@ -4,14 +4,18 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_mouse_wheel_zoom_remains_active_over_canvas_nodes():
+def test_mouse_wheel_zoom_is_captured_only_by_embedded_viewer_canvas():
     app_source = (ROOT / "editor" / "src" / "App.tsx").read_text(encoding="utf-8")
+    viewer_source = (
+        ROOT / "editor" / "src" / "components" / "PointCloudViewer.tsx"
+    ).read_text(encoding="utf-8")
     explorer_source = (
         ROOT / "editor" / "src" / "components" / "ROS2GraphExplorerNode.tsx"
     ).read_text(encoding="utf-8")
 
     assert "zoomOnScroll={true}" in app_source
-    assert 'noWheelClassName="bn-canvas-wheel-suppression-disabled"' in app_source
+    assert 'noWheelClassName="bn-viewer-wheel-capture"' in app_source
+    assert 'className="bn-viewer-wheel-capture"' in viewer_source
     assert 'className="bn-ros-explorer-content nodrag nowheel"' not in explorer_source
 
 

--- a/tests/test_editor_point_cloud_viewer.py
+++ b/tests/test_editor_point_cloud_viewer.py
@@ -4,12 +4,36 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 VIEWER = ROOT / "editor" / "src" / "components" / "PointCloudViewer.tsx"
 BLACK_NODE = ROOT / "editor" / "src" / "components" / "BlackNode.tsx"
+APP = ROOT / "editor" / "src" / "App.tsx"
+INDEX_CSS = ROOT / "editor" / "src" / "index.css"
 
 
 def test_point_cloud_viewer_exposes_spatial_orientation_and_scale():
     source = VIEWER.read_text(encoding="utf-8")
 
-    assert "Robot forward" in source
+    assert "Robot forward" not in source
+    assert "const [showAxes, setShowAxes] = useState(false)" in source
+    assert "const [showFreeSpace, setShowFreeSpace] = useState(true)" in source
+    assert 'type="checkbox"' in source
+    assert "checked={showAxes}" in source
+    assert "roundedPolygonPath" in source
+    assert "'/blacknode-logo-dark.png'" in source
+    assert "const ROBOT_LOGO_ROTATION_RAD = -Math.PI / 2" in source
+    assert "const ROBOT_LOGO_SOURCE = { x: 78, y: 48, width: 352, height: 415 }" in source
+    assert "const ROBOT_LOGO_FOOTPRINT_SCALE = 0.58" in source
+    assert "const ROBOT_FOOTPRINT_VISUAL_SCALE = 0.88" in source
+    assert "const visualRobotLength = robotLength * ROBOT_FOOTPRINT_VISUAL_SCALE" in source
+    assert "const visualRobotWidth = robotWidth * ROBOT_FOOTPRINT_VISUAL_SCALE" in source
+    assert "const robotCornerRadius = clamp(shortestRobotEdge * 0.44, 3, 14)" in source
+    assert "const logoWorldScale = Math.min(" in source
+    assert "const logoWidth = ROBOT_LOGO_SOURCE.width * logoWorldScale / visualRobotWidth" in source
+    assert "const logoHeight = ROBOT_LOGO_SOURCE.height * logoWorldScale / visualRobotLength" in source
+    assert "(forwardUnit[0] - sensorScreen[0]) * visualRobotLength" in source
+    assert "(lateralUnit[0] - sensorScreen[0]) * visualRobotWidth" in source
+    assert "context.rotate(ROBOT_LOGO_ROTATION_RAD)" in source
+    assert "context.rotate(-robotHeadingYaw" not in source
+    assert "projectedHeading" not in source
+    assert "rgba(30, 199, 220, 0.3)" in source
     assert "robotHeadingYaw" in source
     assert "robotCorners" in source
     assert "finite(parsed.robot?.length_m, 0.25)" in source
@@ -26,24 +50,105 @@ def test_point_cloud_viewer_exposes_spatial_orientation_and_scale():
     assert "scanCoverageDeg" in source
     assert "360° scan" in source
     assert "sequenceRef" not in source
-    assert "counterclockwisePoints" in source
+    assert "sweepOrderedPoints" in source
+    assert "parsed.sequence, replayDurationMs" in source
+    assert "Math.max(scanPeriodMs, 700)" in source
+    assert "replayInProgress" in source
+    assert "paced replay" in source
+    assert "Warp occupancy" in source
+    assert "fixed free-floor cells" in source
+    assert "occupied wall cells" in source
+    assert "unknown map extent" in source
+    assert "occupied_points" in source
+    assert "gl.TRIANGLES" in source
+    assert "occupiedCellCount" in source
+    assert "WARP MAP · FILLING" in source
+    assert "WARP MAP · FROZEN" in source
+    assert "decodeOccupancyTexture" in source
+    assert "u2-base64" in source
+    assert "gl.LUMINANCE" in source
+    assert "gl.NEAREST" in source
+    assert "GPU map texture · all cells" in source
+    assert "occupancyEncodeMs" in source
+    assert "Warp match" in source
+    assert "matching_kernel_ms" in source
+    assert "fixed map grid" in source
+    assert "#72ff9d" in source
+    assert ") % 1" not in source
     assert "real_scan_pulse" not in source
     assert "Accumulate:" in source
+    assert "uniform float u_show_free" in source
+    assert "u_show_free < 0.5" in source
+    assert "vec3(0.18, 0.68, 0.36)" in source
+    assert "Floor: {showFreeSpace ? 'On' : 'Off'}" in source
+    assert "const visibleFloorPoints = useMemo(" in source
+    assert "const occupancyCanvasRef = useRef<HTMLCanvasElement | null>(null)" in source
+    assert "const occupancyRasterRef = useRef<{" in source
+    assert "const distanceMix = clamp(Math.hypot(worldX - sensor.x, worldY - sensor.y) / gradientDistance, 0, 1)" in source
+    assert "Math.max(viewport.width, viewport.height) / Math.max(1, pixelsPerMeter) * 0.55" in source
+    assert "image.data[offset + 1] = Math.round(181 + (108 - 181) * smoothMix)" in source
+    assert "image.data[offset + 2] = Math.round(108 + (190 - 108) * smoothMix)" in source
+    assert "image.data[offset + 3] = Math.round(115 + (80 - 115) * smoothMix)" in source
+    assert "context.globalCompositeOperation = 'screen'" in source
+    assert "context.drawImage(raster.canvas, 0, 0)" in source
+    assert "canvas.getContext('webgl', { antialias: true, alpha: true })" in source
+    assert "gl.clearColor(0, 0, 0, 0)" in source
+    assert "position: 'absolute', inset: 0, zIndex: 0" in source
+    assert "position: 'relative', zIndex: 1" in source
 
 
 def test_point_cloud_viewer_has_direct_camera_navigation():
     source = VIEWER.read_text(encoding="utf-8")
 
     assert "onWheel" in source
+    assert 'className="bn-viewer-wheel-capture"' in source
     assert "onPointerMove" in source
-    assert "drag orbit" in source
-    assert "Shift/right-drag pan" in source
-    assert "double-click fit" in source
+    assert "left-drag pan" in source
+    assert "right-drag orbit" in source
+    assert "middle-drag pan" in source
+    assert "double-click reset" in source
     assert "Orbit left" in source
     assert "Orbit right" in source
     assert "Tilt camera up" in source
     assert "pitch:" in source
     assert "onClear" in source
+    assert "clearViewRadiusFloorRef" in source
+    assert "const viewRadius = Math.max(automaticViewRadius, clearViewRadiusFloorRef.current)" in source
+    assert "onDoubleClick={resetCamera}" in source
+    assert "const ROBOT_FIT_RADIUS_MULTIPLIER = 1.65" in source
+    assert "const MAX_CAMERA_ZOOM = 120" in source
+    assert "const TOP_VIEW_YAW = Math.PI / 2" in source
+    assert "yaw: TOP_VIEW_YAW" in source
+    assert "pitch: 0" in source
+    assert "const initialResetPendingRef = useRef(true)" in source
+    assert "initialResetPendingRef.current = false" in source
+    assert "resetCamera()" in source
+    assert "const focusRadius = Math.max(0.35" in source
+    assert "const resetYaw = TOP_VIEW_YAW - robotHeadingYaw" in source
+    assert "yaw: resetYaw" in source
+    assert "const [gridFrame, setGridFrame] = useState<GridFrame>({ x: 0, y: 0, yaw: 0 })" in source
+    assert "setGridFrame({ x: sensor.x, y: sensor.y, yaw: robotHeadingYaw })" in source
+    assert "pitch: 0" in source
+    assert "const focusedSensorX = resetYawCosine * sensor.x - resetYawSine * sensor.y" in source
+    assert "const focusedSensorY = resetYawSine * sensor.x + resetYawCosine * sensor.y" in source
+    assert "panX: -focusedSensorX * appliedPixelsPerMeter" in source
+    assert "panY: focusedSensorY * appliedPixelsPerMeter" in source
+    assert 'title="Top view with world +X (red axis) pointing up"' in source
+    assert 'title="Capture and align the grid at the current robot pose, then keep the grid and map fixed"' in source
+    assert ">Reset</button>" in source
+    assert "const ROBOT_LOGO_ROTATION_RAD = -Math.PI / 2" in source
+    assert "const gridFrameToScreen = (forward: number, lateral: number, z: number)" in source
+    assert "gridFrame.x + gridHeadingCosine * forward - gridHeadingSine * lateral" in source
+    assert "const [x1, y1] = gridFrameToScreen(value, -reach, 0)" in source
+    assert "const [x3, y3] = gridFrameToScreen(-reach, value, 0)" in source
+    assert 'title="Show fixed map X, Y, and Z axes with metric tick labels"' in source
+    assert "event.button === 2 ? 'rotate' : 'pan'" in source
+    assert "event.preventDefault()" in source
+    assert "event.stopPropagation()" in source
+    assert "setSceneCopyMenu" not in source
+    assert "Viewer value menu" not in source
+    assert "copyTextToClipboard" not in source
+    assert "if (event.button === 2) return" not in source
 
 
 def test_point_cloud_viewer_exposes_accumulation_control():
@@ -51,16 +156,107 @@ def test_point_cloud_viewer_exposes_accumulation_control():
 
     assert "onToggleViewerAccumulation" in source
     assert "viewerHistoryPaused ? 'resume' : 'pause'" in source
-    assert "await updateParam(id, 'action', 'status')" in source
+    assert "await controlNode(id, 'clear')" in source
+    assert "await controlNode(id, 'stop')" in source
+    assert "await controlNode(id, viewerHistoryPaused ? 'resume' : 'pause')" in source
+    assert "await updateParam(id, 'action', 'clear')" not in source
     assert "data.type === 'Viewer' || data.type === 'SLAM'" in source
-    assert "optimized trajectory" in VIEWER.read_text(encoding="utf-8")
-    assert "loop closure" in VIEWER.read_text(encoding="utf-8")
+    assert "optimized trajectory" not in VIEWER.read_text(encoding="utf-8")
+    assert "if (trajectory.length > 1)" not in VIEWER.read_text(encoding="utf-8")
+    assert "rgba(224, 105, 255, 0.9)" not in VIEWER.read_text(encoding="utf-8")
+    assert "deskew on" in VIEWER.read_text(encoding="utf-8")
+    assert "uncertain scan match rejected" in VIEWER.read_text(encoding="utf-8")
+    assert "stationary odometry lock" in VIEWER.read_text(encoding="utf-8")
+    assert "large pose correction smoothed across scans" in VIEWER.read_text(encoding="utf-8")
+    assert "uncertain keyframe excluded" in VIEWER.read_text(encoding="utf-8")
+
+
+def test_point_cloud_viewer_fills_resized_node_in_both_dimensions():
+    viewer_source = VIEWER.read_text(encoding="utf-8")
+    node_source = BLACK_NODE.read_text(encoding="utf-8")
+
+    assert 'className="bn-node-parameter-area"' in node_source
+    assert "The viewer is a direct flex child" in node_source
+    assert "margin: '7px 9px 8px'" in viewer_source
+    assert "width: 'calc(100% - 18px)'" in viewer_source
+    assert "flex: '1 1 auto'" in viewer_source
+    assert "minHeight: 0" in viewer_source
+    assert "flex: '1 1 auto'" in viewer_source
+    assert "minHeight: 80" in viewer_source
+    assert "flexWrap: 'wrap'" in viewer_source
+    assert "minWidth={isViewer ? 360 : 160}" in node_source
+    assert "minHeight={isViewer ? 300 : 60}" in node_source
+    assert "display: isViewer ? 'none' : 'flex'" in node_source
+
+
+def test_viewer_ports_are_compact_and_new_viewers_start_square():
+    node_source = BLACK_NODE.read_text(encoding="utf-8")
+    viewer_source = VIEWER.read_text(encoding="utf-8")
+    styles = INDEX_CSS.read_text(encoding="utf-8")
+    store = (ROOT / "editor" / "src" / "store.ts").read_text(encoding="utf-8")
+
+    assert "function ViewerInputStrip" in node_source
+    assert 'className="bn-viewer-input-strip"' in node_source
+    assert "position={Position.Left}" in node_source
+    assert "ports={visibleInputs}" in node_source
+    assert "inputRail={(" in node_source
+    assert "inputRail?: ReactNode" in viewer_source
+    assert "{inputRail}" in viewer_source
+    assert "data-bn-viewer-canvas-region" in viewer_source
+    assert "el.querySelector('[data-bn-viewer-canvas-region]')" in node_source
+    assert "if (viewerRegion) observer.observe(viewerRegion)" in node_source
+    assert "requestAnimationFrame(() => updateNodeInternals(id))" in node_source
+    assert 'className="bn-viewer-hidden-output-anchors"' in node_source
+    assert "opacity: 0, pointerEvents: 'none'" in node_source
+    assert "!isViewer && nodeStats.length > 0" in node_source
+    assert ".bn-viewer-input-strip" in styles
+    assert ".bn-viewer-input-anchor .react-flow__handle" in styles
+    assert "flex-direction: column" in styles
+    assert "position: absolute" in styles
+    assert "top: 12px" in styles
+    assert "left: -10px" in styles
+    assert "left: -5px" in styles
+    assert "margin-top: 0" in styles
+    assert "border-radius: 3px !important" in styles
+    assert "meta.type === 'Viewer' || meta.type === 'SLAM'" in store
+    assert "style: { width: 720, height: 720 }" in store
 
 
 def test_point_cloud_viewer_draws_current_scan_when_map_is_empty():
     source = VIEWER.read_text(encoding="utf-8")
 
-    assert "() => [...points, ...currentPoints]" in source
+    assert "() => [...visibleFloorPoints, ...occupiedPoints, ...points, ...currentPoints]" in source
     assert "currentColors[currentIndex]" in source
-    assert "if (renderedPoints.length === 0) return" in source
+    assert "if (vertexCount === 0) return" in source
     assert "Live scan; map is empty" in source
+
+
+def test_go_live_button_becomes_stop_live_for_viewer_and_slam_sessions():
+    source = APP.read_text(encoding="utf-8")
+    styles = INDEX_CSS.read_text(encoding="utf-8")
+    store = (ROOT / "editor" / "src" / "store.ts").read_text(encoding="utf-8")
+
+    assert "const [activeRunMode, setActiveRunMode]" in source
+    assert "const visualizerRunCount" in source
+    assert "const liveRunActive" in source
+    assert "liveRunActive ? '■ Stop live' : '● Go live'" in source
+    assert "onceRunActive ? '■ Stop once' : '▶ Run once'" in source
+    assert """className="bn-top-button bn-top-run-button"
+                onClick={() => (onceRunActive ? stopCook() : void handleRunGraph('once'))}""" in source
+    assert """className={`bn-top-button bn-top-run-button bn-top-live-button${liveRunActive ? ' is-stop-live' : ' is-start-live'}`}
+                onClick={() => (liveRunActive ? void handleStopRuntime() : void handleRunGraph('live'))}""" in source
+    assert 'className="bn-top-button bn-top-reset-button"' in source
+    assert ".bn-top-live-button.is-start-live" in styles
+    assert "background: var(--ok)" in styles
+    assert ".bn-top-live-button.is-stop-live" in styles
+    assert "background: var(--err)" in styles
+    assert ".bn-top-reset-button" in styles
+    assert "background: var(--warn-soft)" in styles
+    assert "n.data.type === 'Viewer' ||" in store
+    assert "n.data.type === 'SLAM'" in store
+    assert "(node.data.type === 'Viewer' || node.data.type === 'SLAM')" in store
+    assert "if (data.type === 'Viewer' || data.type === 'SLAM')" in store
+    assert "report: `${data.type} stopped by workflow control`" in store
+    assert "running: false" in store
+    assert "live: false" in store
+    assert "status: { ...status, state: 'stopped' }" in store

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -610,6 +610,71 @@ class EditorRuntimeTests(unittest.TestCase):
             for key in [key for key in server._session.graph._cache if key[0] == node_id]:
                 server._session.graph._cache.pop(key, None)
 
+    def test_viewer_and_slam_controls_update_live_sessions_without_cooking_graph(self):
+        viewer_id = "viewer-direct-control-test"
+        slam_id = "slam-direct-control-test"
+        server._session.node_meta[viewer_id] = {
+            "id": viewer_id, "type": "Viewer", "params": {"viewer_id": "viewer-live"},
+        }
+        server._session.node_meta[slam_id] = {
+            "id": slam_id, "type": "SLAM", "params": {"slam_id": "slam-live"},
+        }
+        server._session.graph._dirty.update({viewer_id, slam_id})
+        calls = []
+
+        def runtime_callable(label, _module, function_name):
+            def control(runtime_id, *args):
+                calls.append((label, function_name, runtime_id, *args))
+                paused = function_name in {"pause_viewer", "clear_viewer"} or (
+                    function_name == "set_mapping" and args == (False,)
+                )
+                return {
+                    "scene": {"history_paused": paused},
+                    "status": {"mapping": not paused},
+                    "report": f"{runtime_id}:{function_name}",
+                }
+            return control
+
+        try:
+            with (
+                patch.object(server, "_runtime_callable", side_effect=runtime_callable),
+                patch.object(server, "_prepare_cook") as prepare_cook,
+            ):
+                client = TestClient(server.app)
+                viewer_clear = client.post(f"/nodes/{viewer_id}/control", json={"action": "clear"})
+                viewer_resume = client.post(f"/nodes/{viewer_id}/control", json={"action": "resume"})
+                slam_pause = client.post(f"/nodes/{slam_id}/control", json={"action": "pause"})
+                slam_resume = client.post(f"/nodes/{slam_id}/control", json={"action": "resume"})
+                slam_stop = client.post(f"/nodes/{slam_id}/control", json={"action": "stop"})
+
+            self.assertEqual(viewer_clear.status_code, 200)
+            self.assertTrue(viewer_clear.json()["outputs"]["scene"]["history_paused"])
+            self.assertEqual(viewer_resume.status_code, 200)
+            self.assertEqual(slam_pause.status_code, 200)
+            self.assertFalse(slam_pause.json()["outputs"]["status"]["mapping"])
+            self.assertEqual(slam_resume.status_code, 200)
+            self.assertEqual(slam_stop.status_code, 200)
+            self.assertEqual(calls, [
+                ("viewer", "clear_viewer", "viewer-live"),
+                ("viewer", "resume_viewer", "viewer-live"),
+                ("slam", "set_mapping", "slam-live", False),
+                ("slam", "set_mapping", "slam-live", True),
+                ("slam", "stop_slam", "slam-live"),
+            ])
+            self.assertNotIn(viewer_id, server._session.graph._dirty)
+            self.assertNotIn(slam_id, server._session.graph._dirty)
+            self.assertEqual(
+                server._session.graph._cache[(slam_id, "report")],
+                "slam-live:stop_slam",
+            )
+            prepare_cook.assert_not_called()
+        finally:
+            for node_id in (viewer_id, slam_id):
+                server._session.node_meta.pop(node_id, None)
+                server._session.graph._dirty.discard(node_id)
+                for key in [key for key in server._session.graph._cache if key[0] == node_id]:
+                    server._session.graph._cache.pop(key, None)
+
     def test_trajectory_smoother_control_recomputes_only_smoother(self):
         node_id = "smoother-control-test"
         server._session.node_meta[node_id] = {

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -22,6 +22,7 @@ from blacknode.packages import (
     load_package,
     load_workflow_requirements,
     package_template_dirs,
+    package_application,
     remove_package,
     reset_component,
     set_component_enabled,
@@ -78,6 +79,30 @@ def test_folder_package_registers_nodes(tmp_path):
     assert _PACKAGE_REGISTRY["bn-test-pkg"].categories["Test Pkg"] == "#123456"
     # node runs through the registry like any built-in
     assert _NODE_REGISTRY["_PkgProbe"]({"text": "hi"}) == {"out": "hi"}
+
+
+def test_folder_package_declares_named_application(tmp_path):
+    pkg = _write_package(
+        tmp_path,
+        package_metadata='''
+        [applications.inspect]
+        module = "application"
+        callable = "main"
+        description = "Inspect this package"
+        ''',
+    )
+    (pkg / "nodes" / "application.py").write_text(
+        "def main(argv):\n    return len(argv)\n",
+        encoding="utf-8",
+    )
+
+    info = load_package(pkg)
+    owner, application = package_application("inspect")
+
+    assert owner is info
+    assert application["module"] == "application"
+    assert application["callable"] == "main"
+    assert application["enabled"] is True
 
 
 def test_folder_package_exposes_layer_and_component_catalog(tmp_path):


### PR DESCRIPTION
## What changed
- polished the embedded SLAM viewer, controls, resizing, camera behavior, occupancy presentation, and live-state handling
- added generic named package applications to `blacknode run`
- added the shared standalone SLAM viewer build entry
- updated package application documentation and tests
- updated PostCSS lockfile security resolution

## Why
This lets a managed Jetson run a packaged SLAM application while preserving the same viewer component and controls used in the Blacknode editor.

## Validation
- `python -m unittest discover -s tests`: 536 passed, 8 skipped
- focused CLI/package/editor tests passed
- `npm run build` passed
- `npm run build:slam-viewer` passed