### PR TITLE
Wire generic ROS2 sensor processing

### DIFF
--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -670,6 +670,41 @@ class RuntimeDeviceClient(HardwareDeviceClient):
             timeout=30.0,
         )
 
+    def ros2_image_status(self, stream_id: str) -> dict[str, Any]:
+        return self._request("GET", self._ros2_image_endpoint(stream_id), timeout=5.0)
+
+    def start_ros2_image(
+        self,
+        stream_id: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"{self._ros2_image_endpoint(stream_id)}/start",
+            payload=payload,
+            timeout=max(30.0, float(payload.get("timeout") or 15.0) + 15.0),
+        )
+
+    def read_ros2_image_once(
+        self,
+        stream_id: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"{self._ros2_image_endpoint(stream_id)}/once",
+            payload=payload,
+            timeout=max(30.0, float(payload.get("timeout") or 15.0) + 15.0),
+        )
+
+    def stop_ros2_image(self, stream_id: str) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"{self._ros2_image_endpoint(stream_id)}/stop",
+            payload={},
+            timeout=30.0,
+        )
+
     def get_service(self, service_id: str) -> dict[str, Any]:
         return self._request("GET", self._service_endpoint(service_id), timeout=30.0)
 
@@ -729,6 +764,13 @@ class RuntimeDeviceClient(HardwareDeviceClient):
         if not clean_id:
             raise DeviceRegistryError("ROS 2 topic stream ID is required.")
         return f"/ros2/topics/{urllib.parse.quote(clean_id, safe='')}"
