### PR TITLE
Pin Runtime 0.4.5 device sources

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,10 +3,10 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "569ced3980a3a66f41970c6b4757b05f2807d305"
+    "commit": "1d2ea577cbe01cba8b5b719b5d83d9d86695d477"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "be76528a68fd876ace3ae81311e79289429fe7a2"
+    "commit": "0afc899a0590356eb0e13670b3a8ba9ab3e29e13"
   }
 }


### PR DESCRIPTION
## Summary

- pin merged `blacknode-runtime` 0.4.5 as the managed-device update source
- pin merged Blacknode core containing the dynamic SLAM viewer stabilization
- complete delivery of `blacknode-cuda` 0.4.7 through **Runtime → Update**

## Verification

- source lock parses successfully
- focused managed-device Runtime/package-refresh tests — 3 passed
- persistent agent/release-rule tests — 4 passed, 16 subtests passed

## Managed Runtime release

- [ ] Runtime release not required; the actual operator surface can deliver this through its package card or **Update all**.
- [x] Runtime release completed; Runtime 0.4.5 is merged and this lock pins its merged commit plus the required merged core commit.