### PR TITLE
Add click-to-goal SLAM interaction

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -2319,8 +2319,15 @@ def control_node(node_id: str, req: NodeControlReq):
         return {"ok": True, "node_id": node_id, "outputs": outputs}
     if meta.get("type") in {"Viewer", "SLAM"}:
         action = str(req.action or "").strip().lower()
-        if action not in {"status", "clear", "pause", "resume", "stop"}:
-            raise HTTPException(400, "Viewer and SLAM direct controls support status, clear, pause, resume, or stop")
+        base_actions = {"status", "clear", "pause", "resume", "stop"}
+        if action not in base_actions and not (
+            meta.get("type") == "SLAM" and action == "set-goal"
+        ):
+            raise HTTPException(
+                400,
+                "Viewer controls support status, clear, pause, resume, or stop; "
+                "SLAM additionally supports set-goal",
+            )
         params = dict(meta.get("params") or {})
         if meta.get("type") == "Viewer":
             runtime_id = str(params.get("viewer_id") or "viewer").strip() or "viewer"
@@ -2343,15 +2350,26 @@ def control_node(node_id: str, req: NodeControlReq):
                 "pause": "set_mapping",
                 "resume": "set_mapping",
                 "stop": "stop_slam",
+                "set-goal": "set_trajectory_goal",
             }[action]
             control_fn = _runtime_callable("slam", _RUNTIME_MODULES["slam"], function_name)
             if control_fn is None:
                 raise HTTPException(503, "blacknode-cuda SLAM runtime is not loaded")
-            outputs = dict(
-                control_fn(runtime_id)
-                if action in {"status", "clear", "stop"}
-                else control_fn(runtime_id, action == "resume")
-            )
+            if action == "set-goal":
+                try:
+                    goal_x_m = float(req.payload.get("goal_x_m"))
+                    goal_y_m = float(req.payload.get("goal_y_m"))
+                except (TypeError, ValueError) as exc:
+                    raise HTTPException(400, "SLAM goal coordinates must be finite numbers") from exc
+                if not math.isfinite(goal_x_m) or not math.isfinite(goal_y_m):
+                    raise HTTPException(400, "SLAM goal coordinates must be finite numbers")
+                outputs = dict(control_fn(runtime_id, goal_x_m, goal_y_m))
+            else:
+                outputs = dict(
+                    control_fn(runtime_id)
+                    if action in {"status", "clear", "stop"}
+                    else control_fn(runtime_id, action == "resume")
+                )
         for port, value in outputs.items():
             _session.graph._cache[(node_id, port)] = value
         _session.graph._dirty.discard(node_id)

--- a/editor/src/StandaloneSlam.tsx
+++ b/editor/src/StandaloneSlam.tsx
@@ -9,7 +9,7 @@ interface SlamState {
   report?: string
 }
 
-type ControlAction = 'start' | 'clear' | 'pause' | 'resume' | 'stop'
+type ControlAction = 'start' | 'clear' | 'pause' | 'resume' | 'stop' | 'set-goal'
 
 function actionStyle(kind: 'start' | 'stop', disabled: boolean): CSSProperties {
   const active = kind === 'start' ? 'var(--ok)' : 'var(--err)'
@@ -51,11 +51,15 @@ export default function StandaloneSlam() {
     return () => window.clearInterval(timer)
   }, [refresh])
 