+
+    @staticmethod
+    def _ros2_image_endpoint(stream_id: str) -> str:
+        clean_id = str(stream_id or "").strip()
+        if not clean_id:
+            raise DeviceRegistryError("ROS 2 image stream ID is required.")
+        return f"/ros2/images/{urllib.parse.quote(clean_id, safe='')}"
 
 
 class DeviceRegistry:

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -670,11 +670,18 @@ _RUNTIME_CALLABLE_ALIASES = {
 
 _remote_ros2_lock = threading.RLock()
 _remote_ros2_runs: dict[str, dict[str, Any]] = {}
+_remote_ros2_image_lock = threading.RLock()
+_remote_ros2_image_runs: dict[str, dict[str, Any]] = {}
 
 
 def _remote_ros2_service_id(node_id: str) -> str:
     clean = re.sub(r"[^a-z0-9-]+", "-", str(node_id or "").lower()).strip("-")
     return f"editor-{clean}"[:64] or "editor-ros2"
+
+
+def _remote_ros2_image_service_id(node_id: str) -> str:
+    clean = re.sub(r"[^a-z0-9-]+", "-", str(node_id or "").lower()).strip("-")
+    return f"editor-image-{clean}"[:64] or "editor-image"
 
 
 def _remote_ros2_error_outputs(
@@ -957,6 +964,138 @@ def _stop_remote_ros2_services() -> dict[str, Any]:
     }
 
 
+def _ensure_remote_ros2_image_ready(client: RuntimeDeviceClient) -> None:
+    _ensure_remote_ros2_ready(client)
+    features = {str(item) for item in (client.manifest().get("features") or [])}
+    if "remote_ros2_image_stream_v1" not in features:
+        raise DeviceRegistryError(
+            "Update Blacknode Runtime to 0.4.10 or newer from Devices → Software."
+        )
+
+
+def _paired_stream_url(client: RuntimeDeviceClient, value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    stream = urllib.parse.urlsplit(raw)
+    paired = urllib.parse.urlsplit(client.base_url)
+    if not stream.hostname or not paired.hostname:
+        return raw
+    host = paired.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    port = f":{stream.port}" if stream.port is not None else ""
+    return urllib.parse.urlunsplit((paired.scheme or stream.scheme, host + port, stream.path, stream.query, stream.fragment))
+
+
+def _normalize_remote_ros2_image_response(
+    client: RuntimeDeviceClient,
+    request: dict[str, Any],
+    response: dict[str, Any],
+) -> dict[str, Any]:
+    result = copy.deepcopy(
+        response.get("stream") if isinstance(response.get("stream"), dict) else {}
+    )
+    for key in ("stream_url", "snapshot_url", "health_url", "frame_url"):
+        result[key] = _paired_stream_url(client, result.get(key))
+    result["device_id"] = str(request.get("device_id") or "")
+    result["backend"] = f"remote:{result['device_id']}"
+    return {"id": str(response.get("id") or ""), "stream": result}
+
+
+def _remote_ros2_image_action(request: dict[str, Any]) -> dict[str, Any]:
+    node_id = str(request.get("node_id") or "").strip()
+    device_id = str(request.get("device_id") or "").strip()
+    action = str(request.get("action") or "status").strip().lower()
+    if not node_id or not device_id:
+        raise RuntimeError("ROS2 image execution requires a node and paired device")
+    stream_id = _remote_ros2_image_service_id(node_id)
+    payload = {
+        key: request.get(key)
+        for key in (
+            "topic",
+            "message_type",
+            "port",
+            "max_fps",
+            "max_width",
+            "jpeg_quality",
+            "timeout",
+        )
+    }
+    client = _device_registry.runtime_client(device_id)
+    try:
+        if action == "start":
+            _ensure_remote_ros2_image_ready(client)
+            response = client.start_ros2_image(stream_id, payload)
+            with _remote_ros2_image_lock:
+                _remote_ros2_image_runs[node_id] = dict(request)
+        elif action == "once":
+            _ensure_remote_ros2_image_ready(client)
+            response = client.read_ros2_image_once(stream_id, payload)
+        elif action == "stop":
+            response = client.stop_ros2_image(stream_id)
+            with _remote_ros2_image_lock:
+                _remote_ros2_image_runs.pop(node_id, None)
+        elif action == "status":
+            response = client.ros2_image_status(stream_id)
+        else:
+            raise RuntimeError(f"unknown ROS2 image action {action!r}")
+        return _normalize_remote_ros2_image_response(client, request, response)
+    except DeviceRegistryError as exc:
+        return {
+            "id": stream_id,
+            "stream": {
+                "ok": False,
+                "running": False,
+                "stream_id": stream_id,
+                "device_id": device_id,
+                "backend": f"remote:{device_id}",
+                "error": str(exc),
+            },
+        }
+
+
+def _remote_ros2_image_runtime_status() -> dict[str, Any]:
+    with _remote_ros2_image_lock:
+        runs = [(node_id, dict(item)) for node_id, item in _remote_ros2_image_runs.items()]
+    node_outputs = []
+    for node_id, request in runs:
+        result = _remote_ros2_image_action({**request, "node_id": node_id, "action": "status"})
+        node_outputs.append({
+            "node_type": str(request.get("node_type") or "ROS2Image"),
+            "node_id": node_id,
+            "run_id": str(result.get("id") or _remote_ros2_image_service_id(node_id)),
+            "outputs": dict(result.get("stream") or {}),
+        })
+    return {
+        "ok": all(bool(item.get("outputs", {}).get("ok", True)) for item in node_outputs),
+        "active": bool(runs),
+        "streams": [],
+        "managed_runs": [],
+        "node_outputs": node_outputs,
+        "detached_count": 0,
+    }
+
+
+def _stop_remote_ros2_image_services() -> dict[str, Any]:
+    with _remote_ros2_image_lock:
+        runs = [(node_id, dict(item)) for node_id, item in _remote_ros2_image_runs.items()]
+    errors = []
+    for node_id, request in runs:
+        result = _remote_ros2_image_action({**request, "node_id": node_id, "action": "stop"})
+        error = str(result.get("stream", {}).get("error") or "")
+        if error:
+            errors.append(error)
+    with _remote_ros2_image_lock:
+        _remote_ros2_image_runs.clear()
+    return {
+        "ok": not errors,
+        "stopped": {"streams": len(runs)},
+        "errors": errors,
+        "report": f"stopped {len(runs)} remote ROS2 image stream(s)",
+    }
+
+
 def _runtime_module(module_name: str):
     module = sys.modules.get(module_name)
     if module is not None:
@@ -1021,6 +1160,7 @@ def _runtime_status() -> dict[str, Any]:
         for label, module_name in _RUNTIME_MODULES.items()
     }
     modules["remote_ros2"] = _remote_ros2_runtime_status()
+    modules["remote_ros2_images"] = _remote_ros2_image_runtime_status()
     streams: list[dict[str, Any]] = []
     cv2_streams: list[dict[str, Any]] = []
     reasoning_streams: list[dict[str, Any]] = []
@@ -1080,6 +1220,7 @@ def _stop_runtime_services() -> dict[str, Any]:
         for label, module_name in _RUNTIME_MODULES.items()
     }
     modules["remote_ros2"] = _stop_remote_ros2_services()
