### PR TITLE
Pin managed Runtime 0.4.6 sources

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,10 +3,10 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "1d2ea577cbe01cba8b5b719b5d83d9d86695d477"
+    "commit": "d106f786baa4033aa1c53d330a59fc4d8e0b9c09"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "0afc899a0590356eb0e13670b3a8ba9ab3e29e13"
+    "commit": "6cafa7e487a937167124456b3bf62aa2a56e20d9"
   }
 }


### PR DESCRIPTION
## What does this PR do?

Pins the managed-device installer to the merged Runtime 0.4.6 and Blacknode SLAM viewer commits.

## Changes

- pin blacknode-runtime at d106f786baa4033aa1c53d330a59fc4d8e0b9c09
- pin Blacknode at 6cafa7e487a937167124456b3bf62aa2a56e20d9

## Testing

- python -m pytest tests/test_editor_devices.py tests/test_agent_skill.py -q (143 passed, 18 subtests)

## Managed-device delivery

- [ ] Runtime release not required; the actual operator surface can deliver this through its package card or **Update all**.
- [x] Runtime release completed; the device bundle changed or **Runtime → Update** is the operator's delivery path, blacknode-runtime was bumped and merged, and editor-server/device-runtime-sources.lock.json pins merged commits.

## Related issues

<!-- Closes # -->