### PR TITLE
Align Runtime releases with device update controls

### DIFF
--- a/.agents/skills/blacknode-development/SKILL.md
+++ b/.agents/skills/blacknode-development/SKILL.md
@@ -110,6 +110,15 @@ blacknode-example/
 - Add `metadata.required_packages` to templates that use package nodes.
 - Keep each package independently testable, versioned, documented, and
   publishable from its own Git repository.
+- Check the real managed-device update surface before declaring delivery
+  complete. A package-only release is sufficient only when the operator can use
+  that package's **Update** action or **Update all**. When the operator's
+  available or expected path is **Runtime → Update**, publish a Runtime patch
+  release even if Runtime service code is unchanged; that visible update
+  refreshes installed extension packages. Merge the extension first, merge the
+  Runtime bump next, then pin merged Runtime and required core commits in
+  `editor-server/device-runtime-sources.lock.json`. Never direct an operator to
+  an extension-package control they do not have.
 - Add scoped `AGENTS.md` safety and test instructions. Create a package-specific
   skill only when users need a distinct, substantial operational workflow that
   cannot be routed clearly through `blacknode-workflow`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,8 @@
 
 <!-- Check exactly one. See AGENTS.md: Managed Runtime release decision. -->
 
-- [ ] Runtime release not required; this change does not alter code delivered in the managed-device Runtime bundle.
-- [ ] Runtime release completed; `blacknode-runtime` was bumped and merged, and `editor-server/device-runtime-sources.lock.json` pins the merged Runtime and core commits.
+- [ ] Runtime release not required; the actual operator surface can deliver this through its package card or **Update all**.
+- [ ] Runtime release completed; the device bundle changed or **Runtime → Update** is the operator's delivery path, `blacknode-runtime` was bumped and merged, and `editor-server/device-runtime-sources.lock.json` pins merged commits.
 
 ## Related issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ the decision in the pull request and final handoff.
 |---|---|---|
 | `blacknode-runtime` service, manifest, API, installer, supervision, or package-sync behavior | Yes | Bump and merge `blacknode-runtime`, then update `editor-server/device-runtime-sources.lock.json` |
 | Core Python or CLI behavior that must be present under `~/Blacknode/devices/<instance>/core`, including support for a new package application such as `blacknode run <app>` | Yes | Merge the core behavior, bump and merge `blacknode-runtime`, then pin both merged commits in the device source lock |
-| Extension-package implementation used through the existing package loader and sync contract | No | Bump and merge that package; make the workflow declare it in `metadata.required_packages` |
+| Extension-package implementation used through the existing package loader and sync contract | Operator-surface dependent | Bump and merge that package. If the operator can update it through its package card or **Update all**, no Runtime bump is needed. If the operator's available or expected action is **Runtime → Update**, also publish a Runtime patch release so that action appears and refreshes installed extensions. |
 | Editor-only UI, editor-server orchestration that does not alter the device bundle, workflow/template data, tests, or documentation | No | Release through the owning core or package repository only |
 
 Use this sequence when the answer is **Yes**:
@@ -72,8 +72,11 @@ Use this sequence when the answer is **Yes**:
 
 Do not claim that all work is released until every independently versioned
 repository and the managed-device source lock required by the change are
-merged. Package-only updates remain independently deployable and do not force a
-Runtime version bump.
+merged. Never decide delivery from code ownership alone: verify the update
+control the operator can actually use. Do not tell an operator to update an
+extension-package card they do not have. A package-only release is complete
+only when the real operator surface can deliver it; otherwise use a Runtime
+patch release as the visible update trigger and pin it through the source lock.
 
 ## Operator workflow
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -51,6 +51,13 @@ remote, press **Check updates**, then use **Update all** or the **Update**
 action on the Runtime or Hardware package card. Use the package card's
 **Restart** button when that service needs to restart.
 