+    modules["remote_ros2_images"] = _stop_remote_ros2_image_services()
     stopped = {"streams": 0, "managed_runs": 0, "detached": 0, "cv2_streams": 0, "reasoning_streams": 0}
     for result in modules.values():
         raw_stopped = result.get("stopped") if isinstance(result.get("stopped"), dict) else {}
@@ -4315,6 +4456,7 @@ def _refresh_live_compute_device_params() -> None:
     """Inject ephemeral live state immediately before an editor cook."""
     _session.graph.set_runtime_context(
         __remote_ros2_action__=_remote_ros2_action,
+        __remote_ros2_image_action__=_remote_ros2_image_action,
         __message_stream_reader__=_message_stream_reader,
     )
     for node in _session.graph._nodes.values():

--- a/editor/src/components/ROS2GraphExplorerNode.tsx
+++ b/editor/src/components/ROS2GraphExplorerNode.tsx
@@ -198,6 +198,7 @@ export default function ROS2GraphExplorerNode({ id, data, selected }: NodeProps<
   const [notice, setNotice] = useState('')
   const cookNode = useStore(state => state.cookNode)
   const addNode = useStore(state => state.addNode)
+  const addNodeFromConnection = useStore(state => state.addNodeFromConnection)
   const nodes = useStore(state => state.nodes)
   const nodeDefs = useStore(state => state.nodeDefs)
   const graph = graphValue(data.portResults?.graph)
@@ -262,20 +263,41 @@ export default function ROS2GraphExplorerNode({ id, data, selected }: NodeProps<
 
   const addMonitor = async (topic: RosTopic) => {
     const messageType = topic.types?.[0] || ''
-    const lowerName = topic.name.toLowerCase()
     let type = 'ROS2TopicEcho'
+    let processorType = ''
     let params: Record<string, unknown> = {
       topic: topic.name,
       msg_type: messageType,
       count: 1,
     }
     if (messageType === 'sensor_msgs/msg/Image' || messageType === 'sensor_msgs/msg/CompressedImage') {
-      if (lowerName.includes('depth') && nodeDefs.DepthROS2Subscribe) {
-        type = 'DepthROS2Subscribe'
-        params = { topic: topic.name }
-      } else if (nodeDefs.CameraROS2Subscribe) {
-        type = 'CameraROS2Subscribe'
-        params = { topic: topic.name, message_type: messageType || 'auto' }
+      if (nodeDefs.ROS2) {
+        type = 'ROS2'
+        processorType = /(^|\/)depth([/_]|$)|disparity/i.test(topic.name)
+          ? 'DepthImageProcessor'
+          : 'CameraImageProcessor'
+        params = {
+          action: 'start',
+          topic: topic.name,
+          message_type: messageType,
+          transport: 'image',
+          stream_options: {},
+          qos: 'sensor_data',
+        }
+      }
+    } else if (messageType === 'sensor_msgs/msg/LaserScan' && nodeDefs.ROS2) {
+      type = 'ROS2'
+      processorType = 'LaserScanProcessor'
+      params = {
+        action: 'start', topic: topic.name, message_type: messageType,
+        transport: 'message', stream_options: {}, qos: 'sensor_data',
+      }
+    } else if (messageType === 'sensor_msgs/msg/Imu' && nodeDefs.ROS2) {
+      type = 'ROS2'
+      processorType = 'IMUProcessor'
+      params = {
+        action: 'start', topic: topic.name, message_type: messageType,
+        transport: 'message', stream_options: {}, qos: 'sensor_data',
       }
     } else if (messageType === 'sensor_msgs/msg/JointState' && nodeDefs.ROS2JointState) {
       type = 'ROS2JointState'
@@ -289,10 +311,24 @@ export default function ROS2GraphExplorerNode({ id, data, selected }: NodeProps<
     const existingMonitors = nodes.filter(node => (
       String(node.data.params?.topic || '') === topic.name
     )).length
-    await addNode(type, {
+    const position = {
       x: (self?.position.x ?? 0) + 1080,
       y: (self?.position.y ?? 0) + existingMonitors * 190,
-    }, params)
+    }
+    const transportId = await addNode(type, position, params)
+    if (transportId && processorType && nodeDefs[processorType]) {
+      await addNodeFromConnection(processorType, {
+        x: position.x + 360,
+        y: position.y,
+      }, {
+        nodeId: transportId,
+        handleId: 'stream',
+        handleType: 'source',
+        portType: 'Dict',
+      })
+      setNotice(`Added ROS2 → ${processorType} for ${topic.name}`)
+      return
+    }
     setNotice(`Added ${type} for ${topic.name}`)
   }
 

--- a/editor/src/liveNodeTypes.ts
+++ b/editor/src/liveNodeTypes.ts
@@ -5,7 +5,7 @@
 // sync with the actual `live=True` stream nodes in the Python registry.
 export const LIVE_STREAM_NODE_TYPES = new Set([
   'Camera',
-  'CameraROS2Subscribe',
+  'ROS2',
   'CameraROS2Publish',
   'CameraROS2Http',
   'TrackingObject',

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -291,7 +291,7 @@ interface Store {
     recordHistory?: boolean,
   ) => Promise<void>
 
-  addNode: (typeName: string, pos: { x: number; y: number }, params?: Record<string, unknown>) => Promise<void>
+  addNode: (typeName: string, pos: { x: number; y: number }, params?: Record<string, unknown>) => Promise<string | undefined>
   addNodeFromConnection: (typeName: string, pos: { x: number; y: number }, draft: ConnectionDraft, params?: Record<string, unknown>) => Promise<void>
   removeNode: (id: string) => Promise<void>
   resizeNode: (id: string, size: { width: number; height: number }) => void
@@ -2394,11 +2394,12 @@ export const useStore = create<Store>((set, get) => ({
       // Also remove the node from the root graph (it was added there by api.addNode)
       await api.removeNode(meta.id)
       set(s => ({ nodes: newNodes, ...markActiveTabDirty(s) }))
-      return
+      return meta.id
     }
     const meta = await api.addNode(typeName, [pos.x, pos.y], params)
     const node = makeReactNode(meta)
     set(s => ({ nodes: [...s.nodes, node], ...markActiveTabDirty(s) }))
+    return meta.id
   },
 
   addNodeFromConnection: async (typeName, pos, draft, params = {}) => {

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -656,6 +656,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                         "Camera",
                         "CameraCalibration",
                         "CameraDiscovery",
+                        "CameraImageProcessor",
                         "CameraSelect",
                         "CameraStream"
                     ],
@@ -665,7 +666,6 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                             "default": True,
                             "node_types": [
                                 "CameraROS2Provider",
-                                "CameraROS2Subscribe",
                                 "CameraROS2Publish",
                                 "CameraROS2Http"
                             ]
@@ -690,16 +690,14 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "node_types": [
                         "DepthCamera",
                         "DepthCameraDeviceSelect",
-                        "DepthCameraTestProvider",
+                        "DepthImageProcessor",
                         "DepthObstacleWarning"
                     ],
                     "adapters": {
                         "ros2": {
                             "name": "ros2",
                             "default": True,
-                            "node_types": [
-                                "DepthROS2Subscribe"
-                            ]
+                            "node_types": []
                         }
                     }
                 },
@@ -707,17 +705,14 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "name": "lidar",
                     "default": True,
                     "node_types": [
-                        "LiDAR",
-                        "LiDARTestProvider"
+                        "LaserScanProcessor",
+                        "LiDAR"
                     ],
                     "adapters": {
                         "ros2": {
                             "name": "ros2",
                             "default": True,
-                            "node_types": [
-                                "LiDARROS2Scan",
-                                "LiDARROS2WarpViewer"
-                            ],
+                            "node_types": [],
                             "dependencies": {
                                 "requires": [
                                     {
@@ -739,8 +734,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                     "name": "imu",
                     "default": True,
                     "node_types": [
+                        "IMUProcessor",
                         "IMU",
-                        "IMUTestProvider",
                         "IMUViewer"
                     ]
                 },
@@ -791,26 +786,23 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "CameraCalibration",
                 "CameraDashboard",
                 "CameraDiscovery",
+                "CameraImageProcessor",
                 "CameraROS2Provider",
                 "CameraROS2Http",
                 "CameraROS2Publish",
-                "CameraROS2Subscribe",
                 "CameraSelect",
                 "CameraStream",
                 "DetectionPrompt",
                 "DetectionStream",
                 "DepthCamera",
                 "DepthCameraDeviceSelect",
-                "DepthCameraTestProvider",
+                "DepthImageProcessor",
                 "DepthObstacleWarning",
-                "DepthROS2Subscribe",
                 "FramePrompt",
+                "LaserScanProcessor",
                 "LiDAR",
-                "LiDARROS2Scan",
-                "LiDARROS2WarpViewer",
-                "LiDARTestProvider",
+                "IMUProcessor",
                 "IMU",
-                "IMUTestProvider",
                 "IMUViewer",
                 "ReasoningDashboard",
                 "ReasoningStream",

--- a/python/blacknode/workflow.py
+++ b/python/blacknode/workflow.py
@@ -299,7 +299,7 @@ def run_workflow_logged(data: Mapping[str, Any]) -> dict[str, Any]:
 #: Live stream node types kept for graphs exported on a machine where the
 #: owning package is not installed, so the registry cannot answer for them.
 _LEGACY_LIVE_RUNTIME_NODE_TYPES = frozenset({
-    "Camera", "CameraStream", "CameraROS2Subscribe", "CV2CameraStream",
+    "Camera", "CameraStream", "ROS2", "CV2CameraStream",
     "TrackingObject", "CV2ColorObjectStream", "ReasoningStream", "ROS2ImageStream", "ROS2Run",
 })
 

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -235,7 +235,7 @@ class EditorRuntimeTests(unittest.TestCase):
             def manifest(self):
                 return {
                     "features": ["remote_ros2_topic_stream_v1"],
-                    "packages": [{"name": "blacknode-ros2", "version": "0.5.20"}],
+                    "packages": [{"name": "blacknode-ros2", "version": "0.6.0"}],
                     "node_types": ["ROS2"],
                 }
 
@@ -331,6 +331,73 @@ class EditorRuntimeTests(unittest.TestCase):
         self.assertEqual([item["name"] for item in synced], ["blacknode-ros2"])
         self.assertEqual(synced[0]["components"], ["core", "topics"])
         self.assertTrue(synced[0]["update"])
+
+    def test_remote_ros2_image_action_uses_paired_device_and_rewrites_stream_urls(self):
+        calls = []
+
+        class FakeRuntimeClient:
+            base_url = "http://robot.local:8766"
+
+            def manifest(self):
+                return {
+                    "features": [
+                        "remote_ros2_topic_stream_v1",
+                        "remote_ros2_image_stream_v1",
+                    ],
+                    "packages": [{"name": "blacknode-ros2", "version": "0.6.0"}],
+                    "node_types": ["ROS2"],
+                }
+
+            def start_ros2_image(self, stream_id, payload):
+                calls.append(("start", stream_id, payload))
+                return {"id": stream_id, "stream": {
+                    "ok": True,
+                    "running": True,
+                    "stream_url": "http://0.0.0.0:19001/stream.mjpg",
+                    "snapshot_url": "http://127.0.0.1:19001/snapshot.jpg",
+                    "health_url": "http://0.0.0.0:19001/health",
+                    "frame_url": "http://0.0.0.0:19001/frame.bin",
+                }}
+
+            def ros2_image_status(self, stream_id):
+                calls.append(("status", stream_id))
+                return self.start_ros2_image(stream_id, {})
+
+            def stop_ros2_image(self, stream_id):
+                calls.append(("stop", stream_id))
+                return {"id": stream_id, "stream": {"ok": True, "running": False}}
+
+        registry = SimpleNamespace(runtime_client=lambda device_id: FakeRuntimeClient())
+        request = {
+            "node_id": "rgb-camera",
+            "node_type": "ROS2",
+            "device_id": "jetson",
+            "action": "start",
+            "topic": "/camera/image_raw",
+            "message_type": "auto",
+            "max_fps": 10.0,
+        }
+        server._remote_ros2_image_runs.clear()
+        try:
+            with patch.object(server, "_device_registry", registry):
+                started = server._remote_ros2_image_action(request)
+                runtime = server._remote_ros2_image_runtime_status()
+                stopped = server._remote_ros2_image_action({**request, "action": "stop"})
+
+            self.assertEqual(
+                started["stream"]["stream_url"],
+                "http://robot.local:19001/stream.mjpg",
+            )
+            self.assertEqual(
+                started["stream"]["snapshot_url"],
+                "http://robot.local:19001/snapshot.jpg",
+            )
+            self.assertEqual(started["stream"]["device_id"], "jetson")
+            self.assertTrue(runtime["active"])
+            self.assertFalse(stopped["stream"]["running"])
+            self.assertEqual([item[0] for item in calls], ["start", "status", "start", "stop"])
+        finally:
+            server._remote_ros2_image_runs.clear()
 
     def test_stop_runtime_services_aggregates_package_runtime_modules(self):
         def fake_stop(label, _module_name):

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -34,6 +36,48 @@ def _workflow(node_type: str, required_packages=None):
         },
         "edges": [],
     }
+
+
+def test_real_sensor_templates_use_generic_ros2_then_typed_processor():
+    repository = Path(__file__).resolve().parents[1]
+    template_roots = [
+        repository / "packages" / "blacknode-perception",
+        repository / "packages" / "blacknode-cuda",
+        repository / "packages" / "blacknode-skills",
+    ]
+    processor_types = {
+        "sensor_msgs/msg/Image": {"CameraImageProcessor", "DepthImageProcessor"},
+        "sensor_msgs/msg/CompressedImage": {"CameraImageProcessor"},
+        "sensor_msgs/msg/LaserScan": {"LaserScanProcessor"},
+        "sensor_msgs/msg/Imu": {"IMUProcessor"},
+    }
+    checked = []
+
+    for root in template_roots:
+        for path in root.rglob("templates/*.json"):
+            workflow = json.loads(path.read_text(encoding="utf-8"))
+            if workflow.get("kind") != "blacknode.workflow":
+                continue
+            nodes = workflow.get("node_meta") or {}
+            edges = workflow.get("edges") or []
+            for node_id, meta in nodes.items():
+                if meta.get("type") != "ROS2":
+                    continue
+                message_type = str((meta.get("params") or {}).get("message_type") or "")
+                accepted = processor_types.get(message_type)
+                if not accepted:
+                    continue
+                assert any(item.get("type") == "ComputeDevice" for item in nodes.values()), path
+                assert any(
+                    edge.get("from") == node_id
+                    and edge.get("from_port") == "stream"
+                    and edge.get("to_port") == "source"
+                    and (nodes.get(edge.get("to")) or {}).get("type") in accepted
+                    for edge in edges
+                ), f"{path}: ROS2 {node_id} must feed {sorted(accepted)}"
+                checked.append((path.name, node_id))
+
+    assert len(checked) >= 13
 
 
 def test_core_index_maps_official_node_types_to_git_packages():
@@ -148,14 +192,10 @@ def test_core_index_maps_official_node_types_to_git_packages():
     ]
     perception = payload["packages"]["blacknode-perception"]["components"]
     assert perception["lidar"]["default"] is True
-    assert perception["lidar"]["node_types"] == ["LiDAR", "LiDARTestProvider"]
-    assert perception["lidar"]["adapters"]["ros2"]["node_types"] == [
-        "LiDARROS2Scan",
-        "LiDARROS2WarpViewer",
-    ]
+    assert perception["lidar"]["node_types"] == ["LaserScanProcessor", "LiDAR"]
+    assert perception["lidar"]["adapters"]["ros2"]["node_types"] == []
     assert perception["imu"]["default"] is True
-    assert perception["imu"]["node_types"] == ["IMU", "IMUTestProvider", "IMUViewer"]
-    assert payload["nodes"]["LiDARROS2Scan"]["package"] == "blacknode-perception"
+    assert perception["imu"]["node_types"] == ["IMUProcessor", "IMU", "IMUViewer"]
     assert payload["nodes"]["IMUViewer"]["package"] == "blacknode-perception"
     assert payload["nodes"]["WarpParticleLocalization"]["package"] == "blacknode-cuda"
     assert payload["nodes"]["WarpDynamicOccupancy"]["package"] == "blacknode-cuda"
@@ -220,9 +260,12 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["BaseSafetyGate"]["package"] == "blacknode-motion"
     assert payload["nodes"]["Camera"]["package"] == "blacknode-perception"
     assert payload["nodes"]["CameraStream"]["package"] == "blacknode-perception"
+    assert payload["nodes"]["CameraImageProcessor"]["package"] == "blacknode-perception"
     assert payload["nodes"]["DepthCamera"]["package"] == "blacknode-perception"
     assert payload["nodes"]["DepthCameraDeviceSelect"]["package"] == "blacknode-perception"
-    assert payload["nodes"]["DepthCameraTestProvider"]["package"] == "blacknode-perception"
+    assert payload["nodes"]["DepthImageProcessor"]["package"] == "blacknode-perception"
+    assert payload["nodes"]["LaserScanProcessor"]["package"] == "blacknode-perception"
+    assert payload["nodes"]["IMUProcessor"]["package"] == "blacknode-perception"
     assert payload["nodes"]["DepthObstacleWarning"]["package"] == "blacknode-perception"
     assert payload["nodes"]["ACTTraining"] == {
         "package": "blacknode-training",


### PR DESCRIPTION
## What changed
- routes paired-device ROS2 messages and image streams through the editor Runtime
- updates package ownership and live-node catalogs for typed sensor processors
- makes ROS graph topic actions add `ROS2 → processor` pairs automatically
- adds an architecture regression test for real sensor templates

## Why
The editor must expose one consistent real-sensor pipeline and keep device selection explicit.

## Validation
- core `539 passed, 8 skipped`
- package-index architecture checks `10 passed`
- editor production build
- Rust tests