### PR TITLE
Pin managed Runtime 0.4.9 source

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,7 +3,7 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "41ad6fccacfca98080fff442fb7f4689b5c22a26"
+    "commit": "c3bb1ac327e595e7229786e5fa648c83bdb070d7"
   },
   "core": {
     "repository": "temiroff/Blacknode",


### PR DESCRIPTION
Pins the merged blacknode-runtime 0.4.9 commit so managed-device Update all exposes and delivers blacknode-cuda 0.4.11. Runtime release required: yes, because Runtime/Update all is the expected operator surface.\n\nVerified: focused source-lock test; 537 core tests, 8 skipped.