-  const control = useCallback(async (action: ControlAction) => {
+  const control = useCallback(async (action: ControlAction, payload: Record<string, unknown> = {}) => {
     if (pending) return
     setPending(action)
     try {
-      const response = await fetch(`/api/control/${action}`, { method: 'POST' })
+      const response = await fetch(`/api/control/${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
       if (!response.ok) throw new Error(`control returned HTTP ${response.status}`)
       setState(await response.json() as SlamState)
       setConnectionError('')
@@ -115,8 +119,10 @@ export default function StandaloneSlam() {
           scene={state.scene}
           onClear={() => { void control('clear') }}
           onAccumulationToggle={() => { void control(scene.history_paused ? 'resume' : 'pause') }}
+          onGoalSet={(x, y) => { void control('set-goal', { goal_x_m: x, goal_y_m: y }) }}
           clearPending={pending === 'clear'}
           accumulationPending={pending === 'pause' || pending === 'resume'}
+          goalPending={pending === 'set-goal'}
         />
       </section>
     </main>

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -546,6 +546,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const [viewerStopPending, setViewerStopPending] = useState(false)
   const [viewerClearPending, setViewerClearPending] = useState(false)
   const [viewerAccumulationPending, setViewerAccumulationPending] = useState(false)
+  const [viewerGoalPending, setViewerGoalPending] = useState(false)
   const [manualMovePending, setManualMovePending] = useState<null | 'release' | 'monitor' | 'hold'>(null)
   const [calibrationPending, setCalibrationPending] = useState<null | 'start' | 'pause' | 'capture_home' | 'finish' | 'cancel'>(null)
   const [episodePending, setEpisodePending] = useState<null | 'start' | 'pause' | 'resume' | 'save' | 'stop' | 'discard'>(null)
@@ -1372,6 +1373,50 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       await controlNode(id, viewerHistoryPaused ? 'resume' : 'pause')
     } finally {
       setViewerAccumulationPending(false)
+    }
+  }
+
+  const onSetSlamGoal = async (goalX: number, goalY: number) => {
+    if (viewerGoalPending || data.type !== 'SLAM') return
+    const trajectoryEdge = edges.find(edge => (
+      edge.target === id
+      && edge.targetHandle === 'trajectory_evaluation'
+      && edge.sourceHandle === 'stage'
+    ))
+    const trajectoryNode = nodes.find(node => (
+      node.id === trajectoryEdge?.source
+      && node.data.type === 'WarpTrajectoryEvaluator'
+    ))
+    if (!trajectoryNode) {
+      window.dispatchEvent(new CustomEvent('blacknode:notice', {
+        detail: {
+          kind: 'error',
+          title: 'Trajectory goal unavailable',
+          message: 'Connect WarpTrajectoryEvaluator.stage to SLAM.trajectory_evaluation, then Shift-click the map.',
+        },
+      }))
+      return
+    }
+    const goalXMetres = Number(goalX.toFixed(3))
+    const goalYMetres = Number(goalY.toFixed(3))
+    setViewerGoalPending(true)
+    try {
+      await updateParam(trajectoryNode.id, 'goal_x_m', goalXMetres)
+      await updateParam(trajectoryNode.id, 'goal_y_m', goalYMetres)
+      await controlNode(id, 'set-goal', {
+        goal_x_m: goalXMetres,
+        goal_y_m: goalYMetres,
+      })
+    } catch (err) {
+      window.dispatchEvent(new CustomEvent('blacknode:notice', {
+        detail: {
+          kind: 'error',
+          title: 'Could not set trajectory goal',
+          message: err instanceof Error ? err.message : String(err),
+        },
+      }))
+    } finally {
+      setViewerGoalPending(false)
     }
   }
 
@@ -2667,8 +2712,10 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
           )}
           onClear={() => { void onClearViewer() }}
           onAccumulationToggle={() => { void onToggleViewerAccumulation() }}
+          onGoalSet={data.type === 'SLAM' ? (x, y) => { void onSetSlamGoal(x, y) } : undefined}
           clearPending={viewerClearPending}
           accumulationPending={viewerAccumulationPending}
+          goalPending={viewerGoalPending}
         />
       )}
 

--- a/editor/src/components/PointCloudViewer.tsx
+++ b/editor/src/components/PointCloudViewer.tsx
@@ -379,6 +379,27 @@ function worldToScreen(
   ]
 }
 
+function screenToWorldPlane(
+  screenX: number,
+  screenY: number,
+  viewport: Viewport,
+  camera: CameraState,
+  pixelsPerMeter: number,
+): [number, number] {
+  const yawX = (screenX - viewport.width / 2 - camera.panX) / pixelsPerMeter
+  const pitchCosine = Math.cos(camera.pitch)
+  const safePitchCosine = Math.abs(pitchCosine) < 0.001
+    ? Math.sign(pitchCosine || 1) * 0.001
+    : pitchCosine
+  const yawY = -(screenY - viewport.height / 2 - camera.panY) / pixelsPerMeter / safePitchCosine
+  const yawCosine = Math.cos(camera.yaw)
+  const yawSine = Math.sin(camera.yaw)
+  return [
+    yawCosine * yawX + yawSine * yawY,
+    -yawSine * yawX + yawCosine * yawY,
+  ]
+}
+
 function gridSpacing(pixelsPerMeter: number): number {
   const choices = [0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50, 100, 200]
   return choices.find(value => value * pixelsPerMeter >= 46) ?? 500
@@ -433,15 +454,19 @@ export default function PointCloudViewer({
   inputRail,
   onClear,
   onAccumulationToggle,
+  onGoalSet,
   clearPending = false,
   accumulationPending = false,
+  goalPending = false,
 }: {
   scene: unknown
   inputRail?: ReactNode
   onClear?: () => void
   onAccumulationToggle?: () => void
+  onGoalSet?: (x: number, y: number) => void
   clearPending?: boolean
   accumulationPending?: boolean
+  goalPending?: boolean
 }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const occupancyCanvasRef = useRef<HTMLCanvasElement | null>(null)
@@ -1399,6 +1424,21 @@ export default function PointCloudViewer({
           }}
           onDoubleClick={resetCamera}
           onPointerDown={event => {
+            if (event.shiftKey && event.button === 0 && onGoalSet) {
+              event.preventDefault()
+              event.stopPropagation()
+              if (goalPending) return
+              const bounds = event.currentTarget.getBoundingClientRect()
+              const [goalX, goalY] = screenToWorldPlane(
+                event.clientX - bounds.left,
+                event.clientY - bounds.top,
+                viewport,
+                camera,
+                pixelsPerMeter,
+              )
+              onGoalSet(goalX, goalY)
+              return
+            }
             event.stopPropagation()
             event.currentTarget.setPointerCapture(event.pointerId)
             dragRef.current = {
@@ -1513,7 +1553,7 @@ export default function PointCloudViewer({
           background: 'rgba(3, 10, 16, 0.72)', color: 'rgba(217, 232, 241, 0.74)',
           fontFamily: 'var(--font-mono)', fontSize: 11, pointerEvents: 'none',
         }}>
-          left-drag pan · right-drag orbit · middle-drag pan · wheel zoom · double-click reset
+          {onGoalSet ? 'shift-click goal · ' : ''}left-drag pan · right-drag orbit · middle-drag pan · wheel zoom · double-click reset
         </div>
       </div>
       <div data-bn-viewer-telemetry style={{

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -312,7 +312,7 @@ interface Store {
     copyIdMap: Record<string, string> | null,
   ) => Promise<void>
   updateParam: (id: string, key: string, value: unknown) => Promise<void>
-  controlNode: (id: string, action: string) => Promise<{ ok: boolean; node_id: string; outputs: Record<string, unknown> }>
+  controlNode: (id: string, action: string, payload?: Record<string, unknown>) => Promise<{ ok: boolean; node_id: string; outputs: Record<string, unknown> }>
   pickDirectory: (initialPath?: string) => Promise<string | null>
   updatePortVisibility: (id: string, promotedInputs?: string[], promotedOutputs?: string[]) => Promise<void>
   cookNode: (id: string, port?: string, graphTargets?: GraphRunTarget[], runMode?: 'once' | 'live') => Promise<void>
@@ -3265,8 +3265,8 @@ export const useStore = create<Store>((set, get) => ({
     }
   },
 
-  controlNode: async (id, action) => {
-    const result = await api.controlNode(id, action)
+  controlNode: async (id, action, payload = {}) => {
+    const result = await api.controlNode(id, action, payload)
     set(s => ({
       nodes: propagateLiveTerminalValues(s.nodes.map(node => node.id === id ? {
         ...node,

--- a/tests/test_editor_point_cloud_viewer.py
+++ b/tests/test_editor_point_cloud_viewer.py
@@ -215,6 +215,25 @@ def test_trajectory_evaluation_draws_safe_blocked_and_best_paths_without_motion_
     assert "Warp paths" in viewer_source
 
 
+def test_slam_viewer_shift_click_sets_connected_warp_trajectory_goal_without_recook():
+    viewer_source = VIEWER.read_text(encoding="utf-8")
+    node_source = BLACK_NODE.read_text(encoding="utf-8")
+    store_source = (ROOT / "editor" / "src" / "store.ts").read_text(encoding="utf-8")
+
+    assert "function screenToWorldPlane(" in viewer_source
+    assert "event.shiftKey && event.button === 0 && onGoalSet" in viewer_source
+    assert "shift-click goal" in viewer_source
+    assert "edge.targetHandle === 'trajectory_evaluation'" in node_source
+    assert "edge.sourceHandle === 'stage'" in node_source
+    assert "node.data.type === 'WarpTrajectoryEvaluator'" in node_source
+    assert "updateParam(trajectoryNode.id, 'goal_x_m', goalXMetres)" in node_source
+    assert "updateParam(trajectoryNode.id, 'goal_y_m', goalYMetres)" in node_source
+    assert "await controlNode(id, 'set-goal', {" in node_source
+    assert "controlNode: async (id, action, payload = {})" in store_source
+    assert "api.controlNode(id, action, payload)" in store_source
+    assert "cookNode" not in node_source[node_source.index("const onSetSlamGoal"):node_source.index("const runManualMoveAction")]
+
+
 def test_viewer_ports_are_compact_and_new_viewers_start_square():
     node_source = BLACK_NODE.read_text(encoding="utf-8")
     viewer_source = VIEWER.read_text(encoding="utf-8")

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -645,6 +645,10 @@ class EditorRuntimeTests(unittest.TestCase):
                 viewer_resume = client.post(f"/nodes/{viewer_id}/control", json={"action": "resume"})
                 slam_pause = client.post(f"/nodes/{slam_id}/control", json={"action": "pause"})
                 slam_resume = client.post(f"/nodes/{slam_id}/control", json={"action": "resume"})
+                slam_goal = client.post(
+                    f"/nodes/{slam_id}/control",
+                    json={"action": "set-goal", "payload": {"goal_x_m": -1.25, "goal_y_m": 0.75}},
+                )
                 slam_stop = client.post(f"/nodes/{slam_id}/control", json={"action": "stop"})
 
             self.assertEqual(viewer_clear.status_code, 200)
@@ -653,12 +657,14 @@ class EditorRuntimeTests(unittest.TestCase):
             self.assertEqual(slam_pause.status_code, 200)
             self.assertFalse(slam_pause.json()["outputs"]["status"]["mapping"])
             self.assertEqual(slam_resume.status_code, 200)
+            self.assertEqual(slam_goal.status_code, 200)
             self.assertEqual(slam_stop.status_code, 200)
             self.assertEqual(calls, [
                 ("viewer", "clear_viewer", "viewer-live"),
                 ("viewer", "resume_viewer", "viewer-live"),
                 ("slam", "set_mapping", "slam-live", False),
                 ("slam", "set_mapping", "slam-live", True),
+                ("slam", "set_trajectory_goal", "slam-live", -1.25, 0.75),
                 ("slam", "stop_slam", "slam-live"),
             ])
             self.assertNotIn(viewer_id, server._session.graph._dirty)


### PR DESCRIPTION
Adds Shift-click fixed-map goal placement to the embedded and standalone SLAM viewer. The editor persists goal coordinates on the connected WarpTrajectoryEvaluator and sends a direct live control payload, so paths update without graph recooking or SLAM restart.\n\nVerified: 537 core tests (8 skipped), focused endpoint/viewer tests, editor production build, and blacknode-cuda's 151-test suite.