+Match release instructions to the controls the operator actually has. When an
+installed workflow package has no visible package-card update and the operator
+uses **Runtime → Update**, publish a Runtime patch release as the update trigger;
+the Runtime update flow refreshes installed workflow packages before reloading
+the service. Do not direct the operator to an unavailable extension-package
+button.
+
 For a new remote computer that should remain unchanged, open **Add device →
 Remote SSH**, confirm its host key, and use **Confirm and inspect**. Review the
 read-only system and ROS 2 capability report, then choose **Close — device

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -85,6 +85,12 @@ package card. **Update all** refreshes Runtime, every extension package already
 installed in that Runtime, and Hardware. The package cards also provide
 **Restart** for restarting Runtime or Hardware individually.
 
+Some managed-device layouts expose Runtime as the only actionable workflow
+software card. In that layout, **Runtime → Update** also refreshes every
+installed extension package after updating Runtime. Device-facing package
+releases that must arrive through this operator path publish a Runtime patch
+version so the editor presents an available update.
+
 Blacknode stops active deployments, disarms attached robots, updates the
 selected services and clean package checkouts, reloads Runtime, and verifies
 the resulting package manifest. Deployments remain stopped and disarmed until

--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,10 +3,10 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "5e713f6f56fc0651cd30182a6a4c69176ce39257"
+    "commit": "569ced3980a3a66f41970c6b4757b05f2807d305"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "dbe6664099a0b822ff2860c395b3d36a2f68be70"
+    "commit": "be76528a68fd876ace3ae81311e79289429fe7a2"
   }
 }

--- a/skills/blacknode-development/SKILL.md
+++ b/skills/blacknode-development/SKILL.md
@@ -110,6 +110,15 @@ blacknode-example/
 - Add `metadata.required_packages` to templates that use package nodes.
 - Keep each package independently testable, versioned, documented, and
   publishable from its own Git repository.
+- Check the real managed-device update surface before declaring delivery
+  complete. A package-only release is sufficient only when the operator can use
+  that package's **Update** action or **Update all**. When the operator's
+  available or expected path is **Runtime → Update**, publish a Runtime patch
+  release even if Runtime service code is unchanged; that visible update
+  refreshes installed extension packages. Merge the extension first, merge the
+  Runtime bump next, then pin merged Runtime and required core commits in
+  `editor-server/device-runtime-sources.lock.json`. Never direct an operator to
+  an extension-package control they do not have.
 - Add scoped `AGENTS.md` safety and test instructions. Create a package-specific
   skill only when users need a distinct, substantial operational workflow that
   cannot be routed clearly through `blacknode-workflow`.

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -82,6 +82,22 @@ class AgentSkillTests(unittest.TestCase):
         self.assertIn("primary operator surface", agent_instructions)
         self.assertIn("fallback path", agent_instructions)
 
+    def test_managed_device_delivery_uses_the_operator_actual_update_surface(self):
+        agent_instructions = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        skill_paths = [
+            ROOT / "skills" / "blacknode-development" / "SKILL.md",
+            ROOT / ".agents" / "skills" / "blacknode-development" / "SKILL.md",
+        ]
+
+        self.assertIn("Never decide delivery from code ownership alone", agent_instructions)
+        self.assertIn("Do not tell an operator to update an", agent_instructions)
+        for path in skill_paths:
+            with self.subTest(path=str(path)):
+                text = path.read_text(encoding="utf-8")
+                self.assertIn("real managed-device update surface", text)
+                self.assertIn("Runtime → Update", text)
+                self.assertIn("Never direct an operator", text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- make managed-device release decisions follow the update controls the operator actually has
- require a Runtime patch when **Runtime → Update** is the delivery path for an extension release
- document that Runtime update refreshes installed extension packages
- pin merged `blacknode-runtime` 0.4.4 and the required merged core commit
- add a regression test covering the persistent AGENTS/skill guidance

## Verification

- `python -m pytest tests -q` — 739 passed, 8 skipped, 61 subtests passed
- both Blacknode development skill copies pass `quick_validate.py`
- focused managed Runtime update tests — 3 passed
- `blacknode-runtime` tests with core/runtime on `PYTHONPATH` — 38 passed, 2 skipped

## Managed Runtime release

- [ ] Runtime release not required; the actual operator surface can deliver this through its package card or **Update all**.
- [x] Runtime release completed; `blacknode-runtime` 0.4.4 was merged first and the device source lock pins its merged commit.