### PR TITLE
Pin managed Runtime 0.4.8 sources

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,10 +3,10 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "75192708d6b2246c8ff66bebdea2a79bdffbc5c4"
+    "commit": "41ad6fccacfca98080fff442fb7f4689b5c22a26"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "7bb5a302f05bd9b5c1f6dacf3a729126e1c3a94b"
+    "commit": "56a898da1b87317ab17f12c4442ef90099684319"
   }
 }


### PR DESCRIPTION
Pins the merged blacknode-runtime 0.4.8 and Blacknode click-to-goal commits for managed-device updates. Runtime release required: yes, because the expected operator action is Runtime/Update all and the device bundle needs the new core control endpoint.\n\nVerified: 537 core tests, 8 skipped.