### PR TITLE
Add live controls to the depth viewer

### DIFF
--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Callable
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
@@ -2266,6 +2266,38 @@ def update_param(node_id: str, req: UpdateParamReq):
     _push_live_node_param_update(meta, req.key, req.value, old_params)
     _save()
     return meta
+
+
+@app.get("/nodes/{node_id}/depth-frame")
+def depth_frame(node_id: str):
+    meta = _session.node_meta.get(node_id)
+    if meta is None or meta.get("type") != "DepthViewer":
+        raise HTTPException(404, "DepthViewer node not found")
+    status = _session.graph._cache.get((node_id, "status"))
+    if not isinstance(status, dict):
+        raise HTTPException(409, "Run the DepthViewer once before opening its raw frame")
+    frame_url = str(status.get("frame_url") or "").strip()
+    parsed = urllib.parse.urlparse(frame_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.path != "/frame.bin":
+        raise HTTPException(409, "DepthViewer has no supported raw HTTP frame")
+    try:
+        request = urllib.request.Request(
+            frame_url,
+            headers={"Accept": "application/vnd.blacknode.metric-depth-frame"},
+        )
+        with urllib.request.urlopen(request, timeout=2.0) as upstream:
+            payload = upstream.read(256 * 1024 * 1024 + 1)
+    except (OSError, TimeoutError, urllib.error.URLError) as exc:
+        raise HTTPException(502, f"Raw depth frame unavailable: {type(exc).__name__}: {exc}") from exc
+    if len(payload) > 256 * 1024 * 1024:
+        raise HTTPException(413, "Raw depth frame exceeds 256 MiB")
+    if not payload.startswith(b"BNDEPTH1"):
+        raise HTTPException(502, "Raw depth source returned an invalid frame")
+    return Response(
+        content=payload,
+        media_type="application/vnd.blacknode.metric-depth-frame",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @app.post("/nodes/{node_id}/control")

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1429,6 +1429,12 @@ async function req<T>(method: string, path: string, body?: unknown, timeoutMs?: 
   }
 }
 
+async function binaryReq(path: string, signal?: AbortSignal): Promise<ArrayBuffer> {
+  const res = await fetchBackend(path, { method: 'GET', signal })
+  if (!res.ok) await responseJson<never>(res, path)
+  return res.arrayBuffer()
+}
+
 async function streamCook(
   path: string,
   body: unknown,
@@ -1574,6 +1580,8 @@ async function streamDeviceAction<T>(
 export const api = {
   nodeTypes: ()                              => req<string[]>('GET', '/node-types'),
   nodeDefs:  ()                              => req<Record<string, BnNodeDef>>('GET', '/node-defs'),
+  depthFrame: (nodeId: string, signal?: AbortSignal) =>
+    binaryReq(`/nodes/${encodeURIComponent(nodeId)}/depth-frame`, signal),
   // withGit runs per-package git status (branch/ahead/behind), which the
   // Packages panel shows. Leave it off for the frequent node-grouping refresh so
   // switching tabs or saving a script doesn't fire a burst of git commands.

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -20,6 +20,7 @@ import DatasetBrowserPanel from './DatasetBrowserPanel'
 import PointCloudViewer from './PointCloudViewer'
 import IMUOrientationViewer from './IMUOrientationViewer'
 import ImageSensorViewer from './ImageSensorViewer'
+import type { DepthDisplaySettings } from './ImageSensorViewer'
 import type { NodeCookState } from '../types'
 import { LIVE_STREAM_NODE_TYPES } from '../liveNodeTypes'
 import {
@@ -2732,6 +2733,16 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
           preview={data.portResults?.preview}
           status={data.portResults?.status}
           sensorKind={data.type === 'DepthViewer' ? 'depth' : 'camera'}
+          depthDisplay={data.type === 'DepthViewer' ? {
+            auto_range: data.params?.auto_range !== false,
+            near_m: Number(data.params?.near_m ?? 0.2),
+            far_m: Number(data.params?.far_m ?? 2.0),
+            palette: data.params?.palette === 'turbo' ? 'turbo' : 'grayscale',
+            invalid_color: data.params?.invalid_color === 'magenta' ? 'magenta' : 'black',
+          } satisfies DepthDisplaySettings : undefined}
+          onDepthDisplayChange={data.type === 'DepthViewer'
+            ? (key, value) => { void updateParam(id, key, value) }
+            : undefined}
           inputRail={(
             <ViewerInputStrip
               nodeId={id}

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -2730,6 +2730,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       )}
       {isImageSensorViewer && (
         <ImageSensorViewer
+          nodeId={id}
           preview={data.portResults?.preview}
           status={data.portResults?.status}
           sensorKind={data.type === 'DepthViewer' ? 'depth' : 'camera'}

--- a/editor/src/components/ImageSensorViewer.tsx
+++ b/editor/src/components/ImageSensorViewer.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { api } from '../api'
 
 interface ViewerStatus {
   state?: string
@@ -6,6 +7,7 @@ interface ViewerStatus {
   label?: string
   encoding?: string
   depth_scale?: number
+  frame_url?: string
   display?: {
     range?: string
     near_m?: number
@@ -25,25 +27,112 @@ export interface DepthDisplaySettings {
 
 type DepthDisplayKey = keyof DepthDisplaySettings
 
-function depthPreviewUrl(source: string, settings: DepthDisplaySettings, depthScale: number): string {
-  if (!source || !/^https?:\/\//i.test(source)) return source
-  try {
-    const url = new URL(source)
-    url.searchParams.set('depth_range', settings.auto_range ? 'auto' : 'fixed')
-    url.searchParams.set('depth_scale', String(depthScale))
-    url.searchParams.set('depth_palette', settings.palette)
-    url.searchParams.set('depth_invalid', settings.invalid_color)
-    if (settings.auto_range) {
-      url.searchParams.delete('depth_near_m')
-      url.searchParams.delete('depth_far_m')
-    } else {
-      url.searchParams.set('depth_near_m', String(settings.near_m))
-      url.searchParams.set('depth_far_m', String(settings.far_m))
-    }
-    return url.toString()
-  } catch {
-    return source
+interface MetricDepthFrame {
+  width: number
+  height: number
+  values: Float32Array
+}
+
+function parseMetricDepthFrame(payload: ArrayBuffer): MetricDepthFrame {
+  const bytes = new Uint8Array(payload)
+  if (bytes.length < 12 || new TextDecoder().decode(bytes.subarray(0, 8)) !== 'BNDEPTH1') {
+    throw new Error('Invalid metric depth frame')
   }
+  const view = new DataView(payload)
+  const headerSize = view.getUint32(8, true)
+  const headerEnd = 12 + headerSize
+  if (headerEnd > bytes.length) throw new Error('Truncated metric depth header')
+  const header = JSON.parse(new TextDecoder().decode(bytes.subarray(12, headerEnd))) as Record<string, unknown>
+  const width = Number(header.width ?? 0)
+  const height = Number(header.height ?? 0)
+  const encoding = String(header.encoding ?? '').toLowerCase()
+  const bytesPerPixel = encoding === '32fc1' ? 4 : 2
+  const step = Number(header.step ?? width * bytesPerPixel)
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0
+    || !['mono16', '16uc1', '32fc1'].includes(encoding)
+    || step < width * bytesPerPixel || headerEnd + height * step > bytes.length) {
+    throw new Error('Unsupported metric depth frame')
+  }
+  const littleEndian = header.is_bigendian !== true
+  const values = new Float32Array(width * height)
+  for (let y = 0; y < height; y += 1) {
+    const row = headerEnd + y * step
+    for (let x = 0; x < width; x += 1) {
+      const offset = row + x * bytesPerPixel
+      values[y * width + x] = encoding === '32fc1'
+        ? view.getFloat32(offset, littleEndian)
+        : view.getUint16(offset, littleEndian)
+    }
+  }
+  return { width, height, values }
+}
+
+const turboCoefficients = [
+  [0.13572138, 4.61539260, -42.66032258, 132.13108234, -152.94239396, 59.28637943],
+  [0.09140261, 2.19418839, 4.84296658, -14.18503333, 4.27729857, 2.82956604],
+  [0.10667330, 12.64194608, -60.58204836, 110.36276771, -89.90310912, 27.34824973],
+]
+
+function turboChannel(x: number, coefficients: number[]): number {
+  let value = 0
+  let power = 1
+  for (const coefficient of coefficients) {
+    value += coefficient * power
+    power *= x
+  }
+  return Math.round(Math.max(0, Math.min(1, value)) * 255)
+}
+
+function renderMetricDepth(
+  canvas: HTMLCanvasElement,
+  frame: MetricDepthFrame,
+  settings: DepthDisplaySettings,
+  depthScale: number,
+) {
+  let near = settings.near_m
+  let far = settings.far_m
+  if (settings.auto_range) {
+    const sample: number[] = []
+    const stride = Math.max(1, Math.floor(frame.values.length / 8192))
+    for (let index = 0; index < frame.values.length; index += stride) {
+      const value = frame.values[index] * depthScale
+      if (Number.isFinite(value) && value > 0) sample.push(value)
+    }
+    sample.sort((left, right) => left - right)
+    if (sample.length > 0) {
+      near = sample[Math.floor((sample.length - 1) * 0.02)]
+      far = sample[Math.floor((sample.length - 1) * 0.98)]
+    }
+  }
+  if (!(far > near)) far = near + 0.001
+  canvas.width = frame.width
+  canvas.height = frame.height
+  const context = canvas.getContext('2d')
+  if (!context) return
+  const image = context.createImageData(frame.width, frame.height)
+  for (let index = 0; index < frame.values.length; index += 1) {
+    const depth = frame.values[index] * depthScale
+    const target = index * 4
+    if (!Number.isFinite(depth) || depth <= 0) {
+      image.data[target] = settings.invalid_color === 'magenta' ? 255 : 0
+      image.data[target + 1] = 0
+      image.data[target + 2] = settings.invalid_color === 'magenta' ? 255 : 0
+    } else {
+      const intensity = Math.max(0, Math.min(1, 1 - (depth - near) / (far - near)))
+      if (settings.palette === 'turbo') {
+        image.data[target] = turboChannel(intensity, turboCoefficients[0])
+        image.data[target + 1] = turboChannel(intensity, turboCoefficients[1])
+        image.data[target + 2] = turboChannel(intensity, turboCoefficients[2])
+      } else {
+        const gray = Math.round(intensity * 255)
+        image.data[target] = gray
+        image.data[target + 1] = gray
+        image.data[target + 2] = gray
+      }
+    }
+    image.data[target + 3] = 255
+  }
+  context.putImageData(image, 0, 0)
 }
 
 const depthControl: React.CSSProperties = {
@@ -54,13 +143,14 @@ const depthControl: React.CSSProperties = {
   background: 'var(--lift)',
   color: 'var(--tx1)',
   fontFamily: 'var(--font-mono)',
-  fontSize: 10,
+  fontSize: 11,
   padding: '1px 4px',
   boxSizing: 'border-box',
 }
 
 export default function ImageSensorViewer({
   preview,
+  nodeId,
   status,
   sensorKind,
   inputRail,
@@ -68,6 +158,7 @@ export default function ImageSensorViewer({
   onDepthDisplayChange,
 }: {
   preview: unknown
+  nodeId: string
   status: unknown
   sensorKind: 'camera' | 'depth'
   inputRail?: ReactNode
@@ -83,14 +174,53 @@ export default function ImageSensorViewer({
     palette: parsed.display?.palette === 'turbo' ? 'turbo' : 'grayscale',
     invalid_color: parsed.display?.invalid_color === 'magenta' ? 'magenta' : 'black',
   }
-  const source = sensorKind === 'depth'
-    ? depthPreviewUrl(rawSource, settings, Number(parsed.depth_scale) || 1)
-    : rawSource
+  const source = rawSource
+  const frameUrl = String(parsed.frame_url || '')
+  const depthScale = Number(parsed.depth_scale) || 1
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const latestFrameRef = useRef<MetricDepthFrame | null>(null)
+  const settingsRef = useRef(settings)
+  settingsRef.current = settings
+  const [depthError, setDepthError] = useState('')
   const label = String(parsed.label || (sensorKind === 'depth' ? 'Depth' : 'Camera'))
   const state = String(parsed.state || (source ? 'ready' : 'waiting'))
   const setDepthDisplay = (key: DepthDisplayKey, value: boolean | number | string) => {
     onDepthDisplayChange?.(key, value)
   }
+
+  useEffect(() => {
+    if (sensorKind !== 'depth' || !frameUrl) return undefined
+    let active = true
+    let timer: number | undefined
+    let controller: AbortController | undefined
+    const poll = async () => {
+      controller = new AbortController()
+      try {
+        const payload = await api.depthFrame(nodeId, controller.signal)
+        if (!active) return
+        const frame = parseMetricDepthFrame(payload)
+        latestFrameRef.current = frame
+        if (canvasRef.current) renderMetricDepth(canvasRef.current, frame, settingsRef.current, depthScale)
+        setDepthError('')
+      } catch (error) {
+        if (!active || (error as { name?: string })?.name === 'AbortError') return
+        setDepthError(error instanceof Error ? error.message : String(error))
+      }
+      if (active) timer = window.setTimeout(poll, 100)
+    }
+    void poll()
+    return () => {
+      active = false
+      controller?.abort()
+      if (timer !== undefined) window.clearTimeout(timer)
+    }
+  }, [depthScale, frameUrl, nodeId, sensorKind])
+
+  useEffect(() => {
+    if (canvasRef.current && latestFrameRef.current) {
+      renderMetricDepth(canvasRef.current, latestFrameRef.current, settings, depthScale)
+    }
+  }, [depthScale, settings.auto_range, settings.far_m, settings.invalid_color, settings.near_m, settings.palette])
 
   return (
     <div
@@ -113,7 +243,20 @@ export default function ImageSensorViewer({
         </span>
       </div>
       <div style={{ flex: '1 1 auto', minHeight: 0, display: 'grid', placeItems: 'center', overflow: 'hidden', background: '#090c0f' }}>
-        {source ? (
+        {sensorKind === 'depth' && frameUrl ? (
+          <>
+            <canvas
+              ref={canvasRef}
+              aria-label={`${label} locally rendered metric depth view`}
+              style={{ width: '100%', height: '100%', objectFit: 'contain', imageRendering: 'pixelated' }}
+            />
+            {depthError && (
+              <span style={{ gridArea: '1 / 1', color: 'var(--err)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
+                {depthError}
+              </span>
+            )}
+          </>
+        ) : source ? (
           <img
             src={source}
             alt={`${label} sensor view`}
@@ -131,7 +274,7 @@ export default function ImageSensorViewer({
         <div style={{
           display: 'grid', gridTemplateColumns: 'auto 1fr 1fr', gap: '5px 7px', alignItems: 'center',
           padding: '6px 7px', borderTop: '1px solid var(--line)', color: 'var(--tx2)',
-          fontFamily: 'var(--font-mono)', fontSize: 10,
+          fontFamily: 'var(--font-mono)', fontSize: 11,
         }}>
           <label title="Use per-frame percentile contrast" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
             <input

--- a/editor/src/components/ImageSensorViewer.tsx
+++ b/editor/src/components/ImageSensorViewer.tsx
@@ -6,6 +6,57 @@ interface ViewerStatus {
   label?: string
   encoding?: string
   depth_scale?: number
+  display?: {
+    range?: string
+    near_m?: number
+    far_m?: number
+    palette?: string
+    invalid_color?: string
+  }
+}
+
+export interface DepthDisplaySettings {
+  auto_range: boolean
+  near_m: number
+  far_m: number
+  palette: 'grayscale' | 'turbo'
+  invalid_color: 'black' | 'magenta'
+}
+
+type DepthDisplayKey = keyof DepthDisplaySettings
+
+function depthPreviewUrl(source: string, settings: DepthDisplaySettings, depthScale: number): string {
+  if (!source || !/^https?:\/\//i.test(source)) return source
+  try {
+    const url = new URL(source)
+    url.searchParams.set('depth_range', settings.auto_range ? 'auto' : 'fixed')
+    url.searchParams.set('depth_scale', String(depthScale))
+    url.searchParams.set('depth_palette', settings.palette)
+    url.searchParams.set('depth_invalid', settings.invalid_color)
+    if (settings.auto_range) {
+      url.searchParams.delete('depth_near_m')
+      url.searchParams.delete('depth_far_m')
+    } else {
+      url.searchParams.set('depth_near_m', String(settings.near_m))
+      url.searchParams.set('depth_far_m', String(settings.far_m))
+    }
+    return url.toString()
+  } catch {
+    return source
+  }
+}
+
+const depthControl: React.CSSProperties = {
+  height: 23,
+  minWidth: 0,
+  border: '1px solid var(--line2)',
+  borderRadius: 4,
+  background: 'var(--lift)',
+  color: 'var(--tx1)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  padding: '1px 4px',
+  boxSizing: 'border-box',
 }
 
 export default function ImageSensorViewer({
@@ -13,16 +64,33 @@ export default function ImageSensorViewer({
   status,
   sensorKind,
   inputRail,
+  depthDisplay,
+  onDepthDisplayChange,
 }: {
   preview: unknown
   status: unknown
   sensorKind: 'camera' | 'depth'
   inputRail?: ReactNode
+  depthDisplay?: DepthDisplaySettings
+  onDepthDisplayChange?: (key: DepthDisplayKey, value: boolean | number | string) => void
 }) {
-  const source = typeof preview === 'string' ? preview : ''
+  const rawSource = typeof preview === 'string' ? preview : ''
   const parsed = status && typeof status === 'object' ? status as ViewerStatus : {}
+  const settings: DepthDisplaySettings = depthDisplay ?? {
+    auto_range: parsed.display?.range !== 'fixed',
+    near_m: Number(parsed.display?.near_m ?? 0.2),
+    far_m: Number(parsed.display?.far_m ?? 2.0),
+    palette: parsed.display?.palette === 'turbo' ? 'turbo' : 'grayscale',
+    invalid_color: parsed.display?.invalid_color === 'magenta' ? 'magenta' : 'black',
+  }
+  const source = sensorKind === 'depth'
+    ? depthPreviewUrl(rawSource, settings, Number(parsed.depth_scale) || 1)
+    : rawSource
   const label = String(parsed.label || (sensorKind === 'depth' ? 'Depth' : 'Camera'))
   const state = String(parsed.state || (source ? 'ready' : 'waiting'))
+  const setDepthDisplay = (key: DepthDisplayKey, value: boolean | number | string) => {
+    onDepthDisplayChange?.(key, value)
+  }
 
   return (
     <div
@@ -59,6 +127,76 @@ export default function ImageSensorViewer({
           </span>
         )}
       </div>
+      {sensorKind === 'depth' && (
+        <div style={{
+          display: 'grid', gridTemplateColumns: 'auto 1fr 1fr', gap: '5px 7px', alignItems: 'center',
+          padding: '6px 7px', borderTop: '1px solid var(--line)', color: 'var(--tx2)',
+          fontFamily: 'var(--font-mono)', fontSize: 10,
+        }}>
+          <label title="Use per-frame percentile contrast" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <input
+              type="checkbox"
+              checked={settings.auto_range}
+              onChange={event => setDepthDisplay('auto_range', event.target.checked)}
+            />
+            Auto
+          </label>
+          <label style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: 4, alignItems: 'center' }}>
+            Near m
+            <input
+              type="number"
+              min={0}
+              max={Math.max(0, settings.far_m - 0.001)}
+              step={0.05}
+              disabled={settings.auto_range}
+              value={settings.near_m}
+              onChange={event => {
+                const value = Number(event.target.value)
+                if (Number.isFinite(value)) setDepthDisplay('near_m', Math.max(0, Math.min(value, settings.far_m - 0.001)))
+              }}
+              style={{ ...depthControl, opacity: settings.auto_range ? 0.5 : 1 }}
+            />
+          </label>
+          <label style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: 4, alignItems: 'center' }}>
+            Far m
+            <input
+              type="number"
+              min={settings.near_m + 0.001}
+              step={0.05}
+              disabled={settings.auto_range}
+              value={settings.far_m}
+              onChange={event => {
+                const value = Number(event.target.value)
+                if (Number.isFinite(value)) setDepthDisplay('far_m', Math.max(settings.near_m + 0.001, value))
+              }}
+              style={{ ...depthControl, opacity: settings.auto_range ? 0.5 : 1 }}
+            />
+          </label>
+          <span title="Display changes update live and do not recook the graph">LIVE</span>
+          <label style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: 4, alignItems: 'center' }}>
+            Palette
+            <select
+              value={settings.palette}
+              onChange={event => setDepthDisplay('palette', event.target.value)}
+              style={depthControl}
+            >
+              <option value="grayscale">Gray</option>
+              <option value="turbo">Turbo</option>
+            </select>
+          </label>
+          <label style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: 4, alignItems: 'center' }}>
+            Missing
+            <select
+              value={settings.invalid_color}
+              onChange={event => setDepthDisplay('invalid_color', event.target.value)}
+              style={depthControl}
+            >
+              <option value="black">Black</option>
+              <option value="magenta">Magenta</option>
+            </select>
+          </label>
+        </div>
+      )}
       <div style={{
         minHeight: 25, display: 'flex', alignItems: 'center', gap: 10, padding: '0 9px',
         borderTop: '1px solid var(--line)', color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 11,

--- a/tests/test_editor_depth_viewer.py
+++ b/tests/test_editor_depth_viewer.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import struct
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITOR_SERVER_DIR = ROOT / "editor-server"
+
+if str(EDITOR_SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(EDITOR_SERVER_DIR))
+
+import server  # noqa: E402
+
+
+def _metric_frame() -> bytes:
+    header = json.dumps({
+        "width": 1,
+        "height": 1,
+        "step": 2,
+        "encoding": "16UC1",
+        "is_bigendian": False,
+    }).encode("utf-8")
+    return b"BNDEPTH1" + struct.pack("<I", len(header)) + header + struct.pack("<H", 500)
+
+
+class _UpstreamFrame:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _limit: int) -> bytes:
+        return self.payload
+
+
+def test_depth_frame_relay_uses_the_cooked_viewer_source():
+    node_id = "depth-viewer-relay-test"
+    payload = _metric_frame()
+    server._session.node_meta[node_id] = {
+        "id": node_id,
+        "type": "DepthViewer",
+        "params": {},
+    }
+    server._session.graph._cache[(node_id, "status")] = {
+        "frame_url": "http://robot.local:41000/frame.bin",
+    }
+    try:
+        with patch.object(
+            server.urllib.request,
+            "urlopen",
+            return_value=_UpstreamFrame(payload),
+        ) as open_frame:
+            response = TestClient(server.app).get(f"/nodes/{node_id}/depth-frame")
+    finally:
+        server._session.node_meta.pop(node_id, None)
+        server._session.graph._cache.pop((node_id, "status"), None)
+
+    assert response.status_code == 200
+    assert response.content == payload
+    assert response.headers["content-type"].startswith(
+        "application/vnd.blacknode.metric-depth-frame"
+    )
+    assert open_frame.call_args.args[0].full_url == "http://robot.local:41000/frame.bin"
+
+
+def test_depth_viewer_renders_raw_metric_frames_locally_without_recooking():
+    viewer = (
+        ROOT / "editor" / "src" / "components" / "ImageSensorViewer.tsx"
+    ).read_text(encoding="utf-8")
+    black_node = (
+        ROOT / "editor" / "src" / "components" / "BlackNode.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "parseMetricDepthFrame" in viewer
+    assert "renderMetricDepth" in viewer
+    assert "api.depthFrame(nodeId" in viewer
+    assert "<canvas" in viewer
+    assert "depthPreviewUrl" not in viewer
+    assert "onDepthDisplayChange" in black_node
+    assert "updateParam(id, key, value)" in black_node


### PR DESCRIPTION
## Summary
- relay the selected DepthViewer raw `frame.bin` through the local editor server
- decode and render metric depth in the browser canvas
- show near/far, auto-range, palette, and missing-pixel controls below the live image
- persist display settings and redraw immediately without recooking
- keep ROS2 and the Jetson as raw transport only

## Verification
- `python -m pytest tests -q` (755 passed, 8 skipped, 62 subtests passed)
- `npm run build`

## Managed Runtime release
No Runtime release is required. The relay and canvas renderer are editor/editor-server behavior and do not alter the managed device bundle.