### PR TITLE
Pin sensor viewer device release

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,10 +3,10 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "234ed7c22f04aad1e47a3b9841cf8bd4cbf3f5d2"
+    "commit": "61358c4f70c68ec6ffdcd0150d6a802d64af0818"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "a2bf7fb830cc551d877c2d4228e6155e725abfc1"
+    "commit": "72ea5b6e6b32f7bc48c9476c9da8bec1b5378933"
   }
 }


### PR DESCRIPTION
## What changed
- pins merged Runtime 0.4.11 commit `61358c4f70c68ec6ffdcd0150d6a802d64af0818`
- pins merged core sensor-viewer commit `72ea5b6e6b32f7bc48c9476c9da8bec1b5378933`

## Why
Managed devices need immutable merged sources for the Runtime update flow that delivers the new generic and specialized sensor viewers.

## Checks
- focused device update suite: 139 passed, 2 subtests passed
- full core suite: 753 passed, 8 skipped, 61 subtests passed

## Operator impact
Merging publishes **Latest**. Installed devices remain on **Current** until the operator uses **Devices → Software → Check updates → Update all**.