### PR TITLE
Pin managed Runtime 0.4.7 sources

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,10 +3,10 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "d106f786baa4033aa1c53d330a59fc4d8e0b9c09"
+    "commit": "75192708d6b2246c8ff66bebdea2a79bdffbc5c4"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "6cafa7e487a937167124456b3bf62aa2a56e20d9"
+    "commit": "7bb5a302f05bd9b5c1f6dacf3a729126e1c3a94b"
   }
 }


### PR DESCRIPTION
## What does this PR do?

Pins the managed-device installer to the merged Runtime 0.4.7 and Blacknode Warp trajectory viewer/catalog commits.

## Changes

- pin blacknode-runtime at 75192708d6b2246c8ff66bebdea2a79bdffbc5c4
- pin Blacknode at 7bb5a302f05bd9b5c1f6dacf3a729126e1c3a94b

## Testing

- python -m pytest tests/test_editor_devices.py tests/test_agent_skill.py -q (143 passed, 18 subtests)

## Managed-device delivery

- [ ] Runtime release not required; the actual operator surface can deliver this through its package card or **Update all**.
- [x] Runtime release completed; the device bundle changed or **Runtime → Update** is the operator's delivery path, blacknode-runtime was bumped and merged, and editor-server/device-runtime-sources.lock.json pins merged commits.

## Related issues

<!-- Closes # -->