### PR TITLE
Visualize Warp dynamic occupancy

### DIFF
--- a/editor/src/components/PointCloudViewer.tsx
+++ b/editor/src/components/PointCloudViewer.tsx
@@ -17,6 +17,9 @@ interface ViewerScene {
   particles?: unknown
   particle_yaws?: unknown
   particle_scores?: unknown
+  dynamic_points?: unknown
+  dynamic_velocities?: unknown
+  dynamic_scores?: unknown
   point_count?: number
   current_point_count?: number
   accumulated_scan_count?: number
@@ -96,6 +99,27 @@ interface ViewerScene {
     best_score?: number
     effective_sample_size?: number
     uncertainty?: { x_m?: number; y_m?: number; yaw_rad?: number }
+  }
+  dynamic_occupancy?: {
+    state?: string
+    backend?: string
+    device?: string
+    input_points?: number
+    reference_points?: number
+    dynamic_points?: number
+    display_points?: number
+    pipeline_ms?: number
+    cpu_ms?: number
+    speedup?: number
+    max_error?: number
+    comparison_limited?: boolean
+    dt_s?: number
+    stable_radius_m?: number
+    tracking_radius_m?: number
+    minimum_speed_mps?: number
+    mean_speed_mps?: number
+    max_speed_mps?: number
+    trail_seconds?: number
   }
   animation?: {
     enabled?: boolean
@@ -427,6 +451,12 @@ export default function PointCloudViewer({
   const particleScores = useMemo(
     () => Array.isArray(parsed.particle_scores) ? parsed.particle_scores.map(value => clamp(finite(value), 0, 1)) : [],
     [parsed.particle_scores],
+  )
+  const dynamicPoints = useMemo(() => numericRows(parsed.dynamic_points), [parsed.dynamic_points])
+  const dynamicVelocities = useMemo(() => numericRows(parsed.dynamic_velocities), [parsed.dynamic_velocities])
+  const dynamicScores = useMemo(
+    () => Array.isArray(parsed.dynamic_scores) ? parsed.dynamic_scores.map(value => clamp(finite(value), 0, 1)) : [],
+    [parsed.dynamic_scores],
   )
   const visibleFloorPoints = useMemo(
     () => showFreeSpace ? floorPoints : [],
@@ -1014,6 +1044,45 @@ export default function PointCloudViewer({
       }
     }
 
+    if (dynamicPoints.length > 0) {
+      const trailSeconds = clamp(finite(parsed.dynamic_occupancy?.trail_seconds, 0.35), 0.05, 2)
+      context.save()
+      context.globalCompositeOperation = 'screen'
+      for (let index = 0; index < dynamicPoints.length; index += 1) {
+        const point = dynamicPoints[index]
+        const velocity = dynamicVelocities[index] ?? [0, 0, 0]
+        const score = dynamicScores[index] ?? 0
+        const projected = worldToScreen(
+          point[0], point[1], finite(point[2]), viewport, camera, pixelsPerMeter,
+        )
+        const previous = worldToScreen(
+          point[0] - finite(velocity[0]) * trailSeconds,
+          point[1] - finite(velocity[1]) * trailSeconds,
+          finite(point[2]) - finite(velocity[2]) * trailSeconds,
+          viewport,
+          camera,
+          pixelsPerMeter,
+        )
+        const red = Math.round(246 + score * 9)
+        const green = Math.round(183 - score * 103)
+        const blue = Math.round(76 + score * 102)
+        const color = `${red}, ${green}, ${blue}`
+        context.strokeStyle = `rgba(${color}, ${0.3 + score * 0.55})`
+        context.lineWidth = 1.2 + score * 1.8
+        context.shadowColor = `rgba(${color}, 0.65)`
+        context.shadowBlur = 5 + score * 7
+        context.beginPath()
+        context.moveTo(previous[0], previous[1])
+        context.lineTo(projected[0], projected[1])
+        context.stroke()
+        context.fillStyle = `rgba(${color}, ${0.62 + score * 0.35})`
+        context.beginPath()
+        context.arc(projected[0], projected[1], 2.4 + score * 2.6, 0, Math.PI * 2)
+        context.fill()
+      }
+      context.restore()
+    }
+
     const robotLength = clamp(finite(parsed.robot?.length_m, 0.25), 0.02, 5)
     const robotWidth = clamp(finite(parsed.robot?.width_m, 0.22), 0.02, 5)
     const visualRobotLength = robotLength * ROBOT_FOOTPRINT_VISUAL_SCALE
@@ -1131,9 +1200,13 @@ export default function PointCloudViewer({
     animationPhase,
     camera,
     currentPoints,
+    dynamicPoints,
+    dynamicScores,
+    dynamicVelocities,
     gridFrame,
     parsed.animation?.ray_trail_count,
     parsed.animation?.show_rays,
+    parsed.dynamic_occupancy?.trail_seconds,
     particleScores,
     particleYaws,
     particles,
@@ -1331,6 +1404,19 @@ export default function PointCloudViewer({
                 : 'WARP MAP · READY'}
           </div>
         )}
+        {parsed.dynamic_occupancy?.backend === 'warp-hash-grid' && (
+          <div style={{
+            position: 'absolute', zIndex: 3, top: 39, right: 9, display: 'flex', alignItems: 'center', gap: 6,
+            padding: '4px 7px', borderRadius: 5, background: 'rgba(18, 8, 12, 0.82)',
+            border: '1px solid rgba(255, 127, 101, 0.48)', color: '#ffae82',
+            fontFamily: 'var(--font-mono)', fontSize: 11, pointerEvents: 'none',
+          }}>
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: dynamicPoints.length ? '#ff6f91' : '#8b685f' }} />
+            {parsed.dynamic_occupancy.state === 'warming'
+              ? 'HASHGRID MOTION · WARMING'
+              : `HASHGRID MOTION · ${Number(parsed.dynamic_occupancy.dynamic_points ?? 0).toLocaleString()} MOVING`}
+          </div>
+        )}
         <div style={{
           position: 'absolute', zIndex: 3, right: 8, bottom: 7, padding: '3px 6px', borderRadius: 4,
           background: 'rgba(3, 10, 16, 0.72)', color: 'rgba(217, 232, 241, 0.74)',
@@ -1368,6 +1454,12 @@ export default function PointCloudViewer({
             {finite(parsed.localization.speedup) > 0 ? ` · ${finite(parsed.localization.speedup).toFixed(1)}× CPU` : ''}
           </span>
         )}
+        {parsed.dynamic_occupancy?.state === 'ready' && (
+          <span style={{ color: '#ffae82' }}>
+            Warp HashGrid {Number(parsed.dynamic_occupancy.input_points ?? 0).toLocaleString()} queries · {Number(parsed.dynamic_occupancy.dynamic_points ?? 0).toLocaleString()} moving · {finite(parsed.dynamic_occupancy.pipeline_ms).toFixed(3)} ms · mean {finite(parsed.dynamic_occupancy.mean_speed_mps).toFixed(2)} m/s
+            {finite(parsed.dynamic_occupancy.speedup) > 0 ? ` · ${finite(parsed.dynamic_occupancy.speedup).toFixed(1)}× CPU` : ''}
+          </span>
+        )}
         <span>{scanCoverageDeg >= 359.5 ? `360° scan · ${clockwiseScan ? 'CW' : 'CCW'} paced replay` : `${scanCoverageDeg.toFixed(1)}° scan · ${clockwiseScan ? 'CW' : 'CCW'} paced replay`}</span>
         <span>3D orbit · LaserScan lies on XY plane</span>
       </div>
@@ -1384,6 +1476,7 @@ export default function PointCloudViewer({
         {showFreeSpace && freeCellCount > 0 && <span style={{ color: '#4fc07a' }}>■ {freeCellCount.toLocaleString()} fixed free-floor cells</span>}
         {occupiedCellCount > 0 && <span style={{ color: '#c7e0ef' }}>■ {occupiedCellCount.toLocaleString()} occupied wall cells</span>}
         {particles.length > 0 && <span style={{ color: '#9df0c2' }}>● GPU pose hypotheses · purple low / green high confidence</span>}
+        {dynamicPoints.length > 0 && <span style={{ color: '#ff8b79' }}>● moving returns · amber/magenta velocity trails</span>}
         {showAxes && <span>map <b style={{ color: '#ff6b6b' }}>X</b> / <b style={{ color: '#53e091' }}>Y</b> / <b style={{ color: '#539aff' }}>Z</b> axes</span>}
         {parsed.history_registered === true && <span style={{ color: '#74e7a5' }}>pose-registered history · {parsed.pose_source || 'pose stream'}</span>}
         {Array.isArray(parsed.registration?.tf_path) && parsed.registration.tf_path.length > 1 && (

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -358,6 +358,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                         "Viewer",
                         "SLAM",
                         "WarpParticleLocalization",
+                        "WarpDynamicOccupancy",
                         "WarpLaserScanFilter",
                         "WarpLiDARViewer",
                         "WarpSLAMDiscoveryViewer"
@@ -392,6 +393,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "Viewer",
                 "SLAM",
                 "WarpParticleLocalization",
+                "WarpDynamicOccupancy",
                 "WarpLaserScanFilter",
                 "WarpLiDARViewer",
                 "WarpSLAMDiscoveryViewer"

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -136,6 +136,7 @@ def test_core_index_maps_official_node_types_to_git_packages():
         "Viewer",
         "SLAM",
         "WarpParticleLocalization",
+        "WarpDynamicOccupancy",
         "WarpLaserScanFilter",
         "WarpLiDARViewer",
         "WarpSLAMDiscoveryViewer",
@@ -149,6 +150,7 @@ def test_core_index_maps_official_node_types_to_git_packages():
     ]
     assert payload["nodes"]["LiDARROS2Scan"]["package"] == "blacknode-perception"
     assert payload["nodes"]["WarpParticleLocalization"]["package"] == "blacknode-cuda"
+    assert payload["nodes"]["WarpDynamicOccupancy"]["package"] == "blacknode-cuda"
     drivers = payload["packages"]["blacknode-drivers"]
     assert drivers["layer"] == "drivers"
     assert drivers["components"]["feetech"]["default"] is True


### PR DESCRIPTION
## What changed

- renders moving returns with confidence-colored amber-to-magenta velocity trails
- shows Warp HashGrid workload, motion count, timing, and speed metrics
- registers `WarpDynamicOccupancy` in the official CUDA package catalog

## Why

The next sensor-compute showcase needs a graph-visible GPU stage whose live results are understandable directly in the SLAM viewer.

## Validation

- `npm run build`
- `python -m pytest tests -q` — 738 passed, 8 skipped, 59 subtests passed
- `python -m pytest tests/test_package_index.py -q` — 9 passed

This is an editor/catalog change. It does not require a managed Runtime package release.