### PR TITLE
Add sensor viewers to editor

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -639,6 +639,7 @@ _RUNTIME_MODULES = {
     "vision": "blacknode.pkg.blacknode_perception.cv2_runtime",
     "cuda": "blacknode.pkg.blacknode_cuda.cuda_stream_runtime",
     "viewer": "blacknode.pkg.blacknode_cuda.viewer_runtime",
+    "imu_viewer": "blacknode.pkg.blacknode_perception.imu_runtime",
     "slam": "blacknode.pkg.blacknode_cuda.slam_runtime",
     "robot": "blacknode.pkg.blacknode_robot.robot",
     "dataset": "blacknode.pkg.blacknode_dataset.runtime",
@@ -658,6 +659,7 @@ _RUNTIME_REGISTRY_ANCHORS = {
     "joint_control": "ROS2ManualMove",
     "robot_calibration_control": "RobotCalibrationControl",
     "viewer": "Viewer",
+    "imu_viewer": "IMUViewer",
     "slam": "SLAM",
 }
 
@@ -2317,19 +2319,36 @@ def control_node(node_id: str, req: NodeControlReq):
             _session.graph._cache[(node_id, port)] = value
         _session.graph._dirty.discard(node_id)
         return {"ok": True, "node_id": node_id, "outputs": outputs}
-    if meta.get("type") in {"Viewer", "SLAM"}:
+    if meta.get("type") in {"Viewer", "SLAM", "IMUViewer"}:
         action = str(req.action or "").strip().lower()
-        base_actions = {"status", "clear", "pause", "resume", "stop"}
+        base_actions = (
+            {"status", "stop"}
+            if meta.get("type") == "IMUViewer"
+            else {"status", "clear", "pause", "resume", "stop"}
+        )
         if action not in base_actions and not (
             meta.get("type") == "SLAM" and action == "set-goal"
         ):
             raise HTTPException(
                 400,
                 "Viewer controls support status, clear, pause, resume, or stop; "
+                "IMUViewer supports status or stop; "
                 "SLAM additionally supports set-goal",
             )
         params = dict(meta.get("params") or {})
-        if meta.get("type") == "Viewer":
+        if meta.get("type") == "IMUViewer":
+            runtime_id = str(params.get("viewer_id") or "imu_viewer").strip() or "imu_viewer"
+            function_name = {
+                "status": "imu_viewer_status",
+                "stop": "stop_imu_viewer",
+            }[action]
+            control_fn = _runtime_callable(
+                "imu_viewer", _RUNTIME_MODULES["imu_viewer"], function_name,
+            )
+            if control_fn is None:
+                raise HTTPException(503, "blacknode-perception IMU Viewer runtime is not loaded")
+            outputs = dict(control_fn(runtime_id))
+        elif meta.get("type") == "Viewer":
             runtime_id = str(params.get("viewer_id") or "viewer").strip() or "viewer"
             function_name = {
                 "status": "viewer_status",

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1550,7 +1550,7 @@ export default function App() {
   const manualMoveCount = nodes.filter(n => n.data.type === 'ROS2ManualMove' && n.data.portResults?.live === true).length
   const liveDashboardCount = nodes.filter(n => n.data.type === 'ROS2MotionDashboard' && n.data.portResults?.live === true).length
   const visualizerRunCount = nodes.filter(n => (
-    (n.data.type === 'Viewer' || n.data.type === 'SLAM')
+    (n.data.type === 'Viewer' || n.data.type === 'SLAM' || n.data.type === 'IMUViewer')
     && n.data.portResults?.running === true
   )).length
   const liveCapableCount = nodes.filter(n => n.data.live_capable).length

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -18,6 +18,7 @@ import NodeFrame from './NodeFrame'
 import NodeGlyph from './NodeGlyph'
 import DatasetBrowserPanel from './DatasetBrowserPanel'
 import PointCloudViewer from './PointCloudViewer'
+import IMUOrientationViewer from './IMUOrientationViewer'
 import type { NodeCookState } from '../types'
 import { LIVE_STREAM_NODE_TYPES } from '../liveNodeTypes'
 
@@ -822,7 +823,8 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const isEpisodeRecorder = data.type === 'EpisodeRecorder'
   const isDatasetCreate = data.type === 'DatasetCreate'
   const isDatasetBrowser = data.type === 'DatasetBrowser'
-  const isViewer = data.type === 'Viewer' || data.type === 'SLAM'
+  const isViewer = data.type === 'Viewer' || data.type === 'SLAM' || data.type === 'IMUViewer'
+  const isIMUViewer = data.type === 'IMUViewer'
   const isACTTraining = data.type === 'ACTTraining'
   const availableInputs = isRobotJointList
     ? (data.inputs ?? []).filter(port => edges.some(edge => edge.target === id && edge.targetHandle === port))
@@ -1092,6 +1094,8 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     : viewerActive ? {
       text: data.type === 'SLAM'
         ? (data.portResults?.live === true ? 'LIVE • SLAM' : 'SLAM • WAITING')
+        : data.type === 'IMUViewer'
+          ? (data.portResults?.live === true ? 'LIVE • IMU' : 'IMU • WAITING')
         : (data.portResults?.live === true ? 'LIVE • VIEWING' : 'LIVE • WAITING'),
       tone: data.portResults?.live === true ? 'ok' : 'warn',
       title: String(data.portResults?.report ?? 'Managed Viewer session'),
@@ -2699,7 +2703,20 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
 
       {/* The viewer is a direct flex child so React Flow's resized node height
           reaches the canvas instead of being consumed by the parameter area. */}
-      {isViewer && (
+      {isIMUViewer && (
+        <IMUOrientationViewer
+          scene={data.portResults?.scene}
+          inputRail={(
+            <ViewerInputStrip
+              nodeId={id}
+              ports={visibleInputs}
+              inputTypes={Object.fromEntries(visibleInputs.map(port => [port, effectivePortType(port, 'input')]))}
+              connectedPorts={connectedViewerInputs}
+            />
+          )}
+        />
+      )}
+      {isViewer && !isIMUViewer && (
         <PointCloudViewer
           scene={data.portResults?.scene}
           inputRail={(

--- a/editor/src/components/IMUOrientationViewer.tsx
+++ b/editor/src/components/IMUOrientationViewer.tsx
@@ -1,0 +1,343 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+
+interface Vector3 { x?: number; y?: number; z?: number }
+interface Quaternion extends Vector3 { w?: number }
+
+interface IMUScene {
+  frame?: string
+  sequence?: number
+  robot?: { length_m?: number; width_m?: number; height_m?: number }
+  imu?: {
+    orientation?: Quaternion
+    euler_rad?: { roll?: number; pitch?: number; yaw?: number }
+    angular_velocity_rps?: Vector3
+    linear_acceleration_mps2?: Vector3
+    source_fresh?: boolean
+    age_seconds?: number | null
+    topic?: string
+  }
+}
+
+interface Point3 { x: number; y: number; z: number }
+interface Point2 extends Point3 { sx: number; sy: number; depth: number }
+
+const LOGO_SOURCE = { x: 78, y: 48, width: 352, height: 415 } as const
+
+function finite(value: unknown, fallback = 0): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value))
+}
+
+function normalizeQuaternion(value: Quaternion | undefined): Required<Quaternion> {
+  const quaternion = {
+    x: finite(value?.x), y: finite(value?.y), z: finite(value?.z), w: finite(value?.w, 1),
+  }
+  const norm = Math.hypot(quaternion.x, quaternion.y, quaternion.z, quaternion.w) || 1
+  return {
+    x: quaternion.x / norm,
+    y: quaternion.y / norm,
+    z: quaternion.z / norm,
+    w: quaternion.w / norm,
+  }
+}
+
+function rotate(point: Point3, quaternion: Required<Quaternion>): Point3 {
+  const { x: qx, y: qy, z: qz, w: qw } = quaternion
+  const tx = 2 * (qy * point.z - qz * point.y)
+  const ty = 2 * (qz * point.x - qx * point.z)
+  const tz = 2 * (qx * point.y - qy * point.x)
+  return {
+    x: point.x + qw * tx + qy * tz - qz * ty,
+    y: point.y + qw * ty + qz * tx - qx * tz,
+    z: point.z + qw * tz + qx * ty - qy * tx,
+  }
+}
+
+function degrees(value: unknown): string {
+  return `${(finite(value) * 180 / Math.PI).toFixed(1)}°`
+}
+
+function vectorMagnitude(value: Vector3 | undefined): number {
+  return Math.hypot(finite(value?.x), finite(value?.y), finite(value?.z))
+}
+
+export default function IMUOrientationViewer({
+  scene,
+  inputRail,
+}: {
+  scene: unknown
+  inputRail?: ReactNode
+}) {
+  const parsed = (scene && typeof scene === 'object' ? scene : {}) as IMUScene
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const logoRef = useRef<HTMLImageElement | null>(null)
+  const dragRef = useRef<{ x: number; y: number; yaw: number; pitch: number } | null>(null)
+  const [viewport, setViewport] = useState({ width: 1, height: 420, ratio: 1 })
+  const [camera, setCamera] = useState({ yaw: -0.68, pitch: 0.62, zoom: 1 })
+  const [logoReady, setLogoReady] = useState(false)
+  const quaternion = useMemo(() => normalizeQuaternion(parsed.imu?.orientation), [
+    parsed.imu?.orientation?.w,
+    parsed.imu?.orientation?.x,
+    parsed.imu?.orientation?.y,
+    parsed.imu?.orientation?.z,
+  ])
+
+  useEffect(() => {
+    let cancelled = false
+    const logo = new Image()
+    logo.onload = () => {
+      if (!cancelled) {
+        logoRef.current = logo
+        setLogoReady(true)
+      }
+    }
+    logo.src = '/blacknode-logo-dark.png'
+    return () => {
+      cancelled = true
+      logoRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const observer = new ResizeObserver(entries => {
+      const rect = entries[0]?.contentRect
+      if (!rect) return
+      setViewport({
+        width: Math.max(1, rect.width),
+        height: Math.max(260, rect.height),
+        ratio: Math.min(2, window.devicePixelRatio || 1),
+      })
+    })
+    observer.observe(canvas)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const bufferWidth = Math.max(1, Math.round(viewport.width * viewport.ratio))
+    const bufferHeight = Math.max(1, Math.round(viewport.height * viewport.ratio))
+    if (canvas.width !== bufferWidth) canvas.width = bufferWidth
+    if (canvas.height !== bufferHeight) canvas.height = bufferHeight
+    const context = canvas.getContext('2d')
+    if (!context) return
+    context.setTransform(viewport.ratio, 0, 0, viewport.ratio, 0, 0)
+    context.clearRect(0, 0, viewport.width, viewport.height)
+
+    const centerX = viewport.width / 2
+    const centerY = viewport.height * 0.47
+    const scale = Math.min(viewport.width, viewport.height) * 0.66 * camera.zoom
+    const project = (point: Point3): Point2 => {
+      const cy = Math.cos(camera.yaw)
+      const sy = Math.sin(camera.yaw)
+      const cp = Math.cos(camera.pitch)
+      const sp = Math.sin(camera.pitch)
+      const yawX = cy * point.x - sy * point.y
+      const yawY = sy * point.x + cy * point.y
+      const viewY = cp * yawY - sp * point.z
+      const depth = sp * yawY + cp * point.z
+      return { ...point, sx: centerX + yawX * scale, sy: centerY - viewY * scale, depth }
+    }
+    const bodyPoint = (x: number, y: number, z: number) => project(rotate({ x, y, z }, quaternion))
+
+    const gridReach = 0.72
+    context.lineWidth = 1
+    context.strokeStyle = 'rgba(117, 155, 181, 0.15)'
+    for (let index = -6; index <= 6; index += 1) {
+      const value = index * gridReach / 6
+      const a = project({ x: value, y: -gridReach, z: -0.17 })
+      const b = project({ x: value, y: gridReach, z: -0.17 })
+      const c = project({ x: -gridReach, y: value, z: -0.17 })
+      const d = project({ x: gridReach, y: value, z: -0.17 })
+      context.beginPath()
+      context.moveTo(a.sx, a.sy); context.lineTo(b.sx, b.sy)
+      context.moveTo(c.sx, c.sy); context.lineTo(d.sx, d.sy)
+      context.stroke()
+    }
+
+    const drawArrow = (start: Point2, end: Point2, color: string, label: string, width = 2.4) => {
+      const angle = Math.atan2(end.sy - start.sy, end.sx - start.sx)
+      context.strokeStyle = color
+      context.fillStyle = color
+      context.lineWidth = width
+      context.beginPath()
+      context.moveTo(start.sx, start.sy)
+      context.lineTo(end.sx, end.sy)
+      context.stroke()
+      context.beginPath()
+      context.moveTo(end.sx, end.sy)
+      context.lineTo(end.sx - Math.cos(angle - 0.48) * 9, end.sy - Math.sin(angle - 0.48) * 9)
+      context.lineTo(end.sx - Math.cos(angle + 0.48) * 9, end.sy - Math.sin(angle + 0.48) * 9)
+      context.closePath()
+      context.fill()
+      context.font = '700 12px ui-monospace, SFMono-Regular, Menlo, monospace'
+      context.fillText(label, end.sx + 6, end.sy - 5)
+    }
+
+    const origin = project({ x: 0, y: 0, z: -0.17 })
+    drawArrow(origin, project({ x: 0.46, y: 0, z: -0.17 }), 'rgba(255, 91, 91, 0.42)', 'X', 1.4)
+    drawArrow(origin, project({ x: 0, y: 0.46, z: -0.17 }), 'rgba(83, 224, 145, 0.42)', 'Y', 1.4)
+    drawArrow(origin, project({ x: 0, y: 0, z: 0.29 }), 'rgba(83, 154, 255, 0.5)', 'Z', 1.4)
+
+    const length = clamp(finite(parsed.robot?.length_m, 0.36), 0.05, 2)
+    const width = clamp(finite(parsed.robot?.width_m, 0.28), 0.05, 2)
+    const height = clamp(finite(parsed.robot?.height_m, 0.12), 0.02, 1)
+    const half = { x: length / 2, y: width / 2, z: height / 2 }
+    const vertices = [
+      [-half.x, -half.y, -half.z], [half.x, -half.y, -half.z],
+      [half.x, half.y, -half.z], [-half.x, half.y, -half.z],
+      [-half.x, -half.y, half.z], [half.x, -half.y, half.z],
+      [half.x, half.y, half.z], [-half.x, half.y, half.z],
+    ].map(([x, y, z]) => bodyPoint(x, y, z))
+    const faces = [
+      { indices: [0, 1, 2, 3], fill: 'rgba(13, 104, 124, 0.50)' },
+      { indices: [4, 5, 6, 7], fill: 'rgba(30, 199, 220, 0.38)' },
+      { indices: [0, 1, 5, 4], fill: 'rgba(24, 160, 185, 0.40)' },
+      { indices: [1, 2, 6, 5], fill: 'rgba(16, 133, 159, 0.46)' },
+      { indices: [2, 3, 7, 6], fill: 'rgba(20, 148, 174, 0.40)' },
+      { indices: [3, 0, 4, 7], fill: 'rgba(13, 118, 144, 0.46)' },
+    ].sort((left, right) => {
+      const depth = (face: typeof left) => face.indices.reduce((sum, index) => sum + vertices[index].depth, 0) / 4
+      return depth(left) - depth(right)
+    })
+    context.shadowColor = 'rgba(43, 220, 238, 0.45)'
+    context.shadowBlur = 12
+    for (const face of faces) {
+      context.beginPath()
+      face.indices.forEach((index, offset) => {
+        const point = vertices[index]
+        if (offset === 0) context.moveTo(point.sx, point.sy)
+        else context.lineTo(point.sx, point.sy)
+      })
+      context.closePath()
+      context.fillStyle = face.fill
+      context.fill()
+      context.strokeStyle = 'rgba(124, 244, 255, 0.86)'
+      context.lineWidth = 1.35
+      context.stroke()
+    }
+    context.shadowBlur = 0
+
+    const topCenter = bodyPoint(0, 0, half.z + 0.001)
+    const topX = bodyPoint(length * 0.33, 0, half.z + 0.001)
+    const topY = bodyPoint(0, width * 0.33, half.z + 0.001)
+    const logo = logoRef.current
+    context.save()
+    context.transform(
+      topX.sx - topCenter.sx, topX.sy - topCenter.sy,
+      topY.sx - topCenter.sx, topY.sy - topCenter.sy,
+      topCenter.sx, topCenter.sy,
+    )
+    context.rotate(-Math.PI / 2)
+    context.globalCompositeOperation = 'screen'
+    context.globalAlpha = 0.9
+    if (logo) {
+      context.drawImage(
+        logo,
+        LOGO_SOURCE.x, LOGO_SOURCE.y, LOGO_SOURCE.width, LOGO_SOURCE.height,
+        -0.58, -0.50, 1.16, 1.0,
+      )
+    } else {
+      context.fillStyle = '#e8fdff'
+      context.font = '800 1px var(--font-ui)'
+      context.textAlign = 'center'
+      context.textBaseline = 'middle'
+      context.fillText('B', 0, 0)
+    }
+    context.restore()
+
+    const bodyOrigin = bodyPoint(0, 0, 0)
+    const axisLength = Math.max(length, width) * 0.82
+    drawArrow(bodyOrigin, bodyPoint(axisLength, 0, 0), '#ff5b5b', 'X')
+    drawArrow(bodyOrigin, bodyPoint(0, axisLength, 0), '#53e091', 'Y')
+    drawArrow(bodyOrigin, bodyPoint(0, 0, axisLength), '#539aff', 'Z')
+
+    context.font = '11px ui-monospace, SFMono-Regular, Menlo, monospace'
+    context.fillStyle = parsed.imu?.source_fresh === true ? '#72ff9d' : '#facc15'
+    context.fillText(parsed.imu?.source_fresh === true ? 'LIVE ORIENTATION' : 'WAITING / STALE', 14, 20)
+  }, [camera, logoReady, parsed, quaternion, viewport])
+
+  const angularRate = vectorMagnitude(parsed.imu?.angular_velocity_rps)
+  const acceleration = vectorMagnitude(parsed.imu?.linear_acceleration_mps2)
+  const age = parsed.imu?.age_seconds
+
+  return (
+    <div
+      className="nodrag"
+      onMouseDown={event => event.stopPropagation()}
+      style={{
+        margin: '7px 9px 8px', width: 'calc(100% - 18px)', flex: '1 1 auto', minHeight: 0,
+        display: 'flex', flexDirection: 'column', boxSizing: 'border-box', overflow: 'hidden',
+        border: '1px solid var(--line2)', borderRadius: 'var(--bn-node-inner-radius, 7px)', background: '#242424',
+      }}
+    >
+      <div style={{
+        display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 7, padding: '5px 7px',
+        borderBottom: '1px solid var(--line)', background: 'var(--panel)',
+      }}>
+        {inputRail}
+        <button
+          onClick={event => { event.stopPropagation(); setCamera({ yaw: -0.68, pitch: 0.62, zoom: 1 }) }}
+          style={{
+            marginLeft: 'auto', height: 25, padding: '0 8px', border: '1px solid var(--line2)',
+            background: 'var(--panel2)', color: 'var(--tx2)', fontSize: 11, cursor: 'pointer',
+          }}
+        >
+          Reset view
+        </button>
+      </div>
+      <canvas
+        ref={canvasRef}
+        onMouseDown={event => {
+          event.stopPropagation()
+          dragRef.current = { x: event.clientX, y: event.clientY, yaw: camera.yaw, pitch: camera.pitch }
+        }}
+        onMouseMove={event => {
+          const drag = dragRef.current
+          if (!drag) return
+          setCamera(current => ({
+            ...current,
+            yaw: drag.yaw + (event.clientX - drag.x) * 0.008,
+            pitch: clamp(drag.pitch - (event.clientY - drag.y) * 0.008, -1.35, 1.35),
+          }))
+        }}
+        onMouseUp={() => { dragRef.current = null }}
+        onMouseLeave={() => { dragRef.current = null }}
+        onWheel={event => {
+          event.preventDefault()
+          event.stopPropagation()
+          setCamera(current => ({ ...current, zoom: clamp(current.zoom * Math.exp(-event.deltaY * 0.001), 0.55, 2.4) }))
+        }}
+        style={{ width: '100%', flex: '1 1 auto', minHeight: 260, cursor: 'grab', background: '#161b1d' }}
+      />
+      <div style={{
+        display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 1,
+        borderTop: '1px solid var(--line)', background: 'var(--line)',
+      }}>
+        {[
+          ['ROLL', degrees(parsed.imu?.euler_rad?.roll)],
+          ['PITCH', degrees(parsed.imu?.euler_rad?.pitch)],
+          ['YAW', degrees(parsed.imu?.euler_rad?.yaw)],
+          ['ANGULAR', `${angularRate.toFixed(3)} rad/s`],
+          ['ACCEL', `${acceleration.toFixed(3)} m/s²`],
+          ['FRAME', parsed.frame || 'imu_link'],
+        ].map(([label, value]) => (
+          <div key={label} style={{ background: 'var(--panel)', minWidth: 0, padding: '6px 8px' }}>
+            <div style={{ color: 'var(--tx3)', fontSize: 11, letterSpacing: '.08em' }}>{label}</div>
+            <div style={{ color: 'var(--tx1)', fontFamily: 'var(--font-mono)', fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis' }}>{value}</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ padding: '5px 8px', color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 11, background: 'var(--panel)' }}>
+        {parsed.imu?.topic || 'normalized IMU'} • sample {finite(parsed.sequence)}
+        {typeof age === 'number' ? ` • age ${age.toFixed(3)}s` : ''} • drag to orbit • wheel to zoom
+      </div>
+    </div>
+  )
+}

--- a/editor/src/components/PointCloudViewer.tsx
+++ b/editor/src/components/PointCloudViewer.tsx
@@ -127,6 +127,86 @@ interface ViewerScene {
     trail_seconds?: number
     trail_distance_limit_m?: number
   }
+  depth_projection?: {
+    state?: string
+    backend?: string
+    device?: string
+    width?: number
+    height?: number
+    input_pixels?: number
+    valid_points?: number
+    display_points?: number
+    stride?: number
+    fetch_ms?: number
+    pipeline_ms?: number
+    cpu_ms?: number
+    speedup?: number
+    max_error_m?: number
+    mean_confidence?: number
+    encoding?: string
+    color_registered?: boolean
+    color_fetch_ms?: number
+    color_error?: string
+  }
+  reconstruction?: {
+    kind?: string
+    color_registered?: boolean
+    pose_registered?: boolean
+    integration?: {
+      state?: string
+      backend?: string
+      device?: string
+      frames_integrated?: number
+      input_points?: number
+      work_items?: number
+      integration_ms?: number
+      voxel_size_m?: number
+      truncation_m?: number
+      voxel_count?: number
+      dimensions?: number[]
+    }
+    extraction?: {
+      state?: string
+      backend?: string
+      surface_voxels?: number
+      display_points?: number
+      observed_voxels?: number
+      allocated_voxels?: number
+      extraction_ms?: number
+      minimum_weight?: number
+    }
+  }
+  sensor_fusion?: {
+    state?: string
+    backend?: string
+    device?: string
+    lidar_points?: number
+    depth_points?: number
+    fused_points?: number
+    matched_points?: number
+    unmatched_points?: number
+    matched_ratio?: number
+    mean_residual_m?: number
+    rms_residual_m?: number
+    p95_residual_m?: number
+    maximum_alignment_distance_m?: number
+    mean_confidence?: number
+    calibration_hypotheses?: number
+    calibration_work_items?: number
+    best_score?: number
+    correction?: { x_m?: number; y_m?: number; yaw_deg?: number }
+    pipeline_ms?: number
+    cpu_ms?: number
+    speedup?: number
+  }
+  synchronization?: {
+    state?: string
+    depth_time_ns?: number
+    lidar_time_ns?: number
+    delta_seconds?: number
+    tolerance_seconds?: number
+    rgb_mode?: string
+  }
   trajectory_evaluation?: {
     state?: string
     backend?: string
@@ -1380,7 +1460,7 @@ export default function PointCloudViewer({
           />
           Axes
         </label>
-        {onAccumulationToggle && (
+        {onAccumulationToggle && (!parsed.depth_projection || parsed.reconstruction) && (
           <button
             type="button"
             disabled={accumulationPending}
@@ -1399,7 +1479,7 @@ export default function PointCloudViewer({
         >
           Floor: {showFreeSpace ? 'On' : 'Off'}
         </button>
-        {onClear && <button type="button" disabled={clearPending} style={controlStyle()} title="Clear accumulated scan history and switch accumulation off" onClick={onClear}>{clearPending ? 'Clearing…' : 'Clear history'}</button>}
+        {onClear && (!parsed.depth_projection || parsed.reconstruction) && <button type="button" disabled={clearPending} style={controlStyle()} title={parsed.reconstruction ? 'Clear the persistent RGB-D reconstruction volume and pause integration' : 'Clear accumulated scan history and switch accumulation off'} onClick={onClear}>{clearPending ? 'Clearing…' : parsed.reconstruction ? 'Clear volume' : 'Clear history'}</button>}
         <span style={{ marginLeft: 'auto', color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
           {camera.zoom.toFixed(2)}× · yaw {yawDegrees}° · pitch {pitchDegrees}°
         </span>
@@ -1500,7 +1580,15 @@ export default function PointCloudViewer({
           fontFamily: 'var(--font-mono)', fontSize: 11, pointerEvents: 'none',
         }}>
           <span style={{ width: 7, height: 7, borderRadius: '50%', background: currentPoints.length ? '#56d991' : '#71808d' }} />
-          {currentPoints.length ? `CURRENT SCAN #${Number(parsed.sequence ?? 0).toLocaleString()} · ${clockwiseScan ? 'CW' : 'CCW'} ${Math.round(animationPhase * 100)}%` : 'WAITING FOR SCAN'}
+          {currentPoints.length
+            ? parsed.sensor_fusion?.backend === 'warp-hash-grid'
+              ? `SENSOR FUSION · ${Number(parsed.sensor_fusion.matched_points ?? 0).toLocaleString()} ALIGNED`
+              : parsed.reconstruction?.integration?.backend === 'warp'
+              ? `RGB-D RECONSTRUCTION · ${Number(parsed.reconstruction.integration.frames_integrated ?? 0).toLocaleString()} FRAMES`
+              : parsed.depth_projection?.backend === 'warp'
+              ? `METRIC DEPTH · ${Number(parsed.depth_projection.width ?? 0)}×${Number(parsed.depth_projection.height ?? 0)}`
+              : `CURRENT SCAN #${Number(parsed.sequence ?? 0).toLocaleString()} · ${clockwiseScan ? 'CW' : 'CCW'} ${Math.round(animationPhase * 100)}%`
+            : parsed.depth_projection ? 'WAITING FOR DEPTH' : 'WAITING FOR SCAN'}
         </div>
         {parsed.occupancy?.backend === 'warp' && (
           <div style={{
@@ -1534,6 +1622,17 @@ export default function PointCloudViewer({
               : `HASHGRID MOTION · ${Number(parsed.dynamic_occupancy.dynamic_points ?? 0).toLocaleString()} MOVING`}
           </div>
         )}
+        {parsed.sensor_fusion?.backend === 'warp-hash-grid' && (
+          <div style={{
+            position: 'absolute', zIndex: 3, top: 39, right: 9, display: 'flex', alignItems: 'center', gap: 6,
+            padding: '4px 7px', borderRadius: 5, background: 'rgba(4, 18, 22, 0.84)',
+            border: '1px solid rgba(91, 235, 255, 0.48)', color: '#91f4ff',
+            fontFamily: 'var(--font-mono)', fontSize: 11, pointerEvents: 'none',
+          }}>
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: finite(parsed.sensor_fusion.matched_ratio) > 0.5 ? '#66e091' : '#f2b84b' }} />
+            HASHGRID ALIGN · {(finite(parsed.sensor_fusion.mean_residual_m) * 100).toFixed(1)} CM · {(finite(parsed.sensor_fusion.matched_ratio) * 100).toFixed(0)}%
+          </div>
+        )}
         {parsed.trajectory_evaluation?.backend === 'warp' && (
           <div style={{
             position: 'absolute', zIndex: 3, top: parsed.dynamic_occupancy?.backend === 'warp-hash-grid' ? 70 : 39, right: 9,
@@ -1564,11 +1663,17 @@ export default function PointCloudViewer({
       }}>
         <span>
           {pointCount > 0
-            ? `${pointCount.toLocaleString()} accumulated returns`
+            ? parsed.sensor_fusion?.backend === 'warp-hash-grid'
+              ? `${pointCount.toLocaleString()} fused sensor points`
+              : parsed.reconstruction?.extraction?.backend === 'warp'
+              ? `${pointCount.toLocaleString()} reconstructed surface voxels`
+              : parsed.depth_projection?.backend === 'warp'
+              ? `${pointCount.toLocaleString()} projected depth points`
+              : `${pointCount.toLocaleString()} accumulated returns`
             : currentPoints.length ? 'Live scan; map is empty' : 'Waiting for points'}
         </span>
         {currentPointCount > 0 && <span>{currentPointCount.toLocaleString()} current</span>}
-        {accumulatedScanCount > 0 && <span>{accumulatedScanCount.toLocaleString()} scans</span>}
+        {accumulatedScanCount > 0 && (!parsed.depth_projection || parsed.reconstruction) && <span>{accumulatedScanCount.toLocaleString()} {parsed.reconstruction ? 'RGB-D frames' : 'scans'}</span>}
         {displayCount > 0 && displayCount !== pointCount && <span>{displayCount.toLocaleString()} displayed</span>}
         {kernelMs > 0 && <span>{kernelMs.toFixed(3)} ms Warp</span>}
         {parsed.occupancy?.backend === 'warp' && (
@@ -1592,14 +1697,31 @@ export default function PointCloudViewer({
             {finite(parsed.dynamic_occupancy.speedup) > 0 ? ` · ${finite(parsed.dynamic_occupancy.speedup).toFixed(1)}× CPU` : ''}
           </span>
         )}
+        {parsed.depth_projection?.state === 'ready' && (
+          <span style={{ color: '#7cf4ff' }}>
+            Warp depth {Number(parsed.depth_projection.input_pixels ?? 0).toLocaleString()} pixels · {Number(parsed.depth_projection.valid_points ?? 0).toLocaleString()} valid · stride {Number(parsed.depth_projection.stride ?? 1)} · {finite(parsed.depth_projection.pipeline_ms).toFixed(3)} ms · fetch {finite(parsed.depth_projection.fetch_ms).toFixed(3)} ms · confidence {finite(parsed.depth_projection.mean_confidence).toFixed(2)}
+            {finite(parsed.depth_projection.speedup) > 0 ? ` · ${finite(parsed.depth_projection.speedup).toFixed(1)}× CPU` : ''}
+          </span>
+        )}
+        {parsed.reconstruction?.integration?.state === 'ready' && parsed.reconstruction.extraction?.state === 'ready' && (
+          <span style={{ color: '#9df0c2' }}>
+            Warp TSDF {Number(parsed.reconstruction.integration.frames_integrated ?? 0).toLocaleString()} frames · {Number(parsed.reconstruction.integration.work_items ?? 0).toLocaleString()} integration samples · {finite(parsed.reconstruction.integration.integration_ms).toFixed(3)} ms · extraction {finite(parsed.reconstruction.extraction.extraction_ms).toFixed(3)} ms · {Number(parsed.reconstruction.extraction.observed_voxels ?? 0).toLocaleString()} observed · {Number(parsed.reconstruction.extraction.surface_voxels ?? 0).toLocaleString()} surface · {parsed.reconstruction.color_registered ? 'RGB color' : 'depth confidence color'}
+          </span>
+        )}
+        {parsed.sensor_fusion?.state === 'ready' && (
+          <span style={{ color: '#91f4ff' }}>
+            Warp fusion {Number(parsed.sensor_fusion.lidar_points ?? 0).toLocaleString()} LiDAR + {Number(parsed.sensor_fusion.depth_points ?? 0).toLocaleString()} RGB-D · {Number(parsed.sensor_fusion.matched_points ?? 0).toLocaleString()} matched · mean {(finite(parsed.sensor_fusion.mean_residual_m) * 100).toFixed(1)} cm · p95 {(finite(parsed.sensor_fusion.p95_residual_m) * 100).toFixed(1)} cm · {Number(parsed.sensor_fusion.calibration_hypotheses ?? 0).toLocaleString()} hypotheses · {finite(parsed.sensor_fusion.pipeline_ms).toFixed(3)} ms · sync {(finite(parsed.synchronization?.delta_seconds) * 1000).toFixed(1)} ms
+            {finite(parsed.sensor_fusion.speedup) > 0 ? ` · ${finite(parsed.sensor_fusion.speedup).toFixed(1)}× CPU` : ''}
+          </span>
+        )}
         {parsed.trajectory_evaluation?.state === 'ready' && (
           <span style={{ color: '#91f4ff' }}>
             Warp paths {Number(parsed.trajectory_evaluation.trajectory_count ?? 0).toLocaleString()} × {Number(parsed.trajectory_evaluation.time_steps ?? 0).toLocaleString()} steps = {Number(parsed.trajectory_evaluation.work_items ?? 0).toLocaleString()} evaluations · {finite(parsed.trajectory_evaluation.pipeline_ms).toFixed(3)} ms · best clearance {finite(parsed.trajectory_evaluation.best_minimum_clearance_m).toFixed(2)} m
             {finite(parsed.trajectory_evaluation.speedup) > 0 ? ` · ${finite(parsed.trajectory_evaluation.speedup).toFixed(1)}× CPU` : ''}
           </span>
         )}
-        <span>{scanCoverageDeg >= 359.5 ? `360° scan · ${clockwiseScan ? 'CW' : 'CCW'} paced replay` : `${scanCoverageDeg.toFixed(1)}° scan · ${clockwiseScan ? 'CW' : 'CCW'} paced replay`}</span>
-        <span>3D orbit · LaserScan lies on XY plane</span>
+        {!parsed.depth_projection && <span>{scanCoverageDeg >= 359.5 ? `360° scan · ${clockwiseScan ? 'CW' : 'CCW'} paced replay` : `${scanCoverageDeg.toFixed(1)}° scan · ${clockwiseScan ? 'CW' : 'CCW'} paced replay`}</span>}
+        <span>{parsed.sensor_fusion ? '3D orbit · synchronized LiDAR and colorized depth alignment' : parsed.reconstruction ? '3D orbit · persistent pose-registered RGB-D surface' : parsed.depth_projection ? '3D orbit · calibrated metric surface' : '3D orbit · LaserScan lies on XY plane'}</span>
       </div>
       <div data-bn-viewer-legend style={{
         display: 'flex', alignItems: 'center', gap: 11, flexWrap: 'nowrap',
@@ -1607,9 +1729,10 @@ export default function PointCloudViewer({
         color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 11,
       }}>
         <span style={{ color: '#7cf4ff' }}>B robot {Math.round(finite(parsed.robot?.length_m, 0.25) * 100)}×{Math.round(finite(parsed.robot?.width_m, 0.22) * 100)} cm</span>
-        <span style={{ color: '#72ff9d' }}>— active beam</span>
-        {!fullCircleScan && <span style={{ color: '#85a2b8' }}>┄ scan limits</span>}
-        <span style={{ color: '#32d8ef' }}>● filtered laser returns</span>
+        {!parsed.depth_projection && <span style={{ color: '#72ff9d' }}>— active beam</span>}
+        {!parsed.depth_projection && !fullCircleScan && <span style={{ color: '#85a2b8' }}>┄ scan limits</span>}
+        <span style={{ color: '#32d8ef' }}>{parsed.sensor_fusion ? '● LiDAR cyan · RGB-D green aligned / red residual' : parsed.reconstruction ? '● reconstructed surface · aligned RGB when available' : parsed.depth_projection ? '● projected depth · brightness is surface confidence' : '● filtered laser returns'}</span>
+        {parsed.sensor_fusion && <span style={{ color: '#91f4ff' }}>calibration Δ {finite(parsed.sensor_fusion.correction?.x_m).toFixed(3)} m X · {finite(parsed.sensor_fusion.correction?.y_m).toFixed(3)} m Y · {finite(parsed.sensor_fusion.correction?.yaw_deg).toFixed(2)}° yaw</span>}
         {parsed.occupancy?.fixed_origin === true && <span style={{ color: '#486070' }}>■ unknown map extent</span>}
         {parsed.map_render_mode === 'occupancy-texture' && <span style={{ color: '#74e7a5' }}>GPU map texture · all cells</span>}
         {showFreeSpace && freeCellCount > 0 && <span style={{ color: '#4fc07a' }}>■ {freeCellCount.toLocaleString()} fixed free-floor cells</span>}
@@ -1622,7 +1745,7 @@ export default function PointCloudViewer({
         {Array.isArray(parsed.registration?.tf_path) && parsed.registration.tf_path.length > 1 && (
           <span>{parsed.registration.tf_path.join(' → ')}</span>
         )}
-        {parsed.history_registered === false && <span style={{ color: '#f2b84b' }}>history is sensor-local; moving the robot requires odometry</span>}
+        {parsed.history_registered === false && !parsed.depth_projection && <span style={{ color: '#f2b84b' }}>history is sensor-local; moving the robot requires odometry</span>}
         {parsed.history_paused === true && <span style={{ color: '#f2b84b' }}>accumulation paused</span>}
         {parsed.slam?.tracking_accepted === false && <span style={{ color: '#f2b84b' }}>uncertain scan match rejected · odometry prior kept</span>}
         {parsed.slam?.stationary_odometry_locked === true && <span style={{ color: '#74e7a5' }}>stationary odometry lock · dynamic returns cannot move map</span>}

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -385,7 +385,7 @@ function makeReactNode(meta: BnNodeMeta): Node<NodeData> {
     ...(meta.type === 'Dict'   ? { style: { width: 260, height: 150 } } : {}),
     ...(meta.type === 'Output' ? { style: { width: 320, height: 200 } } : {}),
     ...(meta.type === 'OutputImage' ? { style: { width: 760, height: 620 } } : {}),
-    ...((meta.type === 'Viewer' || meta.type === 'SLAM') ? { style: { width: 720, height: 720 } } : {}),
+    ...((meta.type === 'Viewer' || meta.type === 'SLAM' || meta.type === 'IMUViewer') ? { style: { width: 720, height: 720 } } : {}),
     ...(meta.type === 'DatasetBrowser' ? { style: { width: 980, height: 860 } } : {}),
     ...(hasDashboardImage ? { style: { width: 860, height: 720 } } : {}),
     ...(meta.type === 'ROS2VisualDashboard' ? { style: { width: 840, height: 760 } } : {}),
@@ -676,7 +676,7 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
       },
     }
   }
-  if (data.type === 'Viewer' || data.type === 'SLAM') {
+  if (data.type === 'Viewer' || data.type === 'SLAM' || data.type === 'IMUViewer') {
     const previousStatus = data.portResults?.status
     const status = previousStatus && typeof previousStatus === 'object' && !Array.isArray(previousStatus)
       ? previousStatus as Record<string, unknown>
@@ -1732,7 +1732,7 @@ export const useStore = create<Store>((set, get) => ({
           } : {}
           if (Object.keys(liveOutputs).length === 0 && Object.keys(managedOutputs).length === 0) {
             if (
-              (node.data.type === 'Viewer' || node.data.type === 'SLAM')
+              (node.data.type === 'Viewer' || node.data.type === 'SLAM' || node.data.type === 'IMUViewer')
               && (node.data.portResults?.running === true || node.data.portResults?.live === true)
             ) {
               const previousStatus = node.data.portResults?.status
@@ -3651,7 +3651,8 @@ export const useStore = create<Store>((set, get) => ({
           n.data.type === 'ROS2' ||
           n.data.type === 'ROS2Launch' ||
           n.data.type === 'Viewer' ||
-          n.data.type === 'SLAM'
+          n.data.type === 'SLAM' ||
+          n.data.type === 'IMUViewer'
         )
         return {
           ...n,

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -359,6 +359,10 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                         "SLAM",
                         "WarpParticleLocalization",
                         "WarpDynamicOccupancy",
+                        "WarpDepthProjector",
+                        "WarpTSDFIntegration",
+                        "WarpSurfaceExtraction",
+                        "WarpSensorFusion",
                         "WarpTrajectoryEvaluator",
                         "WarpLaserScanFilter",
                         "WarpLiDARViewer",
@@ -395,6 +399,10 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "SLAM",
                 "WarpParticleLocalization",
                 "WarpDynamicOccupancy",
+                "WarpDepthProjector",
+                "WarpTSDFIntegration",
+                "WarpSurfaceExtraction",
+                "WarpSensorFusion",
                 "WarpTrajectoryEvaluator",
                 "WarpLaserScanFilter",
                 "WarpLiDARViewer",
@@ -729,8 +737,12 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 },
                 "imu": {
                     "name": "imu",
-                    "default": False,
-                    "node_types": []
+                    "default": True,
+                    "node_types": [
+                        "IMU",
+                        "IMUTestProvider",
+                        "IMUViewer"
+                    ]
                 },
                 "detection": {
                     "name": "detection",
@@ -797,6 +809,9 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "LiDARROS2Scan",
                 "LiDARROS2WarpViewer",
                 "LiDARTestProvider",
+                "IMU",
+                "IMUTestProvider",
+                "IMUViewer",
                 "ReasoningDashboard",
                 "ReasoningStream",
                 "VLM",

--- a/tests/test_editor_imu_viewer.py
+++ b/tests/test_editor_imu_viewer.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_imu_viewer_has_quaternion_robot_axes_logo_and_live_telemetry():
+    source = (ROOT / "editor" / "src" / "components" / "IMUOrientationViewer.tsx").read_text(encoding="utf-8")
+
+    assert "normalizeQuaternion" in source
+    assert "rotate(point" in source
+    assert "blacknode-logo-dark.png" in source
+    assert "drawArrow(bodyOrigin" in source
+    assert "ROLL" in source and "PITCH" in source and "YAW" in source
+    assert "ANGULAR" in source and "ACCEL" in source and "FRAME" in source
+
+
+def test_imu_viewer_uses_the_managed_viewer_node_shell():
+    source = (ROOT / "editor" / "src" / "components" / "BlackNode.tsx").read_text(encoding="utf-8")
+    store = (ROOT / "editor" / "src" / "store.ts").read_text(encoding="utf-8")
+
+    assert "data.type === 'IMUViewer'" in source
+    assert "<IMUOrientationViewer" in source
+    assert "LIVE • IMU" in source
+    assert "meta.type === 'IMUViewer'" in store

--- a/tests/test_editor_point_cloud_viewer.py
+++ b/tests/test_editor_point_cloud_viewer.py
@@ -234,6 +234,37 @@ def test_slam_viewer_shift_click_sets_connected_warp_trajectory_goal_without_rec
     assert "cookNode" not in node_source[node_source.index("const onSetSlamGoal"):node_source.index("const runManualMoveAction")]
 
 
+def test_shared_viewer_surfaces_live_warp_depth_projection_metrics():
+    source = VIEWER.read_text(encoding="utf-8")
+
+    assert "depth_projection?:" in source
+    assert "METRIC DEPTH" in source
+    assert "Warp depth" in source
+    assert "calibrated metric surface" in source
+
+
+def test_shared_viewer_surfaces_persistent_rgbd_reconstruction_controls_and_metrics():
+    source = VIEWER.read_text(encoding="utf-8")
+
+    assert "reconstruction?:" in source
+    assert "RGB-D RECONSTRUCTION" in source
+    assert "Warp TSDF" in source
+    assert "reconstructed surface voxels" in source
+    assert "Clear volume" in source
+    assert "persistent pose-registered RGB-D surface" in source
+
+
+def test_shared_viewer_surfaces_lidar_depth_rgb_fusion_alignment_metrics():
+    source = VIEWER.read_text(encoding="utf-8")
+
+    assert "sensor_fusion?:" in source
+    assert "SENSOR FUSION" in source
+    assert "HASHGRID ALIGN" in source
+    assert "Warp fusion" in source
+    assert "synchronized LiDAR and colorized depth alignment" in source
+    assert "calibration Δ" in source
+
+
 def test_viewer_ports_are_compact_and_new_viewers_start_square():
     node_source = BLACK_NODE.read_text(encoding="utf-8")
     viewer_source = VIEWER.read_text(encoding="utf-8")
@@ -299,8 +330,8 @@ def test_go_live_button_becomes_stop_live_for_viewer_and_slam_sessions():
     assert "background: var(--warn-soft)" in styles
     assert "n.data.type === 'Viewer' ||" in store
     assert "n.data.type === 'SLAM'" in store
-    assert "(node.data.type === 'Viewer' || node.data.type === 'SLAM')" in store
-    assert "if (data.type === 'Viewer' || data.type === 'SLAM')" in store
+    assert "(node.data.type === 'Viewer' || node.data.type === 'SLAM' || node.data.type === 'IMUViewer')" in store
+    assert "if (data.type === 'Viewer' || data.type === 'SLAM' || data.type === 'IMUViewer')" in store
     assert "report: `${data.type} stopped by workflow control`" in store
     assert "running: false" in store
     assert "live: false" in store

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -88,6 +88,11 @@ class EditorRuntimeTests(unittest.TestCase):
         )
         self.assertEqual(server._RUNTIME_REGISTRY_ANCHORS["viewer"], "Viewer")
         self.assertEqual(
+            server._RUNTIME_MODULES["imu_viewer"],
+            "blacknode.pkg.blacknode_perception.imu_runtime",
+        )
+        self.assertEqual(server._RUNTIME_REGISTRY_ANCHORS["imu_viewer"], "IMUViewer")
+        self.assertEqual(
             server._RUNTIME_MODULES["slam"],
             "blacknode.pkg.blacknode_cuda.slam_runtime",
         )
@@ -230,7 +235,7 @@ class EditorRuntimeTests(unittest.TestCase):
             def manifest(self):
                 return {
                     "features": ["remote_ros2_topic_stream_v1"],
-                    "packages": [{"name": "blacknode-ros2", "version": "0.5.19"}],
+                    "packages": [{"name": "blacknode-ros2", "version": "0.5.20"}],
                     "node_types": ["ROS2"],
                 }
 
@@ -680,6 +685,51 @@ class EditorRuntimeTests(unittest.TestCase):
                 server._session.graph._dirty.discard(node_id)
                 for key in [key for key in server._session.graph._cache if key[0] == node_id]:
                     server._session.graph._cache.pop(key, None)
+
+    def test_imu_viewer_controls_update_managed_session_without_cooking_graph(self):
+        node_id = "imu-viewer-direct-control-test"
+        server._session.node_meta[node_id] = {
+            "id": node_id,
+            "type": "IMUViewer",
+            "params": {"viewer_id": "imu-live"},
+        }
+        server._session.graph._dirty.add(node_id)
+        calls = []
+
+        def runtime_callable(label, _module, function_name):
+            def control(runtime_id):
+                calls.append((label, function_name, runtime_id))
+                return {
+                    "running": function_name != "stop_imu_viewer",
+                    "live": function_name != "stop_imu_viewer",
+                    "scene": {"primitive": "imu-orientation"},
+                    "status": {"state": "ready"},
+                    "report": f"{runtime_id}:{function_name}",
+                }
+            return control
+
+        try:
+            with (
+                patch.object(server, "_runtime_callable", side_effect=runtime_callable),
+                patch.object(server, "_prepare_cook") as prepare_cook,
+            ):
+                client = TestClient(server.app)
+                status = client.post(f"/nodes/{node_id}/control", json={"action": "status"})
+                stopped = client.post(f"/nodes/{node_id}/control", json={"action": "stop"})
+
+            self.assertEqual(status.status_code, 200)
+            self.assertEqual(stopped.status_code, 200)
+            self.assertEqual(calls, [
+                ("imu_viewer", "imu_viewer_status", "imu-live"),
+                ("imu_viewer", "stop_imu_viewer", "imu-live"),
+            ])
+            prepare_cook.assert_not_called()
+        finally:
+            server._session.node_meta.pop(node_id, None)
+            server._session.graph._dirty.discard(node_id)
+            for key in [key for key in server._session.graph._cache if key[0] == node_id]:
+                server._session.graph._cache.pop(key, None)
+
 
     def test_trajectory_smoother_control_recomputes_only_smoother(self):
         node_id = "smoother-control-test"

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -137,6 +137,10 @@ def test_core_index_maps_official_node_types_to_git_packages():
         "SLAM",
         "WarpParticleLocalization",
         "WarpDynamicOccupancy",
+        "WarpDepthProjector",
+        "WarpTSDFIntegration",
+        "WarpSurfaceExtraction",
+        "WarpSensorFusion",
         "WarpTrajectoryEvaluator",
         "WarpLaserScanFilter",
         "WarpLiDARViewer",
@@ -149,9 +153,16 @@ def test_core_index_maps_official_node_types_to_git_packages():
         "LiDARROS2Scan",
         "LiDARROS2WarpViewer",
     ]
+    assert perception["imu"]["default"] is True
+    assert perception["imu"]["node_types"] == ["IMU", "IMUTestProvider", "IMUViewer"]
     assert payload["nodes"]["LiDARROS2Scan"]["package"] == "blacknode-perception"
+    assert payload["nodes"]["IMUViewer"]["package"] == "blacknode-perception"
     assert payload["nodes"]["WarpParticleLocalization"]["package"] == "blacknode-cuda"
     assert payload["nodes"]["WarpDynamicOccupancy"]["package"] == "blacknode-cuda"
+    assert payload["nodes"]["WarpDepthProjector"]["package"] == "blacknode-cuda"
+    assert payload["nodes"]["WarpTSDFIntegration"]["package"] == "blacknode-cuda"
+    assert payload["nodes"]["WarpSurfaceExtraction"]["package"] == "blacknode-cuda"
+    assert payload["nodes"]["WarpSensorFusion"]["package"] == "blacknode-cuda"
     assert payload["nodes"]["WarpTrajectoryEvaluator"]["package"] == "blacknode-cuda"
     drivers = payload["packages"]["blacknode-drivers"]
     assert drivers["layer"] == "drivers"


### PR DESCRIPTION
## What changed

- add the dedicated 3D IMU orientation viewer with the B-logo robot and body/world axes
- extend the shared point-cloud viewer for metric depth, RGB-D reconstruction, and LiDAR/depth/RGB fusion telemetry
- add direct managed-viewer controls and register the new package nodes in the catalog
- add editor and runtime coverage

## Why

Operators need a separate diagnostic viewer for every sensor before relying on mapping, reconstruction, fusion, or autonomy.

## Impact

The editor now presents camera, LiDAR, SLAM, metric depth, IMU, RGB-D reconstruction, and cross-sensor fusion views through their owning package contracts.

## Validation

- core: 538 passed, 8 skipped
- editor: `npm run build`
- Rust: `cargo test`
- package catalog validation passed

## Delivery

This is editor/catalog integration only, so no managed Runtime release is required. Merge the extension packages first; installed devices receive their package releases after **Devices → Software → Check updates → Update all**.