### PR TITLE
Keep ROS2 runtime tests version aware

### DIFF
--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -20,6 +20,28 @@ if str(EDITOR_SERVER_DIR) not in sys.path:
 import server  # noqa: E402
 
 
+def _target_ros2_version() -> str:
+    workflow = {
+        "kind": "blacknode.workflow",
+        "schema_version": 1,
+        "metadata": {
+            "required_packages": ["blacknode-ros2"],
+            "required_components": [
+                "blacknode-ros2/core",
+                "blacknode-ros2/topics",
+            ],
+        },
+        "node_meta": {"ros2": {"type": "ROS2"}},
+        "edges": [],
+    }
+    spec = next(
+        item
+        for item in server._workflow_target_package_specs(workflow)
+        if item.get("name") == "blacknode-ros2"
+    )
+    return str(spec.get("version") or "")
+
+
 class EditorRuntimeTests(unittest.TestCase):
     def test_streamed_cook_injects_process_local_runtime_services(self):
         node_id = "runtime-context-test"
@@ -235,7 +257,7 @@ class EditorRuntimeTests(unittest.TestCase):
             def manifest(self):
                 return {
                     "features": ["remote_ros2_topic_stream_v1"],
-                    "packages": [{"name": "blacknode-ros2", "version": "0.6.0"}],
+                    "packages": [{"name": "blacknode-ros2", "version": _target_ros2_version()}],
                     "node_types": ["ROS2"],
                 }
 
@@ -344,7 +366,7 @@ class EditorRuntimeTests(unittest.TestCase):
                         "remote_ros2_topic_stream_v1",
                         "remote_ros2_image_stream_v1",
                     ],
-                    "packages": [{"name": "blacknode-ros2", "version": "0.6.0"}],
+                    "packages": [{"name": "blacknode-ros2", "version": _target_ros2_version()}],
                     "node_types": ["ROS2"],
                 }
 


### PR DESCRIPTION
## What changed
- derive the expected `blacknode-ros2` version from the resolved package spec in paired-runtime test fixtures
- preserve the existing no-sync assertions when the installed extension version changes

## Why
Releasing `blacknode-ros2` 0.6.1 correctly made two fixtures pinned to 0.6.0 exercise the package-sync branch instead of the intended live-stream branch.

## Validation
- focused paired ROS2 runtime tests: 2 passed
- core suite: 539 passed, 8 skipped

## Managed Runtime release decision
No Runtime release. This change only updates tests and does not alter the managed-device bundle.