### PR TITLE
Add live spatial viewers and training controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ editor-server/api_keys.json
 editor-server/custom_models.json
 editor-server/runs/
 editor-server/robots/
+editor-server/training/
 editor-server/.driver-*.json
 /trajectories/
 /robots/

--- a/docs/robot-policy-training.md
+++ b/docs/robot-policy-training.md
@@ -1,8 +1,9 @@
 # SO-ARM101 robot learning
 
-Blacknode connects synchronized demonstrations, dataset validation, ACT
-training, recorded-frame preview, policy artifacts, and safety-gated execution
-into one repeatable robot-learning loop.
+Blacknode connects vectorized reinforcement learning, synchronized
+demonstrations, dataset validation, policy training, simulation or recorded-frame
+evaluation, policy artifacts, and safety-gated execution into repeatable
+robot-learning loops.
 
 ```text
 SO-ARM101 teleoperation
@@ -38,10 +39,41 @@ joint and velocity limits, optional workspace bounds, emergency stop, and
 takeover. The physical driver enforces calibrated joint limits and its command
 watchdog again at the hardware boundary.
 
-The current trainer adapter is Blacknode Native ACT. `LeRobotV3Export` provides
-the implemented dataset interchange path for LeRobot-compatible datasets. A
-trainer that emits the Blacknode policy artifact contract can connect to the
-same runtime and safety workflow.
+The current trainer adapters are Blacknode Native ACT and PPO for the
+SO-ARM101 Newton reach environment. `LeRobotV3Export` provides the implemented
+dataset interchange path for LeRobot-compatible datasets. A trainer that emits
+the Blacknode policy artifact contract can connect to the same runtime and
+safety workflow.
+
+## Start with SO-ARM101 reinforcement learning
+
+Open **SO-ARM101 PPO Training**. This template starts with a reaching task so
+the observation, action, reward, checkpoint, and evaluation contracts can be
+validated before any physical policy test.
+
+1. `SO101ReachTask` loads the bundled SO-ARM101 USD and creates 512 replicated
+   arms by default. Its 21-value observation contains normalized joint
+   positions, joint velocities, Cartesian target error, and the prior action.
+2. The six normalized actions are bounded joint-position deltas. The reaching
+   curriculum holds the gripper near its midpoint; grasping can be introduced
+   as a later curriculum stage.
+3. Press **Run** on `PPOTraining`. Newton advances dynamics through Warp and the
+   managed PyTorch PPO job updates the policy. Start with the template defaults;
+   lower `environment_count` to 64 for a lightweight functional check.
+   Blacknode automatically opens the live simulation pane for one sampled arm.
+   The viewer shows the green reach target, orange end-effector trail, reward,
+   distance, episode step, and training update. Select another environment from
+   the viewer without restarting training.
+4. Use the node's **Stop** control for cooperative shutdown. Keep `resume=true`
+   and the same output directory to continue from the newest atomic checkpoint.
+5. Run `PPOPolicyEvaluate` on the checkpoint, then export it with
+   `PPOPolicyExport`. Evaluation and export retain a simulation-only safety
+   contract.
+
+The RL template never opens the SO-ARM101 transport and never authorizes
+physical motion. Moving the learned policy to the real arm is a separate
+milestone requiring calibrated observations, a bounded safety gate, explicit
+arming, stale-data handling, and an operator-held emergency stop.
 
 ## Milestone: 20 demonstrations to interrupted deployment
 
@@ -202,15 +234,18 @@ artifacts and logs so regressions can be traced to a dataset and training step.
 | Layer | Nodes and artifacts |
 | --- | --- |
 | Dataset | `EpisodeRecorder`, `EpisodeDatasetValidate`, `HDF5EpisodeExport`, `LeRobotV3Export` |
-| Training | `TrainingDatasetCheck`, `ACTTraining`, `ACTCheckpointInspect`, `ACTPolicyPreview` |
-| Artifact | `ACTPolicyExport`, `PolicyArtifactLoad`, `blacknode.policy-artifact` |
+| Simulation | `SO101ReachTask`, Newton/Warp vectorized environments |
+| Training | `TrainingDatasetCheck`, `ACTTraining`, `ACTCheckpointInspect`, `ACTPolicyPreview`, `PPOTraining`, `PPOCheckpointInspect`, `PPOPolicyEvaluate` |
+| Artifact | `ACTPolicyExport`, `PPOPolicyExport`, `PolicyArtifactLoad`, `blacknode.policy-artifact` |
 | Deployment | `PolicySafetyGate`, `PolicyRuntime`, `IsaacPolicySafetyGate`, `IsaacPolicyBridge`, `IsaacPolicyRuntime`, SO-ARM101 `Robot` |
 | Monitoring | training dashboard, policy metrics, `.blacknode/policy-runs/*.jsonl`, dataset replay |
 
 ## Verification boundary
 
-The automated suite uses synthetic HDF5 episodes, a compact ACT model, fake
-camera/state sources, and a fake command transport. It verifies artifact
+The automated suite uses synthetic HDF5 episodes, compact ACT and PPO models,
+fake camera/state sources, and a fake command transport. Development GPU smoke
+tests exercise replicated SO-ARM101 stepping, PPO checkpointing, cooperative
+stop, simulation evaluation, and safe artifact export. The suite verifies artifact
 loading, inference dimensions, disarmed preview, current-pose synchronization,
 joint/velocity/workspace gates, emergency stop, takeover semantics, shutdown,
 and replay logging. Physical SO-ARM101 motion requires deliberate operator-led

--- a/editor-server/device_registry.py
+++ b/editor-server/device_registry.py
@@ -667,7 +667,7 @@ class RuntimeDeviceClient(HardwareDeviceClient):
             "POST",
             f"{self._ros2_topic_endpoint(stream_id)}/stop",
             payload={},
-            timeout=30.0,
+            timeout=8.0,
         )
 
     def ros2_image_status(self, stream_id: str) -> dict[str, Any]:
@@ -702,7 +702,7 @@ class RuntimeDeviceClient(HardwareDeviceClient):
             "POST",
             f"{self._ros2_image_endpoint(stream_id)}/stop",
             payload={},
-            timeout=30.0,
+            timeout=8.0,
         )
 
     def get_service(self, service_id: str) -> dict[str, Any]:

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -1,7 +1,9 @@
 """Blacknode editor backend — FastAPI server the React editor talks to."""
 from __future__ import annotations
-import asyncio, uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex, hashlib, math, copy
+import asyncio, uuid, os, sys, json, threading, re, queue, io, contextlib, time, subprocess, importlib, signal, shlex, hashlib, math, copy, base64
+from array import array
 import urllib.error, urllib.parse, urllib.request
+from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
@@ -206,7 +208,8 @@ def _save_now() -> None:
         with open(_SAVE_PATH, "w") as f:
             json.dump({"node_meta": _session.node_meta,
                        "edges":     _session.graph._edges,
-                       "metadata":  _session.metadata}, f, indent=2)
+                       "metadata":  _session.metadata,
+                       "entrypoint": _session.entrypoint}, f, indent=2)
     except Exception as e:
         print(f"[blacknode] save error: {e}")
 
@@ -234,6 +237,8 @@ def _load() -> None:
         edges:    list = data.get("edges",     [])
         metadata = data.get("metadata")
         _session.metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        entrypoint = data.get("entrypoint")
+        _session.entrypoint = dict(entrypoint) if isinstance(entrypoint, dict) else None
         # only restore nodes whose type is still registered
         migrated = False
         for node_id, meta in meta_map.items():
@@ -272,6 +277,7 @@ class Session:
         self.graph = bn.Graph()
         self.node_meta: dict[str, dict] = {}
         self.metadata: dict[str, Any] = {}
+        self.entrypoint: dict[str, str] | None = None
 
 _session = Session()
 
@@ -349,6 +355,7 @@ class SetGraphReq(BaseModel):
     nodes: list[dict[str, Any]] = []
     edges: list[dict[str, Any]] = []
     metadata: dict[str, Any] = {}
+    entrypoint: dict[str, str] | None = None
 
 class UpdateWorkflowRequirementsReq(BaseModel):
     required_capabilities: list[str] = []
@@ -948,14 +955,18 @@ def _remote_ros2_runtime_status() -> dict[str, Any]:
 def _stop_remote_ros2_services() -> dict[str, Any]:
     with _remote_ros2_lock:
         runs = [(node_id, dict(item)) for node_id, item in _remote_ros2_runs.items()]
-    errors = []
-    for node_id, request in runs:
+        _remote_ros2_runs.clear()
+
+    def stop_one(item: tuple[str, dict[str, Any]]) -> str:
+        node_id, request = item
         try:
             _remote_ros2_action({**request, "node_id": node_id, "action": "stop"})
+            return ""
         except Exception as exc:
-            errors.append(str(exc))
-    with _remote_ros2_lock:
-        _remote_ros2_runs.clear()
+            return str(exc)
+
+    with ThreadPoolExecutor(max_workers=max(1, min(8, len(runs)))) as executor:
+        errors = [error for error in executor.map(stop_one, runs) if error] if runs else []
     return {
         "ok": not errors,
         "stopped": {"streams": len(runs)},
@@ -1080,14 +1091,18 @@ def _remote_ros2_image_runtime_status() -> dict[str, Any]:
 def _stop_remote_ros2_image_services() -> dict[str, Any]:
     with _remote_ros2_image_lock:
         runs = [(node_id, dict(item)) for node_id, item in _remote_ros2_image_runs.items()]
-    errors = []
-    for node_id, request in runs:
-        result = _remote_ros2_image_action({**request, "node_id": node_id, "action": "stop"})
-        error = str(result.get("stream", {}).get("error") or "")
-        if error:
-            errors.append(error)
-    with _remote_ros2_image_lock:
         _remote_ros2_image_runs.clear()
+
+    def stop_one(item: tuple[str, dict[str, Any]]) -> str:
+        node_id, request = item
+        try:
+            result = _remote_ros2_image_action({**request, "node_id": node_id, "action": "stop"})
+            return str(result.get("stream", {}).get("error") or "")
+        except Exception as exc:
+            return str(exc)
+
+    with ThreadPoolExecutor(max_workers=max(1, min(8, len(runs)))) as executor:
+        errors = [error for error in executor.map(stop_one, runs) if error] if runs else []
     return {
         "ok": not errors,
         "stopped": {"streams": len(runs)},
@@ -1192,6 +1207,98 @@ def _runtime_status() -> dict[str, Any]:
     }
 
 
+def _spatial_viewer_runtime_status() -> dict[str, Any]:
+    """Return focused spatial-viewer outputs without probing remote services."""
+    labels = ("viewer", "slam", "imu_viewer")
+    modules = {
+        label: _runtime_module_status(label, _RUNTIME_MODULES[label])
+        for label in labels
+    }
+    return _pack_spatial_viewer_scenes({
+        "ok": all(bool(status.get("ok", True)) for status in modules.values()),
+        "active": any(bool(status.get("active")) for status in modules.values()),
+        "modules": modules,
+        "report": "; ".join(
+            str(status.get("report") or status.get("error") or "").strip()
+            for status in modules.values()
+            if status.get("report") or status.get("error")
+        ),
+    })
+
+
+_SPATIAL_POINT_FIELDS = {
+    "points", "current_points", "floor_points", "occupied_points",
+    "particles", "dynamic_points", "dynamic_velocities",
+}
+_SPATIAL_COLOR_FIELDS = {
+    "colors", "current_colors", "floor_colors", "occupied_colors",
+}
+
+
+def _pack_numeric_rows(value: Any, *, color: bool = False) -> Any:
+    if not isinstance(value, list) or len(value) < 64:
+        return value
+    rows = [row for row in value if isinstance(row, (list, tuple)) and len(row) >= 2]
+    if len(rows) != len(value):
+        return value
+    try:
+        if color:
+            values = array("B")
+            for row in rows:
+                components = [float(row[index] if index < len(row) else 0.0) for index in range(3)]
+                if not all(math.isfinite(component) for component in components):
+                    return value
+                values.extend(max(0, min(255, round(component * 255.0))) for component in components)
+            encoding = "uint8-normalized-base64"
+        else:
+            values = array("f")
+            for row in rows:
+                components = [float(row[index] if index < len(row) else 0.0) for index in range(3)]
+                if not all(math.isfinite(component) for component in components):
+                    return value
+                values.extend(components)
+            if sys.byteorder != "little":
+                values.byteswap()
+            encoding = "float32-le-base64"
+    except (OverflowError, TypeError, ValueError):
+        return value
+    return {
+        "kind": "blacknode.numeric-rows",
+        "schema_version": 1,
+        "encoding": encoding,
+        "components": 3,
+        "count": len(rows),
+        "data": base64.b64encode(values.tobytes()).decode("ascii"),
+    }
+
+
+def _pack_spatial_viewer_scenes(status: dict[str, Any]) -> dict[str, Any]:
+    packed = dict(status)
+    packed_modules: dict[str, Any] = {}
+    for label, module_status in dict(status.get("modules") or {}).items():
+        module_copy = dict(module_status)
+        packed_outputs = []
+        for item in module_status.get("node_outputs", []):
+            if not isinstance(item, dict):
+                continue
+            item_copy = dict(item)
+            outputs = dict(item.get("outputs") or {})
+            scene = dict(outputs.get("scene") or {})
+            for field in _SPATIAL_POINT_FIELDS | _SPATIAL_COLOR_FIELDS:
+                if field in scene:
+                    scene[field] = _pack_numeric_rows(
+                        scene[field],
+                        color=field in _SPATIAL_COLOR_FIELDS,
+                    )
+            outputs["scene"] = scene
+            item_copy["outputs"] = outputs
+            packed_outputs.append(item_copy)
+        module_copy["node_outputs"] = packed_outputs
+        packed_modules[label] = module_copy
+    packed["modules"] = packed_modules
+    return packed
+
+
 def _stop_runtime_module(label: str, module_name: str) -> dict[str, Any]:
     stop_fn = _runtime_callable(label, module_name, "stop_runtime_services")
     if stop_fn is None:
@@ -1214,13 +1321,57 @@ def _stop_runtime_module(label: str, module_name: str) -> dict[str, Any]:
         }
 
 
+_RUNTIME_STOP_TIMEOUT_SECONDS = 12.0
+
+
 def _stop_runtime_services() -> dict[str, Any]:
-    modules = {
-        label: _stop_runtime_module(label, module_name)
+    stop_tasks: dict[str, Callable[[], dict[str, Any]]] = {
+        label: (lambda label=label, module_name=module_name: _stop_runtime_module(label, module_name))
         for label, module_name in _RUNTIME_MODULES.items()
     }
-    modules["remote_ros2"] = _stop_remote_ros2_services()
-    modules["remote_ros2_images"] = _stop_remote_ros2_image_services()
+    stop_tasks["remote_ros2"] = _stop_remote_ros2_services
+    stop_tasks["remote_ros2_images"] = _stop_remote_ros2_image_services
+
+    # Package and remote services are independent managed runtimes. Stop them
+    # concurrently and bound the HTTP response so one faulty package cannot
+    # strand the editor in "Stopping live" forever. A timed-out handler keeps
+    # finishing in its worker while the editor receives an actionable result.
+    executor = ThreadPoolExecutor(max_workers=max(1, min(16, len(stop_tasks))))
+    future_labels = {
+        executor.submit(stop_task): label
+        for label, stop_task in stop_tasks.items()
+    }
+    completed, pending = wait(
+        future_labels,
+        timeout=_RUNTIME_STOP_TIMEOUT_SECONDS,
+    )
+    completed_results: dict[str, dict[str, Any]] = {}
+    for future in completed:
+        label = future_labels[future]
+        try:
+            completed_results[label] = dict(future.result())
+        except Exception as exc:
+            completed_results[label] = {
+                "ok": False,
+                "stopped": {},
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+    for future in pending:
+        label = future_labels[future]
+        future.cancel()
+        completed_results[label] = {
+            "ok": False,
+            "stopped": {},
+            "error": (
+                f"{label} stop is still completing in the background after "
+                f"{_RUNTIME_STOP_TIMEOUT_SECONDS:g} seconds"
+            ),
+        }
+    executor.shutdown(wait=False, cancel_futures=True)
+    modules = {
+        label: completed_results[label]
+        for label in stop_tasks
+    }
     stopped = {"streams": 0, "managed_runs": 0, "detached": 0, "cv2_streams": 0, "reasoning_streams": 0}
     for result in modules.values():
         raw_stopped = result.get("stopped") if isinstance(result.get("stopped"), dict) else {}
@@ -1306,6 +1457,20 @@ def _push_live_node_param_update(meta: dict[str, Any], key: str, value: Any, old
             return
         if not result.get("ok", True) and "not running" not in str(result.get("report") or ""):
             print(f"[blacknode] live leader-follower update failed for {run_id}.{key}: {result.get('error') or result.get('report')}")
+        return
+    if meta.get("type") == "DepthCloudViewer" and key == "color_mode":
+        update_fn = _runtime_callable("viewer", _RUNTIME_MODULES["viewer"], "set_viewer_color_mode")
+        if update_fn is None:
+            return
+        viewer_id = str(
+            old_params.get("viewer_id")
+            or meta.get("params", {}).get("viewer_id")
+            or "depth_cloud_viewer"
+        ).strip() or "depth_cloud_viewer"
+        try:
+            update_fn(viewer_id, value)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[blacknode] live depth-cloud color update failed for {viewer_id}: {type(exc).__name__}: {exc}")
         return
     if meta.get("type") != "TrackingObject" or key not in _CV2_STREAM_LIVE_CONFIG_KEYS:
         return
@@ -1959,6 +2124,7 @@ def get_graph():
         "nodes": nodes,
         "edges": _session.graph._edges,
         "metadata": dict(_session.metadata),
+        "entrypoint": dict(_session.entrypoint) if _session.entrypoint else None,
     }
 
 
@@ -2084,7 +2250,12 @@ def refresh_canvas_node_schemas():
 
 @app.post("/graph")
 def set_graph(req: SetGraphReq):
-    _restore_session_from_nodes(req.nodes, req.edges, metadata=req.metadata)
+    _restore_session_from_nodes(
+        req.nodes,
+        req.edges,
+        metadata=req.metadata,
+        entrypoint=req.entrypoint,
+    )
     _save()
     return get_graph()
 
@@ -2484,6 +2655,21 @@ def control_node(node_id: str, req: NodeControlReq):
         if control_fn is None:
             raise HTTPException(503, "blacknode-training runtime is not loaded")
         run_id = str(meta.get("params", {}).get("run_id") or "act-training").strip() or "act-training"
+        try:
+            outputs = dict(control_fn(run_id, req.action))
+        except ValueError as exc:
+            raise HTTPException(409, str(exc)) from exc
+        for port, value in outputs.items():
+            _session.graph._cache[(node_id, port)] = value
+        _session.graph._dirty.discard(node_id)
+        return {"ok": True, "node_id": node_id, "outputs": outputs}
+    if meta.get("type") == "PPOTraining":
+        if req.action not in {"status", "stop"}:
+            raise HTTPException(400, "PPOTraining direct controls support status or stop; use Run to start")
+        control_fn = _runtime_callable("training", _RUNTIME_MODULES["training"], "control_ppo_training_job")
+        if control_fn is None:
+            raise HTTPException(503, "blacknode-training PPO runtime is not loaded")
+        run_id = str(meta.get("params", {}).get("run_id") or "so101-reach-ppo").strip() or "so101-reach-ppo"
         try:
             outputs = dict(control_fn(run_id, req.action))
         except ValueError as exc:
@@ -3054,8 +3240,13 @@ _RUNTIME_STATUS_KEYS = ("cookResult", "cookError", "cooking", "cookPort")
 
 
 def _status_value(value: Any) -> Any:
-    if isinstance(value, float) and not math.isfinite(value):
-        return None
+    # Runtime scenes contain hundreds of thousands of ordinary numeric
+    # scalars. Sending each one through json.dumps/json.loads made a 15k-point
+    # cloud spend close to a second in status normalization alone.
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
     if isinstance(value, dict):
         return {str(key): _status_value(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
@@ -3965,6 +4156,11 @@ def console_exec(req: ConsoleExecReq):
 @app.get("/runtime/status")
 def runtime_status():
     return _status_value(_runtime_status())
+
+
+@app.get("/runtime/spatial-viewers")
+def spatial_viewer_runtime_status():
+    return _status_value(_spatial_viewer_runtime_status())
 
 
 @app.get("/api/dataset/media/{token}")
@@ -11756,11 +11952,12 @@ def _current_workflow() -> tuple[dict, dict | None]:
         nid: {k: v for k, v in meta.items() if k not in _RUNTIME_KEYS}
         for nid, meta in _session.node_meta.items()
     }
-    entry = None
-    for nid, meta in node_meta.items():
-        if meta.get("type") in ("SlackReply", "TelegramReply"):
-            entry = {"node_id": nid, "port": "text"}
-            break
+    entry = dict(_session.entrypoint) if _session.entrypoint else None
+    if entry is None:
+        for nid, meta in node_meta.items():
+            if meta.get("type") in ("SlackReply", "TelegramReply"):
+                entry = {"node_id": nid, "port": "text"}
+                break
     if entry is None:
         for nid, meta in node_meta.items():
             if meta.get("type") == "Output":
@@ -12219,6 +12416,7 @@ def reset():
     _session.graph = bn.Graph()
     _session.node_meta.clear()
     _session.metadata.clear()
+    _session.entrypoint = None
     _save()
     return {"ok": True}
 
@@ -12260,8 +12458,9 @@ def _workflow_payload(
         "node_meta": _portable_node_meta(_session.node_meta),
         "edges": [dict(edge) for edge in _session.graph._edges],
     }
-    if entrypoint is not None:
-        payload["entrypoint"] = dict(entrypoint)
+    selected_entrypoint = entrypoint if entrypoint is not None else _session.entrypoint
+    if selected_entrypoint is not None:
+        payload["entrypoint"] = dict(selected_entrypoint)
     combined_metadata = dict(_session.metadata)
     if metadata is not None:
         combined_metadata.update(metadata)
@@ -12513,11 +12712,13 @@ def _restore_session(
     edges: list,
     *,
     metadata: dict[str, Any] | None = None,
+    entrypoint: dict[str, str] | None = None,
 ):
     """Replace current session with the given node_meta + edges."""
     _session.graph = bn.Graph()
     _session.node_meta.clear()
     _session.metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    _session.entrypoint = dict(entrypoint) if isinstance(entrypoint, dict) else None
     for node_id, meta in node_meta.items():
         if meta["type"] not in _NODE_REGISTRY and meta["type"] not in _SUBGRAPH_NODE_TYPES:
             continue
@@ -12546,11 +12747,13 @@ def _restore_session_from_nodes(
     edges: list,
     *,
     metadata: dict[str, Any] | None = None,
+    entrypoint: dict[str, str] | None = None,
 ):
     _restore_session(
         {node["id"]: node for node in nodes if "id" in node},
         edges,
         metadata=metadata,
+        entrypoint=entrypoint,
     )
 
 
@@ -12631,6 +12834,7 @@ _PROJECT_COLLECT_NODES = {
 }
 _PROJECT_TRAIN_NODES = {
     "ACTTraining",
+    "PPOTraining",
 }
 _PROJECT_SIMULATE_NODES = {
     "IsaacPolicySafetyGate",
@@ -13199,6 +13403,7 @@ def load_template(slug: str):
         data.get("node_meta", {}),
         data.get("edges", []),
         metadata=data.get("metadata") if isinstance(data.get("metadata"), dict) else {},
+        entrypoint=data.get("entrypoint") if isinstance(data.get("entrypoint"), dict) else None,
     )
     _save()
     return get_graph()
@@ -13209,6 +13414,7 @@ def validate_current_workflow():
     report = validate_bn_graph(
         _portable_node_meta(_session.node_meta),
         [dict(edge) for edge in _session.graph._edges],
+        entrypoint=_session.entrypoint,
     )
     return report.to_dict()
 
@@ -13378,6 +13584,7 @@ def load_workflow(slug: str):
         data.get("node_meta", {}),
         data.get("edges", []),
         metadata=data.get("metadata") if isinstance(data.get("metadata"), dict) else {},
+        entrypoint=data.get("entrypoint") if isinstance(data.get("entrypoint"), dict) else None,
     )
     _save()
     return get_graph()

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -172,9 +172,9 @@ function nodeIdAtScreenPoint(point: { x: number; y: number }): string | null {
 export default function App() {
   const {
     nodes, edges, nodeTypes, nodeDefs, selectedId, serverOk, serverError, cookLog, cookActive, cookStatusHidden,
-    tabs, activeTabId, activeProject,
+    tabs, activeTabId, activeProject, workflowEntrypoint,
     onNodesChange, onEdgesChange, onConnect: storeOnConnect, disconnectEdge, reconnectEdge,
-    addNode, selectNode, loadNodeTypes, loadGraph, loadApiKeys, loadApiKeyStatus, loadCustomModels, loadLearnedNodes, loadDriverStatus, loadRuntimeNodeOutputs, loadDrivers,
+    addNode, selectNode, loadNodeTypes, loadGraph, loadApiKeys, loadApiKeyStatus, loadCustomModels, loadLearnedNodes, loadDriverStatus, loadRuntimeNodeOutputs, loadSpatialViewerNodeOutputs, loadDrivers,
     addNodeFromConnection, copySelection, pasteClipboard,
     beginAltDragCopy, finishAltDragCopy, undoGraph,
     checkServer, reset, newTab, insertTab, switchTab, closeTab, duplicateTab,
@@ -249,6 +249,23 @@ export default function App() {
   const pendingCloseTab = pendingClose ? tabs.find(tab => tab.id === pendingClose.tabId) : null
   const simulationViewer = useMemo(() => {
     for (const node of nodes) {
+      if (node.data.type === 'PPOTraining') {
+        const results = node.data.portResults ?? {}
+        const status = results.status && typeof results.status === 'object'
+          ? results.status as Record<string, unknown>
+          : {}
+        const viewer = results.viewer && typeof results.viewer === 'object'
+          ? results.viewer as Record<string, unknown>
+          : {}
+        const url = String(results.viewer_url ?? status.viewer_url ?? viewer.viewer_url ?? '').trim()
+        if (!url || results.running !== true) continue
+        return {
+          url,
+          label: String(node.data.params?.run_id ?? 'SO-ARM101 PPO training'),
+          phase: String(results.phase ?? status.phase ?? 'running'),
+          armed: false,
+        }
+      }
       if (node.data.type !== 'NewtonSimulation') continue
       const results = node.data.portResults ?? {}
       const session = results.session && typeof results.session === 'object'
@@ -620,13 +637,23 @@ export default function App() {
       loadGraph()
       loadDriverStatus()
       loadRuntimeNodeOutputs()
+      loadSpatialViewerNodeOutputs()
       loadDrivers()
     })
     const id = setInterval(checkServer, 5000)
     // Poll running-driver heartbeats so trigger nodes show live/offline truthfully.
     const driverId = setInterval(loadDriverStatus, 4000)
-    const runtimeOutputsId = setInterval(loadRuntimeNodeOutputs, 250)
-    return () => { clearInterval(id); clearInterval(driverId); clearInterval(runtimeOutputsId) }
+    const runtimeOutputsId = setInterval(loadRuntimeNodeOutputs, 1000)
+    // Spatial scenes are cached by their managed workers, so this lightweight
+    // poll can deliver responsive point-cloud motion independently of slower
+    // ROS/device health checks.
+    const spatialViewerOutputsId = setInterval(loadSpatialViewerNodeOutputs, 100)
+    return () => {
+      clearInterval(id)
+      clearInterval(driverId)
+      clearInterval(runtimeOutputsId)
+      clearInterval(spatialViewerOutputsId)
+    }
   }, [])
 
   useEffect(() => {
@@ -1409,7 +1436,13 @@ export default function App() {
   }, [loadGraph, loadNodeTypes, refreshingCanvas])
 
   const handleRunGraph = useCallback(async (runMode: 'once' | 'live' = 'once') => {
-    const targets = inferGraphRunTargets(nodes, edges)
+    const entrypointTarget = workflowEntrypoint && nodes.some(node => (
+      node.id === workflowEntrypoint.node_id
+      && (node.data.outputs.includes(workflowEntrypoint.port) || node.data.inputs.includes(workflowEntrypoint.port))
+    ))
+      ? { id: workflowEntrypoint.node_id, port: workflowEntrypoint.port }
+      : null
+    const targets = entrypointTarget ? [entrypointTarget] : inferGraphRunTargets(nodes, edges)
     if (targets.length === 0) {
       window.dispatchEvent(new CustomEvent('blacknode:notice', {
         detail: {
@@ -1438,7 +1471,7 @@ export default function App() {
     } finally {
       setActiveRunMode(current => current === effectiveMode ? null : current)
     }
-  }, [cookNode, edges, fitCurrentCanvas, nodes])
+  }, [cookNode, edges, fitCurrentCanvas, nodes, workflowEntrypoint])
 
   const handleResetRun = useCallback(() => {
     stopCook()
@@ -1454,6 +1487,9 @@ export default function App() {
 
   const handleStopRuntime = useCallback(async () => {
     if (runtimeStopPending) return
+    // Stop is authoritative from the moment it is requested. Do not let an
+    // unreachable device keep the top-level live state latched on.
+    setActiveRunMode(null)
     setRuntimeStopPending(true)
     try {
       const result = await stopRuntimeServices()
@@ -1555,8 +1591,20 @@ export default function App() {
     && n.data.portResults?.running === true
   )).length
   const liveCapableCount = nodes.filter(n => n.data.live_capable).length
+  // The node card treats any live-capable node with an active runtime flag as
+  // live. Keep the global control aligned with that generic contract so new
+  // ROS 2 and package nodes do not need to be added to a hard-coded list here.
+  const liveCapableRuntimeCount = nodes.filter(n => (
+    n.data.live_capable === true
+    && (
+      n.data.portResults?.live === true
+      || n.data.portResults?.running === true
+      || n.data.portResults?.streaming === true
+      || n.data.portResults?.launched === true
+    )
+  )).length
   const runOnceNodeCount = Math.max(0, nodes.length - liveCapableCount)
-  const runtimeActive = liveStreamCount > 0 || managedRunCount > 0 || simulationRunCount > 0 || controllerRunningCount > 0 || manualMoveCount > 0 || liveDashboardCount > 0 || visualizerRunCount > 0
+  const runtimeActive = liveCapableRuntimeCount > 0 || liveStreamCount > 0 || managedRunCount > 0 || simulationRunCount > 0 || controllerRunningCount > 0 || manualMoveCount > 0 || liveDashboardCount > 0 || visualizerRunCount > 0
   const liveRunActive = (cookActive && activeRunMode === 'live') || runtimeActive
   const onceRunActive = cookActive && activeRunMode !== 'live'
   const visibleEdges = useMemo(() => {

--- a/editor/src/StandaloneSlam.tsx
+++ b/editor/src/StandaloneSlam.tsx
@@ -72,7 +72,12 @@ export default function StandaloneSlam() {
 
   const scene = (state.scene && typeof state.scene === 'object' ? state.scene : {}) as {
     history_paused?: boolean
+    trajectory_evaluation?: Record<string, unknown>
   }
+  const trajectoriesEnabled = Boolean(
+    scene.trajectory_evaluation
+    && Object.keys(scene.trajectory_evaluation).length,
+  )
   const statusState = connectionError ? 'disconnected' : String(state.status?.state || (state.running ? 'waiting' : 'stopped'))
   const statusColor = connectionError || statusState === 'error'
     ? 'var(--err)'
@@ -120,7 +125,9 @@ export default function StandaloneSlam() {
           viewerRole="map"
           onClear={() => { void control('clear') }}
           onAccumulationToggle={() => { void control(scene.history_paused ? 'resume' : 'pause') }}
-          onGoalSet={(x, y) => { void control('set-goal', { goal_x_m: x, goal_y_m: y }) }}
+          onGoalSet={trajectoriesEnabled
+            ? (x, y) => { void control('set-goal', { goal_x_m: x, goal_y_m: y }) }
+            : undefined}
           clearPending={pending === 'clear'}
           accumulationPending={pending === 'pause' || pending === 'resume'}
           goalPending={pending === 'set-goal'}

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -847,6 +847,7 @@ export interface GraphSnapshot {
   nodes: any[]
   edges: any[]
   metadata: WorkflowMetadata
+  entrypoint?: { node_id: string; port: string } | null
 }
 
 export interface FileBrowserListing {
@@ -1618,8 +1619,12 @@ export const api = {
     }>('GET', `/packages/${encodeURIComponent(name)}/components/${encodeURIComponent(component)}/dependencies`),
   deletePackage: (name: string)              => req<{ ok: boolean }>('DELETE', `/packages/${encodeURIComponent(name)}`),
   getGraph:  ()                              => req<GraphSnapshot>('GET', '/graph'),
-  setGraph:  (nodes: any[], edges: any[], metadata: WorkflowMetadata = {}) =>
-    req<GraphSnapshot>('POST', '/graph', { nodes, edges, metadata }),
+  setGraph:  (
+    nodes: any[],
+    edges: any[],
+    metadata: WorkflowMetadata = {},
+    entrypoint: GraphSnapshot['entrypoint'] = null,
+  ) => req<GraphSnapshot>('POST', '/graph', { nodes, edges, metadata, entrypoint }),
   updateWorkflowRequirements: (
     requiredCapabilities: string[],
     deviceCalibration: { profile_id: string; hardware_id: string } | null,
@@ -1692,6 +1697,7 @@ export const api = {
     req<{ value: unknown; port: string }>('POST', '/cook', { node_id, port }),
   stopCook:   () => req<RuntimeStopResult>('POST', '/cook/stop'),
   runtimeStatus: () => req<RuntimeStatus>('GET', '/runtime/status'),
+  spatialViewerRuntimeStatus: () => req<RuntimeStatus>('GET', '/runtime/spatial-viewers'),
   newtonWorkspaceStatus: () =>
     req<NewtonWorkspaceStatus>('GET', '/newton/workspace'),
   controlNewtonWorkspace: (action: string, payload: Record<string, unknown> = {}) =>
@@ -1723,7 +1729,7 @@ export const api = {
     req<Record<string, unknown>>('POST', '/console/exec', { command, timeout }),
   ollamaModels: (endpointUrl: string) =>
     req<{ ok: boolean; models: string[]; error?: string }>('GET', `/ollama/models?endpoint_url=${encodeURIComponent(endpointUrl)}`),
-  stopRuntime: () => req<RuntimeStopResult>('POST', '/runtime/stop'),
+  stopRuntime: () => req<RuntimeStopResult>('POST', '/runtime/stop', undefined, 15000),
   cookStream: (node_id: string, port = 'output', onEvent: (event: CookEvent) => void, signal?: AbortSignal, run_mode: 'once' | 'live' = 'once') =>
     streamCook('/cook-stream', { node_id, port, run_mode }, `${node_id}.${port}`, onEvent, signal),
   cookGraphStream: (targets: GraphRunTarget[], onEvent: (event: CookEvent) => void, signal?: AbortSignal, run_mode: 'once' | 'live' = 'once') =>

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -838,6 +838,8 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const isSpatialViewer = SPATIAL_VIEWER_TYPES.has(data.type)
   const managedSpatialViewer = MANAGED_SPATIAL_VIEWER_TYPES.has(data.type)
   const isACTTraining = data.type === 'ACTTraining'
+  const isPPOTraining = data.type === 'PPOTraining'
+  const isPolicyTraining = isACTTraining || isPPOTraining
   const availableInputs = isRobotJointList
     ? (data.inputs ?? []).filter(port => edges.some(edge => edge.target === id && edge.targetHandle === port))
     : isVariadic
@@ -976,14 +978,20 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     && edges.some(edge => edge.target === id && edge.targetHandle === 'dataset')
     && edges.some(edge => edge.target === id && edge.targetHandle === 'robot_stream')
     && edges.some(edge => edge.target === id && (edge.targetHandle === 'camera_stream' || edge.targetHandle === 'camera_streams'))
-  const trainingRunning = isACTTraining && data.portResults?.running === true
-  const trainingPhase = isACTTraining ? String(data.portResults?.phase ?? 'not started') : ''
+  const trainingRunning = isPolicyTraining && data.portResults?.running === true
+  const trainingPhase = isPolicyTraining ? String(data.portResults?.phase ?? 'not started') : ''
   const trainingStopping = trainingRunning && trainingPhase === 'stopping'
-  const trainingStep = isACTTraining ? Number(data.portResults?.step ?? 0) : 0
-  const trainingStatus = isACTTraining && data.portResults?.status && typeof data.portResults.status === 'object'
+  const trainingStep = isPolicyTraining
+    ? Number(data.portResults?.[isPPOTraining ? 'update' : 'step'] ?? 0)
+    : 0
+  const trainingStatus = isPolicyTraining && data.portResults?.status && typeof data.portResults.status === 'object'
     ? data.portResults.status as Record<string, unknown>
     : {}
-  const trainingSteps = Number(trainingStatus.steps ?? data.params?.steps ?? 0)
+  const trainingSteps = Number(
+    isPPOTraining
+      ? (trainingStatus.updates ?? data.params?.updates ?? 0)
+      : (trainingStatus.steps ?? data.params?.steps ?? 0)
+  )
   const trainingProgress = trainingSteps > 0 ? Math.max(0, Math.min(1, trainingStep / trainingSteps)) : 0
   const datasetRoot = isDatasetCreate ? String(data.params?.root ?? '').trim() : ''
   const datasetId = isDatasetCreate ? String(data.params?.dataset_id ?? 'dataset').trim() || 'dataset' : ''
@@ -1005,7 +1013,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   // back to the generic "snapshot" badge — that badge is what read as "broken".
   const streamStartable = data.type === 'StreamPublisher' && !streamActive
   const snapshotResult = data.live_capable === true
-    && !isACTTraining
+    && !isPolicyTraining
     && !streamActive
     && !streamStartable
     && !manualMoveLive
@@ -1664,7 +1672,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   }, [id, isViewer, updateNodeInternals])
 
   useEffect(() => {
-    if (!isACTTraining || !trainingRunning) return
+    if (!isPolicyTraining || !trainingRunning) return
     let cancelled = false
     const refresh = async () => {
       try {
@@ -1680,7 +1688,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       cancelled = true
       window.clearInterval(timer)
     }
-  }, [controlNode, id, isACTTraining, trainingRunning])
+  }, [controlNode, id, isPolicyTraining, trainingRunning])
 
   return (
     <NodeFrame
@@ -1729,7 +1737,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
         </div>
       )}
 
-      {isACTTraining && (
+      {isPolicyTraining && (
         <div
           className="nodrag"
           onMouseDown={e => e.stopPropagation()}
@@ -2769,6 +2777,16 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
           onClear={managedSpatialViewer || data.type === 'SLAM' ? () => { void onClearViewer() } : undefined}
           onAccumulationToggle={managedSpatialViewer || data.type === 'SLAM' ? () => { void onToggleViewerAccumulation() } : undefined}
           onGoalSet={data.type === 'SLAM' ? (x, y) => { void onSetSlamGoal(x, y) } : undefined}
+          depthColorMode={data.type === 'DepthCloudViewer'
+            ? data.params?.color_mode === 'rgb'
+              ? 'rgb'
+              : data.params?.color_mode === 'ir'
+                ? 'ir'
+                : 'depth'
+            : undefined}
+          onDepthColorModeChange={data.type === 'DepthCloudViewer'
+            ? mode => { void updateParam(id, 'color_mode', mode) }
+            : undefined}
           clearPending={viewerClearPending}
           accumulationPending={viewerAccumulationPending}
           goalPending={viewerGoalPending}

--- a/editor/src/components/DevicesPanel.tsx
+++ b/editor/src/components/DevicesPanel.tsx
@@ -1004,7 +1004,30 @@ export default function DevicesPanel({
     )),
     reportProgress = true,
   ) => {
-    if (device.robots.length === 0 || rosChecksInFlight.current.has(device.id)) {
+    if (device.robots.length === 0) {
+      const health: RosHealth = {
+        state: 'unavailable',
+        checking: false,
+        summary: 'No robot attached · ROS 2 check not required',
+        issues: [],
+        checkedAt: Date.now(),
+      }
+      setRosHealthByDevice(previous => ({
+        ...previous,
+        [device.id]: health,
+      }))
+      if (reportProgress) {
+        setActionProgress(previous => ({
+          ...previous,
+          [device.id]: {
+            progress: 100,
+            message: 'No robot attached · ROS 2 check skipped',
+          },
+        }))
+      }
+      return health
+    }
+    if (rosChecksInFlight.current.has(device.id)) {
       return undefined
     }
     rosChecksInFlight.current.add(device.id)

--- a/editor/src/components/IMUOrientationViewer.tsx
+++ b/editor/src/components/IMUOrientationViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { spatialCameraCoordinates } from '../spatialCamera'
 
 interface Vector3 { x?: number; y?: number; z?: number }
 interface Quaternion extends Vector3 { w?: number }
@@ -7,6 +8,12 @@ interface IMUScene {
   frame?: string
   sequence?: number
   robot?: { length_m?: number; width_m?: number; height_m?: number }
+  mounting?: {
+    body_frame?: string
+    sensor_frame?: string
+    body_from_sensor_rpy_deg?: { roll?: number; pitch?: number; yaw?: number }
+    body_from_sensor_quaternion?: Quaternion
+  }
   imu?: {
     orientation?: Quaternion
     euler_rad?: { roll?: number; pitch?: number; yaw?: number }
@@ -20,8 +27,16 @@ interface IMUScene {
 
 interface Point3 { x: number; y: number; z: number }
 interface Point2 extends Point3 { sx: number; sy: number; depth: number }
+type NormalizedQuaternion = Required<Quaternion>
 
 const LOGO_SOURCE = { x: 78, y: 48, width: 352, height: 415 } as const
+const IMU_DEFAULT_CAMERA: { yaw: number; pitch: number; zoom: number } = {
+  yaw: -0.68,
+  pitch: -0.62,
+  zoom: 1,
+}
+const IMU_CAMERA_MIN_PITCH = -1.52
+const IMU_CAMERA_MAX_PITCH = -0.05
 
 function finite(value: unknown, fallback = 0): number {
   const parsed = Number(value)
@@ -32,7 +47,7 @@ function clamp(value: number, minimum: number, maximum: number): number {
   return Math.max(minimum, Math.min(maximum, value))
 }
 
-function normalizeQuaternion(value: Quaternion | undefined): Required<Quaternion> {
+function normalizeQuaternion(value: Quaternion | undefined): NormalizedQuaternion {
   const quaternion = {
     x: finite(value?.x), y: finite(value?.y), z: finite(value?.z), w: finite(value?.w, 1),
   }
@@ -43,6 +58,32 @@ function normalizeQuaternion(value: Quaternion | undefined): Required<Quaternion
     z: quaternion.z / norm,
     w: quaternion.w / norm,
   }
+}
+
+function multiplyQuaternion(left: NormalizedQuaternion, right: NormalizedQuaternion): NormalizedQuaternion {
+  return normalizeQuaternion({
+    x: left.w * right.x + left.x * right.w + left.y * right.z - left.z * right.y,
+    y: left.w * right.y - left.x * right.z + left.y * right.w + left.z * right.x,
+    z: left.w * right.z + left.x * right.y - left.y * right.x + left.z * right.w,
+    w: left.w * right.w - left.x * right.x - left.y * right.y - left.z * right.z,
+  })
+}
+
+function inverseQuaternion(value: NormalizedQuaternion): NormalizedQuaternion {
+  return { x: -value.x, y: -value.y, z: -value.z, w: value.w }
+}
+
+function quaternionEuler(value: NormalizedQuaternion): { roll: number; pitch: number; yaw: number } {
+  const roll = Math.atan2(
+    2 * (value.w * value.x + value.y * value.z),
+    1 - 2 * (value.x * value.x + value.y * value.y),
+  )
+  const pitch = Math.asin(clamp(2 * (value.w * value.y - value.z * value.x), -1, 1))
+  const yaw = Math.atan2(
+    2 * (value.w * value.z + value.x * value.y),
+    1 - 2 * (value.y * value.y + value.z * value.z),
+  )
+  return { roll, pitch, yaw }
 }
 
 function rotate(point: Point3, quaternion: Required<Quaternion>): Point3 {
@@ -77,14 +118,61 @@ export default function IMUOrientationViewer({
   const logoRef = useRef<HTMLImageElement | null>(null)
   const dragRef = useRef<{ x: number; y: number; yaw: number; pitch: number } | null>(null)
   const [viewport, setViewport] = useState({ width: 1, height: 420, ratio: 1 })
-  const [camera, setCamera] = useState({ yaw: -0.68, pitch: 0.62, zoom: 1 })
+  const [camera, setCamera] = useState({ ...IMU_DEFAULT_CAMERA })
   const [logoReady, setLogoReady] = useState(false)
-  const quaternion = useMemo(() => normalizeQuaternion(parsed.imu?.orientation), [
+  const [orientationMode, setOrientationMode] = useState<'zeroed' | 'absolute'>('zeroed')
+  const [referenceQuaternion, setReferenceQuaternion] = useState<NormalizedQuaternion | null>(null)
+  const [showSensorAxes, setShowSensorAxes] = useState(true)
+  const rawQuaternion = useMemo(() => normalizeQuaternion(parsed.imu?.orientation), [
     parsed.imu?.orientation?.w,
     parsed.imu?.orientation?.x,
     parsed.imu?.orientation?.y,
     parsed.imu?.orientation?.z,
   ])
+  const sensorMountQuaternion = useMemo(
+    () => normalizeQuaternion(parsed.mounting?.body_from_sensor_quaternion),
+    [
+      parsed.mounting?.body_from_sensor_quaternion?.w,
+      parsed.mounting?.body_from_sensor_quaternion?.x,
+      parsed.mounting?.body_from_sensor_quaternion?.y,
+      parsed.mounting?.body_from_sensor_quaternion?.z,
+    ],
+  )
+  // ROS gives q_world_sensor. The URDF/TF mounting is q_body_sensor, so the
+  // physical robot pose is q_world_body = q_world_sensor * inverse(q_body_sensor).
+  const rawBodyQuaternion = useMemo(
+    () => multiplyQuaternion(rawQuaternion, inverseQuaternion(sensorMountQuaternion)),
+    [rawQuaternion, sensorMountQuaternion],
+  )
+  const hasOrientation = parsed.imu?.orientation !== undefined
+  const quaternion = useMemo(() => {
+    if (orientationMode === 'absolute') return rawBodyQuaternion
+    if (!referenceQuaternion) return normalizeQuaternion(undefined)
+    return multiplyQuaternion(rawBodyQuaternion, inverseQuaternion(referenceQuaternion))
+  }, [orientationMode, rawBodyQuaternion, referenceQuaternion])
+  const displayedSensorQuaternion = useMemo(
+    () => multiplyQuaternion(quaternion, sensorMountQuaternion),
+    [quaternion, sensorMountQuaternion],
+  )
+  const displayedEuler = useMemo(() => quaternionEuler(quaternion), [quaternion])
+
+  useEffect(() => {
+    setReferenceQuaternion(null)
+    setOrientationMode('zeroed')
+  }, [
+    parsed.frame,
+    parsed.imu?.topic,
+    parsed.mounting?.body_from_sensor_quaternion?.w,
+    parsed.mounting?.body_from_sensor_quaternion?.x,
+    parsed.mounting?.body_from_sensor_quaternion?.y,
+    parsed.mounting?.body_from_sensor_quaternion?.z,
+  ])
+
+  useEffect(() => {
+    if (orientationMode === 'zeroed' && !referenceQuaternion && hasOrientation) {
+      setReferenceQuaternion(rawBodyQuaternion)
+    }
+  }, [hasOrientation, orientationMode, rawBodyQuaternion, referenceQuaternion])
 
   useEffect(() => {
     let cancelled = false
@@ -134,17 +222,20 @@ export default function IMUOrientationViewer({
     const centerY = viewport.height * 0.47
     const scale = Math.min(viewport.width, viewport.height) * 0.66 * camera.zoom
     const project = (point: Point3): Point2 => {
-      const cy = Math.cos(camera.yaw)
-      const sy = Math.sin(camera.yaw)
-      const cp = Math.cos(camera.pitch)
-      const sp = Math.sin(camera.pitch)
-      const yawX = cy * point.x - sy * point.y
-      const yawY = sy * point.x + cy * point.y
-      const viewY = cp * yawY - sp * point.z
-      const depth = sp * yawY + cp * point.z
-      return { ...point, sx: centerX + yawX * scale, sy: centerY - viewY * scale, depth }
+      const [cameraX, cameraY, cameraDepth] = spatialCameraCoordinates(
+        point.x, point.y, point.z, camera.yaw, camera.pitch,
+      )
+      return {
+        ...point,
+        sx: centerX + cameraX * scale,
+        sy: centerY - cameraY * scale,
+        depth: cameraDepth,
+      }
     }
     const bodyPoint = (x: number, y: number, z: number) => project(rotate({ x, y, z }, quaternion))
+    const sensorPoint = (x: number, y: number, z: number) => project(
+      rotate({ x, y, z }, displayedSensorQuaternion),
+    )
 
     const gridReach = 0.72
     context.lineWidth = 1
@@ -204,7 +295,7 @@ export default function IMUOrientationViewer({
       { indices: [3, 0, 4, 7], fill: 'rgba(13, 118, 144, 0.46)' },
     ].sort((left, right) => {
       const depth = (face: typeof left) => face.indices.reduce((sum, index) => sum + vertices[index].depth, 0) / 4
-      return depth(left) - depth(right)
+      return depth(right) - depth(left)
     })
     context.shadowColor = 'rgba(43, 220, 238, 0.45)'
     context.shadowBlur = 12
@@ -254,6 +345,12 @@ export default function IMUOrientationViewer({
 
     const bodyOrigin = bodyPoint(0, 0, 0)
     const axisLength = Math.max(length, width) * 0.82
+    if (showSensorAxes) {
+      const sensorAxisLength = axisLength * 0.76
+      drawArrow(bodyOrigin, sensorPoint(sensorAxisLength, 0, 0), '#ffc857', 'IMU X', 1.55)
+      drawArrow(bodyOrigin, sensorPoint(0, sensorAxisLength, 0), '#cf8cff', 'IMU Y', 1.55)
+      drawArrow(bodyOrigin, sensorPoint(0, 0, sensorAxisLength), '#72c8ff', 'IMU Z', 1.55)
+    }
     drawArrow(bodyOrigin, bodyPoint(axisLength, 0, 0), '#ff5b5b', 'X')
     drawArrow(bodyOrigin, bodyPoint(0, axisLength, 0), '#53e091', 'Y')
     drawArrow(bodyOrigin, bodyPoint(0, 0, axisLength), '#539aff', 'Z')
@@ -261,7 +358,7 @@ export default function IMUOrientationViewer({
     context.font = '11px ui-monospace, SFMono-Regular, Menlo, monospace'
     context.fillStyle = parsed.imu?.source_fresh === true ? '#72ff9d' : '#facc15'
     context.fillText(parsed.imu?.source_fresh === true ? 'LIVE ORIENTATION' : 'WAITING / STALE', 14, 20)
-  }, [camera, logoReady, parsed, quaternion, viewport])
+  }, [camera, displayedSensorQuaternion, logoReady, parsed, quaternion, showSensorAxes, viewport])
 
   const angularRate = vectorMagnitude(parsed.imu?.angular_velocity_rps)
   const acceleration = vectorMagnitude(parsed.imu?.linear_acceleration_mps2)
@@ -283,9 +380,50 @@ export default function IMUOrientationViewer({
       }}>
         {inputRail}
         <button
-          onClick={event => { event.stopPropagation(); setCamera({ yaw: -0.68, pitch: 0.62, zoom: 1 }) }}
+          onClick={event => {
+            event.stopPropagation()
+            setReferenceQuaternion(rawBodyQuaternion)
+            setOrientationMode('zeroed')
+          }}
+          disabled={!hasOrientation}
+          title="Treat the robot's current pose as level and forward"
           style={{
             marginLeft: 'auto', height: 25, padding: '0 8px', border: '1px solid var(--line2)',
+            background: orientationMode === 'zeroed' ? 'rgba(86, 217, 145, 0.16)' : 'var(--panel2)',
+            color: orientationMode === 'zeroed' ? '#8df0b5' : 'var(--tx2)', fontSize: 11,
+            cursor: hasOrientation ? 'pointer' : 'default',
+          }}
+        >
+          Zero pose
+        </button>
+        <button
+          onClick={event => { event.stopPropagation(); setOrientationMode('absolute') }}
+          disabled={!hasOrientation}
+          title="Show the unmodified ROS IMU orientation"
+          style={{
+            height: 25, padding: '0 8px', border: '1px solid var(--line2)',
+            background: orientationMode === 'absolute' ? 'rgba(91, 154, 255, 0.16)' : 'var(--panel2)',
+            color: orientationMode === 'absolute' ? '#91c4ff' : 'var(--tx2)', fontSize: 11,
+            cursor: hasOrientation ? 'pointer' : 'default',
+          }}
+        >
+          Absolute
+        </button>
+        <label
+          title="Show the physical IMU calibration axes after applying its URDF mounting"
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--tx2)', fontSize: 11 }}
+        >
+          <input
+            type="checkbox"
+            checked={showSensorAxes}
+            onChange={event => setShowSensorAxes(event.target.checked)}
+          />
+          IMU axes
+        </label>
+        <button
+          onClick={event => { event.stopPropagation(); setCamera({ ...IMU_DEFAULT_CAMERA }) }}
+          style={{
+            height: 25, padding: '0 8px', border: '1px solid var(--line2)',
             background: 'var(--panel2)', color: 'var(--tx2)', fontSize: 11, cursor: 'pointer',
           }}
         >
@@ -304,7 +442,11 @@ export default function IMUOrientationViewer({
           setCamera(current => ({
             ...current,
             yaw: drag.yaw + (event.clientX - drag.x) * 0.008,
-            pitch: clamp(drag.pitch - (event.clientY - drag.y) * 0.008, -1.35, 1.35),
+            pitch: clamp(
+              drag.pitch - (event.clientY - drag.y) * 0.008,
+              IMU_CAMERA_MIN_PITCH,
+              IMU_CAMERA_MAX_PITCH,
+            ),
           }))
         }}
         onMouseUp={() => { dragRef.current = null }}
@@ -321,9 +463,9 @@ export default function IMUOrientationViewer({
         borderTop: '1px solid var(--line)', background: 'var(--line)',
       }}>
         {[
-          ['ROLL', degrees(parsed.imu?.euler_rad?.roll)],
-          ['PITCH', degrees(parsed.imu?.euler_rad?.pitch)],
-          ['YAW', degrees(parsed.imu?.euler_rad?.yaw)],
+          ['ROLL', degrees(displayedEuler.roll)],
+          ['PITCH', degrees(displayedEuler.pitch)],
+          ['YAW', degrees(displayedEuler.yaw)],
           ['ANGULAR', `${angularRate.toFixed(3)} rad/s`],
           ['ACCEL', `${acceleration.toFixed(3)} m/s²`],
           ['FRAME', parsed.frame || 'imu_link'],
@@ -336,7 +478,12 @@ export default function IMUOrientationViewer({
       </div>
       <div style={{ padding: '5px 8px', color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 11, background: 'var(--panel)' }}>
         {parsed.imu?.topic || 'normalized IMU'} • sample {finite(parsed.sequence)}
-        {typeof age === 'number' ? ` • age ${age.toFixed(3)}s` : ''} • drag to orbit • wheel to zoom
+        {typeof age === 'number' ? ` • age ${age.toFixed(3)}s` : ''}
+        {` • ${orientationMode === 'zeroed' ? 'startup-relative robot pose' : 'absolute robot pose'}`}
+        {` • mount ${finite(parsed.mounting?.body_from_sensor_rpy_deg?.roll).toFixed(1)}°/`}
+        {`${finite(parsed.mounting?.body_from_sensor_rpy_deg?.pitch).toFixed(1)}°/`}
+        {`${finite(parsed.mounting?.body_from_sensor_rpy_deg?.yaw).toFixed(1)}°`}
+        {' • drag to orbit • wheel to zoom'}
       </div>
     </div>
   )

--- a/editor/src/components/ImageSensorViewer.tsx
+++ b/editor/src/components/ImageSensorViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type MouseEvent, type ReactNode } from 'react'
 import { api } from '../api'
 
 interface ViewerStatus {
@@ -31,6 +31,15 @@ interface MetricDepthFrame {
   width: number
   height: number
   values: Float32Array
+}
+
+interface DepthPixel {
+  x: number
+  y: number
+}
+
+interface DepthSample extends DepthPixel {
+  distanceM: number | null
 }
 
 function parseMetricDepthFrame(payload: ArrayBuffer): MetricDepthFrame {
@@ -88,6 +97,7 @@ function renderMetricDepth(
   frame: MetricDepthFrame,
   settings: DepthDisplaySettings,
   depthScale: number,
+  inspectedPixel?: DepthPixel | null,
 ) {
   let near = settings.near_m
   let far = settings.far_m
@@ -133,6 +143,50 @@ function renderMetricDepth(
     image.data[target + 3] = 255
   }
   context.putImageData(image, 0, 0)
+  if (inspectedPixel) {
+    const radius = Math.max(4, Math.min(frame.width, frame.height) * 0.015)
+    const drawMarker = (strokeStyle: string, lineWidth: number) => {
+      context.strokeStyle = strokeStyle
+      context.lineWidth = lineWidth
+      context.beginPath()
+      context.arc(inspectedPixel.x + 0.5, inspectedPixel.y + 0.5, radius, 0, Math.PI * 2)
+      context.moveTo(inspectedPixel.x + 0.5 - radius * 1.5, inspectedPixel.y + 0.5)
+      context.lineTo(inspectedPixel.x + 0.5 + radius * 1.5, inspectedPixel.y + 0.5)
+      context.moveTo(inspectedPixel.x + 0.5, inspectedPixel.y + 0.5 - radius * 1.5)
+      context.lineTo(inspectedPixel.x + 0.5, inspectedPixel.y + 0.5 + radius * 1.5)
+      context.stroke()
+    }
+    drawMarker('rgba(0, 0, 0, 0.9)', Math.max(3, radius * 0.35))
+    drawMarker('#ffffff', Math.max(1, radius * 0.14))
+  }
+}
+
+function depthPixelFromPointer(
+  canvas: HTMLCanvasElement,
+  frame: MetricDepthFrame,
+  clientX: number,
+  clientY: number,
+): DepthPixel | null {
+  const rect = canvas.getBoundingClientRect()
+  const scale = Math.min(rect.width / frame.width, rect.height / frame.height)
+  if (!(scale > 0)) return null
+  const displayedWidth = frame.width * scale
+  const displayedHeight = frame.height * scale
+  const x = clientX - rect.left - (rect.width - displayedWidth) / 2
+  const y = clientY - rect.top - (rect.height - displayedHeight) / 2
+  if (x < 0 || y < 0 || x >= displayedWidth || y >= displayedHeight) return null
+  return {
+    x: Math.min(frame.width - 1, Math.floor(x / scale)),
+    y: Math.min(frame.height - 1, Math.floor(y / scale)),
+  }
+}
+
+function sampleDepth(frame: MetricDepthFrame, pixel: DepthPixel, depthScale: number): DepthSample {
+  const distanceM = frame.values[pixel.y * frame.width + pixel.x] * depthScale
+  return {
+    ...pixel,
+    distanceM: Number.isFinite(distanceM) && distanceM > 0 ? distanceM : null,
+  }
 }
 
 const depthControl: React.CSSProperties = {
@@ -179,9 +233,11 @@ export default function ImageSensorViewer({
   const depthScale = Number(parsed.depth_scale) || 1
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const latestFrameRef = useRef<MetricDepthFrame | null>(null)
+  const selectedPixelRef = useRef<DepthPixel | null>(null)
   const settingsRef = useRef(settings)
   settingsRef.current = settings
   const [depthError, setDepthError] = useState('')
+  const [depthSample, setDepthSample] = useState<DepthSample | null>(null)
   const label = String(parsed.label || (sensorKind === 'depth' ? 'Depth' : 'Camera'))
   const state = String(parsed.state || (source ? 'ready' : 'waiting'))
   const setDepthDisplay = (key: DepthDisplayKey, value: boolean | number | string) => {
@@ -200,7 +256,16 @@ export default function ImageSensorViewer({
         if (!active) return
         const frame = parseMetricDepthFrame(payload)
         latestFrameRef.current = frame
-        if (canvasRef.current) renderMetricDepth(canvasRef.current, frame, settingsRef.current, depthScale)
+        const selectedPixel = selectedPixelRef.current
+        if (selectedPixel && selectedPixel.x < frame.width && selectedPixel.y < frame.height) {
+          setDepthSample(sampleDepth(frame, selectedPixel, depthScale))
+        } else if (selectedPixel) {
+          selectedPixelRef.current = null
+          setDepthSample(null)
+        }
+        if (canvasRef.current) {
+          renderMetricDepth(canvasRef.current, frame, settingsRef.current, depthScale, selectedPixelRef.current)
+        }
         setDepthError('')
       } catch (error) {
         if (!active || (error as { name?: string })?.name === 'AbortError') return
@@ -217,10 +282,27 @@ export default function ImageSensorViewer({
   }, [depthScale, frameUrl, nodeId, sensorKind])
 
   useEffect(() => {
+    selectedPixelRef.current = null
+    setDepthSample(null)
+  }, [frameUrl, nodeId, sensorKind])
+
+  useEffect(() => {
     if (canvasRef.current && latestFrameRef.current) {
-      renderMetricDepth(canvasRef.current, latestFrameRef.current, settings, depthScale)
+      renderMetricDepth(canvasRef.current, latestFrameRef.current, settings, depthScale, selectedPixelRef.current)
     }
   }, [depthScale, settings.auto_range, settings.far_m, settings.invalid_color, settings.near_m, settings.palette])
+
+  const inspectDepth = (event: MouseEvent<HTMLCanvasElement>) => {
+    event.stopPropagation()
+    const canvas = canvasRef.current
+    const frame = latestFrameRef.current
+    if (!canvas || !frame) return
+    const pixel = depthPixelFromPointer(canvas, frame, event.clientX, event.clientY)
+    if (!pixel) return
+    selectedPixelRef.current = pixel
+    setDepthSample(sampleDepth(frame, pixel, depthScale))
+    renderMetricDepth(canvas, frame, settingsRef.current, depthScale, pixel)
+  }
 
   return (
     <div
@@ -248,7 +330,9 @@ export default function ImageSensorViewer({
             <canvas
               ref={canvasRef}
               aria-label={`${label} locally rendered metric depth view`}
-              style={{ width: '100%', height: '100%', objectFit: 'contain', imageRendering: 'pixelated' }}
+              onClick={inspectDepth}
+              title="Click to inspect metric distance"
+              style={{ width: '100%', height: '100%', objectFit: 'contain', imageRendering: 'pixelated', cursor: 'crosshair' }}
             />
             {depthError && (
               <span style={{ gridArea: '1 / 1', color: 'var(--err)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
@@ -347,6 +431,15 @@ export default function ImageSensorViewer({
         <span>{sensorKind === 'depth' ? 'metric depth image' : 'camera image'}</span>
         {parsed.encoding && <span>{parsed.encoding}</span>}
         {sensorKind === 'depth' && Number(parsed.depth_scale) > 0 && <span>scale {Number(parsed.depth_scale)} m/unit</span>}
+        {sensorKind === 'depth' && (
+          <span style={{ marginLeft: 'auto', color: depthSample?.distanceM ? 'var(--accent)' : 'var(--tx3)', fontWeight: 700 }}>
+            {depthSample
+              ? depthSample.distanceM !== null
+                ? `${depthSample.distanceM.toFixed(3)} m · pixel ${depthSample.x}, ${depthSample.y}`
+                : `No depth · pixel ${depthSample.x}, ${depthSample.y}`
+              : 'Click image to measure'}
+          </span>
+        )}
         {parsed.error && <span style={{ color: 'var(--err)' }}>{parsed.error}</span>}
       </div>
     </div>

--- a/editor/src/components/PointCloudViewer.tsx
+++ b/editor/src/components/PointCloudViewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { SpatialViewerRole } from '../viewerTypes'
+import { spatialCameraCoordinates as cameraCoordinates } from '../spatialCamera'
 
 interface ViewerScene {
   kind?: string
@@ -11,6 +12,7 @@ interface ViewerScene {
   colors?: unknown
   current_points?: unknown
   current_colors?: unknown
+  points_are_current?: boolean
   floor_points?: unknown
   floor_colors?: unknown
   occupied_points?: unknown
@@ -60,7 +62,14 @@ interface ViewerScene {
     revision?: number
   }
   sensor?: { x_m?: number; y_m?: number; yaw_rad?: number }
-  robot?: { length_m?: number; width_m?: number; height_m?: number }
+  robot?: {
+    x_m?: number
+    y_m?: number
+    yaw_rad?: number
+    length_m?: number
+    width_m?: number
+    height_m?: number
+  }
   scan?: {
     angle_min_rad?: number
     angle_max_rad?: number
@@ -135,9 +144,13 @@ interface ViewerScene {
     width?: number
     height?: number
     input_pixels?: number
+    candidate_points?: number
     valid_points?: number
     display_points?: number
     stride?: number
+    requested_stride?: number
+    buffers_reused?: boolean
+    duplicate_frame?: boolean
     fetch_ms?: number
     pipeline_ms?: number
     cpu_ms?: number
@@ -146,8 +159,19 @@ interface ViewerScene {
     mean_confidence?: number
     encoding?: string
     color_registered?: boolean
+    color_mode?: string
+    color_applied?: string
     color_fetch_ms?: number
     color_error?: string
+    cleanup?: {
+      enabled?: boolean
+      valid_pixels?: number
+      holes_filled?: number
+      outliers_replaced?: number
+      temporally_blended?: number
+      temporal_smoothing?: number
+      temporal_max_delta_m?: number
+    }
   }
   reconstruction?: {
     kind?: string
@@ -270,6 +294,10 @@ interface OccupancyTextureData {
 }
 
 const TOP_VIEW_YAW = Math.PI / 2
+// Depth projection stores camera optical coordinates as +X forward, +Y left,
+// and +Z up. Look almost straight down +X so image-right stays right and +Z
+// stays visually up, while retaining a little depth perspective.
+const DEPTH_CAMERA_VIEW_PITCH = -Math.PI / 2 + Math.PI / 18
 
 const DEFAULT_CAMERA: CameraState = {
   zoom: 1,
@@ -286,8 +314,48 @@ const ROBOT_FOOTPRINT_VISUAL_SCALE = 0.88
 const ROBOT_FIT_RADIUS_MULTIPLIER = 1.65
 const MIN_CAMERA_ZOOM = 0.1
 const MAX_CAMERA_ZOOM = 120
+const UPRIGHT_ORBIT_POLE_MARGIN = Math.PI / 180
+const UPRIGHT_ORBIT_MIN_PITCH = -Math.PI + UPRIGHT_ORBIT_POLE_MARGIN
+const UPRIGHT_ORBIT_MAX_PITCH = -UPRIGHT_ORBIT_POLE_MARGIN
 
 function numericRows(value: unknown): number[][] {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const packed = value as Record<string, unknown>
+    if (packed.kind === 'blacknode.numeric-rows' && typeof packed.data === 'string') {
+      try {
+        const binary = atob(packed.data)
+        const components = Math.max(2, Math.min(4, Math.floor(finite(packed.components, 3))))
+        const count = Math.max(0, Math.floor(finite(packed.count)))
+        const rows: number[][] = []
+        if (packed.encoding === 'float32-le-base64') {
+          const bytes = Uint8Array.from(binary, character => character.charCodeAt(0))
+          const view = new DataView(bytes.buffer)
+          const available = Math.min(count, Math.floor(bytes.byteLength / (components * 4)))
+          for (let rowIndex = 0; rowIndex < available; rowIndex += 1) {
+            const row: number[] = []
+            for (let component = 0; component < components; component += 1) {
+              row.push(view.getFloat32((rowIndex * components + component) * 4, true))
+            }
+            rows.push(row)
+          }
+          return rows
+        }
+        if (packed.encoding === 'uint8-normalized-base64') {
+          const available = Math.min(count, Math.floor(binary.length / components))
+          for (let rowIndex = 0; rowIndex < available; rowIndex += 1) {
+            const row: number[] = []
+            for (let component = 0; component < components; component += 1) {
+              row.push(binary.charCodeAt(rowIndex * components + component) / 255)
+            }
+            rows.push(row)
+          }
+          return rows
+        }
+      } catch {
+        return []
+      }
+    }
+  }
   if (!Array.isArray(value)) return []
   return value
     .filter((row): row is unknown[] => Array.isArray(row) && row.length >= 2)
@@ -440,6 +508,10 @@ function drawOccupancyTexture(
   }
 }
 
+function wrapAngle(value: number): number {
+  return Math.atan2(Math.sin(value), Math.cos(value))
+}
+
 function worldToScreen(
   x: number,
   y: number,
@@ -448,16 +520,10 @@ function worldToScreen(
   camera: CameraState,
   pixelsPerMeter: number,
 ): [number, number] {
-  const yawCosine = Math.cos(camera.yaw)
-  const yawSine = Math.sin(camera.yaw)
-  const yawX = yawCosine * x - yawSine * y
-  const yawY = yawSine * x + yawCosine * y
-  const pitchCosine = Math.cos(camera.pitch)
-  const pitchSine = Math.sin(camera.pitch)
-  const pitchedY = pitchCosine * yawY - pitchSine * z
+  const [cameraX, cameraY] = cameraCoordinates(x, y, z, camera.yaw, camera.pitch)
   return [
-    viewport.width / 2 + camera.panX + yawX * pixelsPerMeter,
-    viewport.height / 2 + camera.panY - pitchedY * pixelsPerMeter,
+    viewport.width / 2 + camera.panX + cameraX * pixelsPerMeter,
+    viewport.height / 2 + camera.panY - cameraY * pixelsPerMeter,
   ]
 }
 
@@ -538,6 +604,8 @@ export default function PointCloudViewer({
   onClear,
   onAccumulationToggle,
   onGoalSet,
+  depthColorMode = 'depth',
+  onDepthColorModeChange,
   clearPending = false,
   accumulationPending = false,
   goalPending = false,
@@ -548,6 +616,8 @@ export default function PointCloudViewer({
   onClear?: () => void
   onAccumulationToggle?: () => void
   onGoalSet?: (x: number, y: number) => void
+  depthColorMode?: 'depth' | 'rgb' | 'ir'
+  onDepthColorModeChange?: (mode: 'depth' | 'rgb' | 'ir') => void
   clearPending?: boolean
   accumulationPending?: boolean
   goalPending?: boolean
@@ -575,12 +645,21 @@ export default function PointCloudViewer({
   const showRobot = mapFeatures
   const [showAxes, setShowAxes] = useState(viewerRole !== 'map' && viewerRole !== 'legacy')
   const [showFreeSpace, setShowFreeSpace] = useState(true)
+  const [showLocalization, setShowLocalization] = useState(true)
+  const [showTrajectories, setShowTrajectories] = useState(true)
+  const [frozenDepthScene, setFrozenDepthScene] = useState<ViewerScene | null>(null)
+  const [depthOcclusion, setDepthOcclusion] = useState(false)
   const robotLogoRef = useRef<HTMLImageElement | null>(null)
   const [robotLogoReady, setRobotLogoReady] = useState(false)
   const clearViewRadiusFloorRef = useRef(0)
   const initialResetPendingRef = useRef(true)
   const [viewport, setViewport] = useState<Viewport>({ width: 1, height: 360, ratio: 1 })
-  const parsed = (scene && typeof scene === 'object' ? scene : {}) as ViewerScene
+  const liveParsed = (scene && typeof scene === 'object' ? scene : {}) as ViewerScene
+  const viewFrozen = viewerRole === 'depth-cloud' && frozenDepthScene !== null
+  const parsed = viewFrozen ? frozenDepthScene : liveParsed
+  useEffect(() => {
+    if (viewerRole !== 'depth-cloud' || !scene) setFrozenDepthScene(null)
+  }, [scene, viewerRole])
   useEffect(() => {
     setShowAxes(parsed.show_axes ?? (viewerRole !== 'map' && viewerRole !== 'legacy'))
   }, [parsed.show_axes, viewerRole])
@@ -628,6 +707,33 @@ export default function PointCloudViewer({
     () => [...visibleFloorPoints, ...visibleOccupiedPoints, ...points, ...currentPoints],
     [currentPoints, points, visibleFloorPoints, visibleOccupiedPoints],
   )
+  const pointCloudCenter = useMemo<[number, number, number]>(() => {
+    if (!renderedPoints.length) return [0, 0, 0]
+    let minimumX = Number.POSITIVE_INFINITY
+    let minimumY = Number.POSITIVE_INFINITY
+    let minimumZ = Number.POSITIVE_INFINITY
+    let maximumX = Number.NEGATIVE_INFINITY
+    let maximumY = Number.NEGATIVE_INFINITY
+    let maximumZ = Number.NEGATIVE_INFINITY
+    for (const point of renderedPoints) {
+      const x = Number(point[0])
+      const y = Number(point[1])
+      const z = finite(point[2])
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue
+      minimumX = Math.min(minimumX, x)
+      minimumY = Math.min(minimumY, y)
+      minimumZ = Math.min(minimumZ, z)
+      maximumX = Math.max(maximumX, x)
+      maximumY = Math.max(maximumY, y)
+      maximumZ = Math.max(maximumZ, z)
+    }
+    if (!Number.isFinite(minimumX)) return [0, 0, 0]
+    return [
+      (minimumX + maximumX) / 2,
+      (minimumY + maximumY) / 2,
+      (minimumZ + maximumZ) / 2,
+    ]
+  }, [renderedPoints])
   const occupancyBackground = useMemo(() => {
     if (!mapFeatures) return []
     if (parsed.occupancy?.fixed_origin !== true) return []
@@ -674,7 +780,7 @@ export default function PointCloudViewer({
   }), [parsed.sensor?.x_m, parsed.sensor?.y_m, parsed.sensor?.yaw_rad])
 
   const animationEnabled = parsed.animation?.enabled !== false
-  const hasCurrentPoints = currentPoints.length > 0
+  const hasCurrentPoints = currentPoints.length > 0 || parsed.points_are_current === true
   const pulseHz = clamp(finite(parsed.animation?.pulse_hz, 1), 0.05, 30)
   const scanPeriodMs = 1000 / pulseHz
   const replayDurationMs = Math.max(scanPeriodMs, 700)
@@ -685,9 +791,25 @@ export default function PointCloudViewer({
   const scanCoverageRad = clamp(Math.abs(scanAngleMaximum - scanAngleMinimum), 0, Math.PI * 2)
   const scanCoverageDeg = scanCoverageRad * 180 / Math.PI
   const fullCircleScan = scanCoverageRad >= Math.PI * 2 - Math.PI / 180
-  const robotHeadingYaw = sensor.yaw + (
+  const inferredRobotHeadingYaw = sensor.yaw + (
     fullCircleScan ? 0 : (scanAngleMinimum + scanAngleMaximum) / 2
   )
+  const robot = useMemo(() => ({
+    x: finite(parsed.robot?.x_m, sensor.x),
+    y: finite(parsed.robot?.y_m, sensor.y),
+    yaw: finite(parsed.robot?.yaw_rad, inferredRobotHeadingYaw),
+  }), [
+    inferredRobotHeadingYaw,
+    parsed.robot?.x_m,
+    parsed.robot?.y_m,
+    parsed.robot?.yaw_rad,
+    sensor.x,
+    sensor.y,
+  ])
+  const robotHeadingYaw = robot.yaw
+  const cameraAnchorReady = viewerRole === 'depth-cloud'
+    ? renderedPoints.length > 0
+    : !showRobot || Boolean(parsed.robot || parsed.sensor || renderedPoints.length)
   const animationPhase = animationEnabled
     ? clamp((animationClock - scanStartedRef.current) / replayDurationMs, 0, 1)
     : 1
@@ -732,8 +854,13 @@ export default function PointCloudViewer({
       0,
     )
     const configured = finite(parsed.view?.radius_m)
-    return clamp(Math.max(configured, pointRadius * 1.08, Math.hypot(sensor.x, sensor.y) + 0.5), 0.5, 10_000)
-  }, [parsed.view?.radius_m, renderedPoints, sensor.x, sensor.y])
+    return clamp(Math.max(
+      configured,
+      pointRadius * 1.08,
+      Math.hypot(sensor.x, sensor.y) + 0.5,
+      Math.hypot(robot.x, robot.y) + 0.5,
+    ), 0.5, 10_000)
+  }, [parsed.view?.radius_m, renderedPoints, robot.x, robot.y, sensor.x, sensor.y])
   // Clear changes map contents, not the camera. Capture the pre-clear metric
   // radius while the request is pending and retain it after the empty scene is
   // applied so removing points cannot briefly enlarge the robot on screen.
@@ -749,11 +876,85 @@ export default function PointCloudViewer({
     Math.min(viewport.width, viewport.height) / (viewRadius * 2.15),
   )
   const pixelsPerMeter = basePixelsPerMeter * camera.zoom
+  const fitPointCloudCamera = (yaw: number, pitch: number): CameraState => {
+    let minimumX = Number.POSITIVE_INFINITY
+    let minimumY = Number.POSITIVE_INFINITY
+    let maximumX = Number.NEGATIVE_INFINITY
+    let maximumY = Number.NEGATIVE_INFINITY
+    for (const point of renderedPoints) {
+      const x = Number(point[0])
+      const y = Number(point[1])
+      const z = finite(point[2])
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue
+      const [cameraX, cameraY] = cameraCoordinates(x, y, z, yaw, pitch)
+      minimumX = Math.min(minimumX, cameraX)
+      minimumY = Math.min(minimumY, cameraY)
+      maximumX = Math.max(maximumX, cameraX)
+      maximumY = Math.max(maximumY, cameraY)
+    }
+    if (!Number.isFinite(minimumX)) return { ...DEFAULT_CAMERA, yaw, pitch }
+    const spanX = Math.max(0.001, maximumX - minimumX)
+    const spanY = Math.max(0.001, maximumY - minimumY)
+    const fittedPixelsPerMeter = Math.min(
+      Math.max(1, viewport.width * 0.9) / spanX,
+      Math.max(1, viewport.height * 0.9) / spanY,
+    )
+    const zoom = clamp(
+      fittedPixelsPerMeter / basePixelsPerMeter,
+      MIN_CAMERA_ZOOM,
+      MAX_CAMERA_ZOOM,
+    )
+    const appliedPixelsPerMeter = basePixelsPerMeter * zoom
+    return {
+      zoom,
+      yaw,
+      pitch,
+      panX: -(minimumX + maximumX) / 2 * appliedPixelsPerMeter,
+      panY: (minimumY + maximumY) / 2 * appliedPixelsPerMeter,
+    }
+  }
+  const orbitPointCloudCamera = (
+    value: CameraState,
+    requestedYaw: number,
+    requestedPitch: number,
+  ): CameraState => {
+    const yaw = wrapAngle(requestedYaw)
+    // In this camera basis -90° is the front view, 0° is overhead, and -180°
+    // is underneath. Staying inside that negative polar interval guarantees
+    // -sin(pitch) > 0, so world +Z always remains screen-up. Positive pitch
+    // crosses the overhead pole and visually flips the cloud.
+    const pitch = clamp(
+      requestedPitch,
+      UPRIGHT_ORBIT_MIN_PITCH,
+      UPRIGHT_ORBIT_MAX_PITCH,
+    )
+    const [oldX, oldY] = cameraCoordinates(
+      pointCloudCenter[0], pointCloudCenter[1], pointCloudCenter[2], value.yaw, value.pitch,
+    )
+    const [nextX, nextY] = cameraCoordinates(
+      pointCloudCenter[0], pointCloudCenter[1], pointCloudCenter[2], yaw, pitch,
+    )
+    const appliedPixelsPerMeter = basePixelsPerMeter * value.zoom
+    return {
+      ...value,
+      yaw,
+      pitch,
+      panX: value.panX + (oldX - nextX) * appliedPixelsPerMeter,
+      panY: value.panY + (nextY - oldY) * appliedPixelsPerMeter,
+    }
+  }
+  const alignDepthCameraView = () => {
+    setGridFrame({ x: 0, y: 0, yaw: 0 })
+    setCamera(fitPointCloudCamera(TOP_VIEW_YAW, DEPTH_CAMERA_VIEW_PITCH))
+  }
   const resetCamera = () => {
     clearViewRadiusFloorRef.current = 0
     if (!showRobot) {
       setGridFrame({ x: 0, y: 0, yaw: 0 })
-      setCamera({ ...DEFAULT_CAMERA, yaw: TOP_VIEW_YAW, pitch: 0 })
+      setCamera(fitPointCloudCamera(
+        TOP_VIEW_YAW,
+        viewerRole === 'depth-cloud' ? DEPTH_CAMERA_VIEW_PITCH : UPRIGHT_ORBIT_MAX_PITCH,
+      ))
       return
     }
     const robotLength = clamp(finite(parsed.robot?.length_m, 0.25), 0.02, 5)
@@ -774,23 +975,48 @@ export default function PointCloudViewer({
     const resetYaw = TOP_VIEW_YAW - robotHeadingYaw
     const resetYawCosine = Math.cos(resetYaw)
     const resetYawSine = Math.sin(resetYaw)
-    const focusedSensorX = resetYawCosine * sensor.x - resetYawSine * sensor.y
-    const focusedSensorY = resetYawSine * sensor.x + resetYawCosine * sensor.y
-    setGridFrame({ x: sensor.x, y: sensor.y, yaw: robotHeadingYaw })
+    const focusedRobotX = resetYawCosine * robot.x - resetYawSine * robot.y
+    const focusedRobotY = resetYawSine * robot.x + resetYawCosine * robot.y
+    setGridFrame({ x: robot.x, y: robot.y, yaw: robotHeadingYaw })
     setCamera({
       zoom,
       yaw: resetYaw,
       pitch: 0,
-      panX: -focusedSensorX * appliedPixelsPerMeter,
-      panY: focusedSensorY * appliedPixelsPerMeter,
+      panX: -focusedRobotX * appliedPixelsPerMeter,
+      panY: focusedRobotY * appliedPixelsPerMeter,
+    })
+  }
+
+  const alignRobotView = () => {
+    const yaw = TOP_VIEW_YAW - robotHeadingYaw
+    const yawCosine = Math.cos(yaw)
+    const yawSine = Math.sin(yaw)
+    const focusedRobotX = yawCosine * robot.x - yawSine * robot.y
+    const focusedRobotY = yawSine * robot.x + yawCosine * robot.y
+    setGridFrame({ x: robot.x, y: robot.y, yaw: robotHeadingYaw })
+    setCamera(value => {
+      const appliedPixelsPerMeter = basePixelsPerMeter * value.zoom
+      return {
+        ...value,
+        yaw,
+        pitch: 0,
+        panX: -focusedRobotX * appliedPixelsPerMeter,
+        panY: focusedRobotY * appliedPixelsPerMeter,
+      }
     })
   }
 
   useEffect(() => {
-    if (!initialResetPendingRef.current || !scene || viewport.width <= 1 || viewport.height <= 1) return
+    if (
+      !initialResetPendingRef.current
+      || !scene
+      || !cameraAnchorReady
+      || viewport.width <= 1
+      || viewport.height <= 1
+    ) return
     initialResetPendingRef.current = false
     resetCamera()
-  }, [scene, viewport.height, viewport.width])
+  }, [cameraAnchorReady, scene, viewport.height, viewport.width])
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -916,7 +1142,17 @@ export default function PointCloudViewer({
     if (canvas.height !== bufferHeight) canvas.height = bufferHeight
     gl.viewport(0, 0, bufferWidth, bufferHeight)
     gl.clearColor(0, 0, 0, 0)
-    gl.clear(gl.COLOR_BUFFER_BIT)
+    const xrayPointCloud = viewerRole === 'depth-cloud' && !depthOcclusion
+    if (xrayPointCloud) {
+      gl.disable(gl.DEPTH_TEST)
+      gl.enable(gl.BLEND)
+      gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+    } else {
+      gl.disable(gl.BLEND)
+      gl.enable(gl.DEPTH_TEST)
+      gl.depthFunc(gl.LEQUAL)
+    }
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
     const vertexCount = renderedPoints.length
     if (vertexCount === 0) return
 
@@ -925,14 +1161,14 @@ export default function PointCloudViewer({
     let program: WebGLProgram | null = null
     try {
       vertex = shader(gl, gl.VERTEX_SHADER, `
-        attribute vec2 a_position;
+        attribute vec3 a_position;
         attribute vec3 a_color;
         attribute float a_size;
         attribute float a_square;
         varying vec3 v_color;
         varying float v_square;
         void main() {
-          gl_Position = vec4(a_position, 0.0, 1.0);
+          gl_Position = vec4(a_position, 1.0);
           gl_PointSize = a_size;
           v_color = a_color;
           v_square = a_square;
@@ -940,12 +1176,13 @@ export default function PointCloudViewer({
       `)
       fragment = shader(gl, gl.FRAGMENT_SHADER, `
         precision mediump float;
+        uniform float u_alpha;
         varying vec3 v_color;
         varying float v_square;
         void main() {
           vec2 centered = gl_PointCoord - vec2(0.5);
           if (v_square < 0.5 && dot(centered, centered) > 0.25) discard;
-          gl_FragColor = vec4(v_color, 1.0);
+          gl_FragColor = vec4(v_color, u_alpha);
         }
       `)
       program = gl.createProgram()
@@ -955,11 +1192,34 @@ export default function PointCloudViewer({
       gl.linkProgram(program)
       if (!gl.getProgramParameter(program, gl.LINK_STATUS)) return
       gl.useProgram(program)
+      const alphaLocation = gl.getUniformLocation(program, 'u_alpha')
+      if (alphaLocation) gl.uniform1f(alphaLocation, xrayPointCloud ? 0.72 : 1.0)
     } catch {
       return
     }
 
-    const positions = new Float32Array(vertexCount * 2)
+    const positions = new Float32Array(vertexCount * 3)
+    const cameraDepths = new Float32Array(vertexCount)
+    let minimumCameraDepth = Number.POSITIVE_INFINITY
+    let maximumCameraDepth = Number.NEGATIVE_INFINITY
+    renderedPoints.forEach((point, index) => {
+      const [, , cameraDepth] = cameraCoordinates(
+        point[0], point[1], finite(point[2]), camera.yaw, camera.pitch,
+      )
+      cameraDepths[index] = cameraDepth
+      minimumCameraDepth = Math.min(minimumCameraDepth, cameraDepth)
+      maximumCameraDepth = Math.max(maximumCameraDepth, cameraDepth)
+    })
+    const cameraDepthSpan = Math.max(0.001, maximumCameraDepth - minimumCameraDepth)
+    // Standard alpha blending is order-dependent. X-ray points must be drawn
+    // far-to-near in the current camera frame or overlaps appear to flip as
+    // the camera rotates. Solid mode keeps source order and uses the Z buffer.
+    const renderOrder = Array.from({ length: vertexCount }, (_, index) => index)
+    if (xrayPointCloud) {
+      renderOrder.sort((left, right) => (
+        cameraDepths[right] - cameraDepths[left] || left - right
+      ))
+    }
     const palette = new Float32Array(vertexCount * 3)
     const pointSizes = new Float32Array(vertexCount)
     const squarePoints = new Float32Array(vertexCount)
@@ -967,21 +1227,24 @@ export default function PointCloudViewer({
       1.25 * viewport.ratio,
       finite(parsed.occupancy?.resolution_m, 0.05) * pixelsPerMeter * viewport.ratio * 1.45,
     )
-    renderedPoints.forEach((point, index) => {
-      const vertexIndex = index
+    renderOrder.forEach((sourceIndex, vertexIndex) => {
+      const point = renderedPoints[sourceIndex]
       const [screenX, screenY] = worldToScreen(
         point[0], point[1], finite(point[2]), viewport, camera, pixelsPerMeter,
       )
-      positions[vertexIndex * 2] = (screenX / viewport.width) * 2 - 1
-      positions[vertexIndex * 2 + 1] = 1 - (screenY / viewport.height) * 2
+      positions[vertexIndex * 3] = (screenX / viewport.width) * 2 - 1
+      positions[vertexIndex * 3 + 1] = 1 - (screenY / viewport.height) * 2
+      positions[vertexIndex * 3 + 2] = (
+        (cameraDepths[sourceIndex] - minimumCameraDepth) / cameraDepthSpan
+      ) * 2 - 1
       const occupancyPointCount = visibleFloorPoints.length + visibleOccupiedPoints.length
-      const mapIndex = index - occupancyPointCount
+      const mapIndex = sourceIndex - occupancyPointCount
       const currentIndex = mapIndex - points.length
-      const isFloor = index < visibleFloorPoints.length
-      const isOccupied = !isFloor && index < occupancyPointCount
-      const occupiedIndex = index - visibleFloorPoints.length
+      const isFloor = sourceIndex < visibleFloorPoints.length
+      const isOccupied = !isFloor && sourceIndex < occupancyPointCount
+      const occupiedIndex = sourceIndex - visibleFloorPoints.length
       const color = isFloor
-        ? floorColors[index] ?? [0.18, 0.68, 0.36]
+        ? floorColors[sourceIndex] ?? [0.18, 0.68, 0.36]
         : isOccupied
           ? occupiedColors[occupiedIndex] ?? [0.78, 0.88, 0.94]
         : currentIndex >= 0
@@ -1001,7 +1264,7 @@ export default function PointCloudViewer({
     gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW)
     const positionLocation = gl.getAttribLocation(program, 'a_position')
     gl.enableVertexAttribArray(positionLocation)
-    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, 0, 0)
 
     const colorBuffer = gl.createBuffer()
     gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer)
@@ -1034,7 +1297,7 @@ export default function PointCloudViewer({
       if (vertex) gl.deleteShader(vertex)
       if (fragment) gl.deleteShader(fragment)
     }
-  }, [camera, colors, currentColors, floorColors, occupiedColors, parsed.occupancy?.resolution_m, pixelsPerMeter, points.length, renderedPoints, viewport, visibleFloorPoints.length, visibleOccupiedPoints.length])
+  }, [camera, colors, currentColors, depthOcclusion, floorColors, occupiedColors, parsed.occupancy?.resolution_m, pixelsPerMeter, points.length, renderedPoints, viewerRole, viewport, visibleFloorPoints.length, visibleOccupiedPoints.length])
 
   useEffect(() => {
     const overlay = overlayRef.current
@@ -1066,22 +1329,22 @@ export default function PointCloudViewer({
       Math.ceil((Math.hypot(viewport.width, viewport.height) + Math.hypot(camera.panX, camera.panY) * 2) / pixelsPerMeter / spacing) * spacing,
     )
     const steps = Math.min(100, Math.ceil(reach / spacing))
-    context.strokeStyle = 'rgba(117, 155, 181, 0.14)'
-    context.beginPath()
-    for (let index = -steps; index <= steps; index += 1) {
-      const value = index * spacing
-      const [x1, y1] = gridFrameToScreen(value, -reach, 0)
-      const [x2, y2] = gridFrameToScreen(value, reach, 0)
-      const [x3, y3] = gridFrameToScreen(-reach, value, 0)
-      const [x4, y4] = gridFrameToScreen(reach, value, 0)
-      context.moveTo(x1, y1)
-      context.lineTo(x2, y2)
-      context.moveTo(x3, y3)
-      context.lineTo(x4, y4)
-    }
-    context.stroke()
-
     if (showAxes) {
+      context.strokeStyle = 'rgba(117, 155, 181, 0.14)'
+      context.beginPath()
+      for (let index = -steps; index <= steps; index += 1) {
+        const value = index * spacing
+        const [x1, y1] = gridFrameToScreen(value, -reach, 0)
+        const [x2, y2] = gridFrameToScreen(value, reach, 0)
+        const [x3, y3] = gridFrameToScreen(-reach, value, 0)
+        const [x4, y4] = gridFrameToScreen(reach, value, 0)
+        context.moveTo(x1, y1)
+        context.lineTo(x2, y2)
+        context.moveTo(x3, y3)
+        context.lineTo(x4, y4)
+      }
+      context.stroke()
+
       const drawAxis = (endX: number, endY: number, endZ: number, color: string) => {
         const start = gridFrameToScreen(-endX, -endY, -endZ)
         const end = gridFrameToScreen(endX, endY, endZ)
@@ -1112,6 +1375,7 @@ export default function PointCloudViewer({
     }
 
     const sensorScreen = worldToScreen(sensor.x, sensor.y, 0, viewport, camera, pixelsPerMeter)
+    const robotScreen = worldToScreen(robot.x, robot.y, 0, viewport, camera, pixelsPerMeter)
     const scanMinimum = sensor.yaw + scanAngleMinimum
     const scanMaximum = sensor.yaw + scanAngleMaximum
     const sweepOrderedPoints = [...currentPoints].sort((left, right) => {
@@ -1181,7 +1445,7 @@ export default function PointCloudViewer({
       }
     }
 
-    if (particles.length > 0) {
+    if (showLocalization && particles.length > 0) {
       for (let index = 0; index < particles.length; index += 1) {
         const particle = particles[index]
         const score = particleScores[index] ?? 0
@@ -1215,7 +1479,7 @@ export default function PointCloudViewer({
       }
     }
 
-    if (trajectoryPaths.length > 0) {
+    if (showTrajectories && trajectoryPaths.length > 0) {
       context.save()
       context.lineCap = 'round'
       context.lineJoin = 'round'
@@ -1297,8 +1561,8 @@ export default function PointCloudViewer({
       [-visualRobotLength / 2, -visualRobotWidth / 2],
       [-visualRobotLength / 2, visualRobotWidth / 2],
     ].map(([localX, localY]) => worldToScreen(
-      sensor.x + headingCosine * localX - headingSine * localY,
-      sensor.y + headingSine * localX + headingCosine * localY,
+      robot.x + headingCosine * localX - headingSine * localY,
+      robot.y + headingSine * localX + headingCosine * localY,
       0,
       viewport,
       camera,
@@ -1321,16 +1585,16 @@ export default function PointCloudViewer({
     context.shadowBlur = 0
 
     const forwardUnit = worldToScreen(
-      sensor.x + headingCosine,
-      sensor.y + headingSine,
+      robot.x + headingCosine,
+      robot.y + headingSine,
       0,
       viewport,
       camera,
       pixelsPerMeter,
     )
     const lateralUnit = worldToScreen(
-      sensor.x - headingSine,
-      sensor.y + headingCosine,
+      robot.x - headingSine,
+      robot.y + headingCosine,
       0,
       viewport,
       camera,
@@ -1352,12 +1616,12 @@ export default function PointCloudViewer({
       roundedPolygonPath(context, robotCorners, robotCornerRadius)
       context.clip()
       context.transform(
-        (forwardUnit[0] - sensorScreen[0]) * visualRobotLength,
-        (forwardUnit[1] - sensorScreen[1]) * visualRobotLength,
-        (lateralUnit[0] - sensorScreen[0]) * visualRobotWidth,
-        (lateralUnit[1] - sensorScreen[1]) * visualRobotWidth,
-        sensorScreen[0],
-        sensorScreen[1],
+        (forwardUnit[0] - robotScreen[0]) * visualRobotLength,
+        (forwardUnit[1] - robotScreen[1]) * visualRobotLength,
+        (lateralUnit[0] - robotScreen[0]) * visualRobotWidth,
+        (lateralUnit[1] - robotScreen[1]) * visualRobotWidth,
+        robotScreen[0],
+        robotScreen[1],
       )
       context.rotate(ROBOT_LOGO_ROTATION_RAD)
       context.globalAlpha = 0.8
@@ -1379,7 +1643,7 @@ export default function PointCloudViewer({
       context.font = `800 ${clamp(shortestRobotEdge * 0.66, 9, 18)}px var(--font-ui)`
       context.textAlign = 'center'
       context.textBaseline = 'middle'
-      context.fillText('B', sensorScreen[0], sensorScreen[1])
+      context.fillText('B', robotScreen[0], robotScreen[1])
       context.textAlign = 'start'
       context.textBaseline = 'alphabetic'
     }
@@ -1411,6 +1675,7 @@ export default function PointCloudViewer({
     particleScores,
     particleYaws,
     particles,
+    robot,
     parsed.robot?.length_m,
     parsed.robot?.width_m,
     parsed.scan?.angle_max_rad,
@@ -1421,8 +1686,10 @@ export default function PointCloudViewer({
     robotHeadingYaw,
     robotLogoReady,
     sensor,
+    showLocalization,
     showRobot,
     showAxes,
+    showTrajectories,
     trajectoryGoal,
     trajectoryPaths,
     trajectorySafe,
@@ -1467,14 +1734,74 @@ export default function PointCloudViewer({
       }}>
         <button type="button" style={controlStyle()} title="Zoom out" onClick={() => setCamera(value => ({ ...value, zoom: clamp(value.zoom / 1.25, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM) }))}>−</button>
         <button type="button" style={controlStyle()} title="Zoom in" onClick={() => setCamera(value => ({ ...value, zoom: clamp(value.zoom * 1.25, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM) }))}>+</button>
-        <button type="button" style={controlStyle()} title="Orbit left" onClick={() => setCamera(value => ({ ...value, yaw: value.yaw - Math.PI / 12 }))}>↶</button>
-        <button type="button" style={controlStyle()} title="Orbit right" onClick={() => setCamera(value => ({ ...value, yaw: value.yaw + Math.PI / 12 }))}>↷</button>
-        <button type="button" style={controlStyle()} title="Tilt camera up" onClick={() => setCamera(value => ({ ...value, pitch: clamp(value.pitch + Math.PI / 18, -1.45, 1.45) }))}>↑</button>
-        <button type="button" style={controlStyle()} title="Tilt camera down" onClick={() => setCamera(value => ({ ...value, pitch: clamp(value.pitch - Math.PI / 18, -1.45, 1.45) }))}>↓</button>
-        <button type="button" style={controlStyle(camera.pitch === 0 && camera.yaw === TOP_VIEW_YAW)} title="Top view with world +X (red axis) pointing up" onClick={() => setCamera(value => ({ ...value, yaw: TOP_VIEW_YAW, pitch: 0 }))}>Top</button>
-        <button type="button" style={controlStyle()} title={mapFeatures ? 'Capture and align the map grid at the current robot pose' : 'Reset the sensor view'} onClick={resetCamera}>Reset</button>
+        <button type="button" style={controlStyle()} title="Orbit left" onClick={() => setCamera(value => orbitPointCloudCamera(value, value.yaw - Math.PI / 12, value.pitch))}>↶</button>
+        <button type="button" style={controlStyle()} title="Orbit right" onClick={() => setCamera(value => orbitPointCloudCamera(value, value.yaw + Math.PI / 12, value.pitch))}>↷</button>
+        <button type="button" style={controlStyle()} title="Tilt camera up to the stable overhead limit" onClick={() => setCamera(value => orbitPointCloudCamera(value, value.yaw, value.pitch + Math.PI / 18))}>↑</button>
+        <button type="button" style={controlStyle()} title="Tilt camera down to the stable underside limit" onClick={() => setCamera(value => orbitPointCloudCamera(value, value.yaw, value.pitch - Math.PI / 18))}>↓</button>
+        <button
+          type="button"
+          style={controlStyle(camera.pitch === (showRobot ? 0 : UPRIGHT_ORBIT_MAX_PITCH) && camera.yaw === TOP_VIEW_YAW)}
+          title="Top view with world +X (red axis) pointing up"
+          onClick={() => setCamera(value => showRobot
+            ? { ...value, yaw: TOP_VIEW_YAW, pitch: 0 }
+            : fitPointCloudCamera(TOP_VIEW_YAW, UPRIGHT_ORBIT_MAX_PITCH))}
+        >
+          Top
+        </button>
+        {viewerRole === 'depth-cloud' && (
+          <button
+            type="button"
+            style={controlStyle(viewFrozen)}
+            title={viewFrozen ? 'Resume displaying incoming depth frames' : 'Freeze the current depth frame for stable inspection'}
+            onClick={() => setFrozenDepthScene(current => current ? null : liveParsed)}
+          >
+            View: {viewFrozen ? 'Frozen' : 'Live'}
+          </button>
+        )}
+        {viewerRole === 'depth-cloud' && (
+          <button
+            type="button"
+            style={controlStyle(!depthOcclusion)}
+            title={depthOcclusion ? 'Show back points with translucent X-ray rendering' : 'Hide points occluded by nearer surfaces'}
+            onClick={() => setDepthOcclusion(value => !value)}
+          >
+            Points: {depthOcclusion ? 'Solid' : 'X-ray'}
+          </button>
+        )}
+        {viewerRole === 'depth-cloud' && (
+          <button
+            type="button"
+            style={controlStyle(camera.pitch === DEPTH_CAMERA_VIEW_PITCH && camera.yaw === TOP_VIEW_YAW)}
+            title="Upright front camera view with image right pointing right and world +Z pointing up"
+            onClick={alignDepthCameraView}
+          >
+            Camera
+          </button>
+        )}
+        {showRobot && (
+          <button
+            type="button"
+            style={controlStyle()}
+            title="Center the B robot and point its forward direction toward the top of the view"
+            onClick={alignRobotView}
+          >
+            Robot ↑
+          </button>
+        )}
+        <button
+          type="button"
+          style={controlStyle()}
+          title={mapFeatures
+            ? 'Capture and align the map grid at the current robot pose'
+            : viewerRole === 'depth-cloud'
+              ? 'Reset to the upright front camera view'
+              : 'Reset the sensor view'}
+          onClick={resetCamera}
+        >
+          Reset
+        </button>
         <label
-          title={`Show fixed ${mapFeatures ? 'map' : 'sensor'} X, Y, and Z axes with metric tick labels`}
+          title={`Show or hide the fixed ${mapFeatures ? 'map' : 'sensor'} grid, X/Y/Z axes, and metric tick labels`}
           style={{ ...controlStyle(showAxes), display: 'inline-flex', alignItems: 'center', gap: 5, width: 'auto' }}
         >
           <input
@@ -1506,7 +1833,42 @@ export default function PointCloudViewer({
             Floor: {showFreeSpace ? 'On' : 'Off'}
           </button>
         )}
+        {mapFeatures && particles.length > 0 && (
+          <button
+            type="button"
+            style={controlStyle(showLocalization)}
+            title="Show or hide localization hypotheses without changing SLAM"
+            onClick={() => setShowLocalization(value => !value)}
+          >
+            Localization: {showLocalization ? 'On' : 'Off'}
+          </button>
+        )}
+        {mapFeatures && trajectoryPaths.length > 0 && (
+          <button
+            type="button"
+            style={controlStyle(showTrajectories)}
+            title="Show or hide candidate navigation paths and their goal without changing evaluation"
+            onClick={() => setShowTrajectories(value => !value)}
+          >
+            Paths: {showTrajectories ? 'On' : 'Off'}
+          </button>
+        )}
         {onClear && (!parsed.depth_projection || parsed.reconstruction) && <button type="button" disabled={clearPending} style={controlStyle()} title={parsed.reconstruction ? 'Clear the persistent RGB-D reconstruction volume and pause integration' : 'Clear accumulated scan history and switch accumulation off'} onClick={onClear}>{clearPending ? 'Clearing…' : parsed.reconstruction ? 'Clear volume' : 'Clear history'}</button>}
+        {viewerRole === 'depth-cloud' && onDepthColorModeChange && (
+          <label style={{ ...controlStyle(true), display: 'inline-flex', alignItems: 'center', gap: 5, width: 'auto' }}>
+            Point color
+            <select
+              value={depthColorMode}
+              onChange={event => onDepthColorModeChange(event.target.value as 'depth' | 'rgb' | 'ir')}
+              title="Color projected points by depth, aligned RGB, or aligned infrared intensity"
+              style={{ border: 0, background: 'transparent', color: 'inherit', font: 'inherit', cursor: 'pointer' }}
+            >
+              <option value="depth">Depth</option>
+              <option value="rgb">RGB</option>
+              <option value="ir">IR</option>
+            </select>
+          </label>
+        )}
         <span style={{ marginLeft: 'auto', color: 'var(--tx3)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
           {camera.zoom.toFixed(2)}× · yaw {yawDegrees}° · pitch {pitchDegrees}°
         </span>
@@ -1533,7 +1895,7 @@ export default function PointCloudViewer({
           }}
           onDoubleClick={resetCamera}
           onPointerDown={event => {
-            if (event.shiftKey && event.button === 0 && onGoalSet) {
+            if (event.shiftKey && event.button === 0 && onGoalSet && showTrajectories) {
               event.preventDefault()
               event.stopPropagation()
               if (goalPending) return
@@ -1563,11 +1925,11 @@ export default function PointCloudViewer({
             const deltaX = event.clientX - drag.x
             const deltaY = event.clientY - drag.y
             if (drag.mode === 'rotate') {
-              setCamera({
-                ...drag.camera,
-                yaw: drag.camera.yaw + deltaX * 0.008,
-                pitch: clamp(drag.camera.pitch - deltaY * 0.008, -1.45, 1.45),
-              })
+              setCamera(orbitPointCloudCamera(
+                drag.camera,
+                drag.camera.yaw + deltaX * 0.008,
+                drag.camera.pitch - deltaY * 0.008,
+              ))
             } else {
               setCamera({ ...drag.camera, panX: drag.camera.panX + deltaX, panY: drag.camera.panY + deltaY })
             }
@@ -1608,8 +1970,8 @@ export default function PointCloudViewer({
           border: '1px solid rgba(86, 217, 145, 0.38)', color: '#8df0b5',
           fontFamily: 'var(--font-mono)', fontSize: 11, pointerEvents: 'none',
         }}>
-          <span style={{ width: 7, height: 7, borderRadius: '50%', background: currentPoints.length ? '#56d991' : '#71808d' }} />
-          {currentPoints.length
+          <span style={{ width: 7, height: 7, borderRadius: '50%', background: hasCurrentPoints ? '#56d991' : '#71808d' }} />
+          {hasCurrentPoints
             ? parsed.sensor_fusion?.backend === 'warp-hash-grid'
               ? `SENSOR FUSION · ${Number(parsed.sensor_fusion.matched_points ?? 0).toLocaleString()} ALIGNED`
               : parsed.reconstruction?.integration?.backend === 'warp'
@@ -1662,7 +2024,7 @@ export default function PointCloudViewer({
             HASHGRID ALIGN · {(finite(parsed.sensor_fusion.mean_residual_m) * 100).toFixed(1)} CM · {(finite(parsed.sensor_fusion.matched_ratio) * 100).toFixed(0)}%
           </div>
         )}
-        {parsed.trajectory_evaluation?.backend === 'warp' && (
+        {showTrajectories && parsed.trajectory_evaluation?.backend === 'warp' && (
           <div style={{
             position: 'absolute', zIndex: 3, top: parsed.dynamic_occupancy?.backend === 'warp-hash-grid' ? 70 : 39, right: 9,
             display: 'flex', alignItems: 'center', gap: 6,
@@ -1681,7 +2043,7 @@ export default function PointCloudViewer({
           background: 'rgba(3, 10, 16, 0.72)', color: 'rgba(217, 232, 241, 0.74)',
           fontFamily: 'var(--font-mono)', fontSize: 11, pointerEvents: 'none',
         }}>
-          {onGoalSet ? 'shift-click goal · ' : ''}left-drag pan · right-drag orbit · middle-drag pan · wheel zoom · double-click reset
+          {onGoalSet && showTrajectories ? 'shift-click goal · ' : ''}left-drag pan · right-drag orbit · middle-drag pan · wheel zoom · double-click reset
         </div>
       </div>
       <div data-bn-viewer-telemetry style={{
@@ -1711,9 +2073,10 @@ export default function PointCloudViewer({
           </span>
         )}
         {parsed.device && <span>{parsed.device}</span>}
+        {viewFrozen && <span style={{ color: '#ffd27a' }}>depth view frozen for navigation</span>}
         {parsed.frame && <span>{parsed.frame}</span>}
         {parsed.slam && <span>{Number(parsed.slam.keyframes ?? 0).toLocaleString()} keyframes · score {finite(parsed.slam.match_score).toFixed(2)} · {parsed.slam.matching_backend === 'warp' ? `Warp match ${finite(parsed.slam.matching_kernel_ms).toFixed(3)} ms` : 'CPU match'} · {parsed.slam.deskewed ? 'deskew on' : 'deskew unavailable'} · {Number(parsed.slam.loop_closures ?? 0).toLocaleString()} loops</span>}
-        {parsed.localization?.state === 'ready' && (
+        {showLocalization && parsed.localization?.state === 'ready' && (
           <span style={{ color: '#9df0c2' }}>
             {parsed.localization.backend === 'warp' ? 'Warp' : 'CPU'} particles {Number(parsed.localization.evaluated_particles ?? 0).toLocaleString()} × {Number(parsed.localization.beam_count ?? 0).toLocaleString()} beams = {Number(parsed.localization.work_items ?? 0).toLocaleString()} scores · {finite(parsed.localization.pipeline_ms).toFixed(3)} ms
             {finite(parsed.localization.effective_sample_size) > 0 ? ` · ESS ${Math.round(finite(parsed.localization.effective_sample_size)).toLocaleString()}` : ''}
@@ -1728,8 +2091,16 @@ export default function PointCloudViewer({
         )}
         {parsed.depth_projection?.state === 'ready' && (
           <span style={{ color: '#7cf4ff' }}>
-            Warp depth {Number(parsed.depth_projection.input_pixels ?? 0).toLocaleString()} pixels · {Number(parsed.depth_projection.valid_points ?? 0).toLocaleString()} valid · stride {Number(parsed.depth_projection.stride ?? 1)} · {finite(parsed.depth_projection.pipeline_ms).toFixed(3)} ms · fetch {finite(parsed.depth_projection.fetch_ms).toFixed(3)} ms · confidence {finite(parsed.depth_projection.mean_confidence).toFixed(2)}
+            Warp depth {Number(parsed.depth_projection.input_pixels ?? 0).toLocaleString()} pixels → {Number(parsed.depth_projection.candidate_points ?? parsed.depth_projection.valid_points ?? 0).toLocaleString()} candidates · {Number(parsed.depth_projection.valid_points ?? 0).toLocaleString()} valid · stride {Number(parsed.depth_projection.stride ?? 1)} · {finite(parsed.depth_projection.pipeline_ms).toFixed(3)} ms · fetch {finite(parsed.depth_projection.fetch_ms).toFixed(3)} ms · confidence {finite(parsed.depth_projection.mean_confidence).toFixed(2)}
+            {parsed.depth_projection.cleanup?.enabled ? ` · cleanup +${Number(parsed.depth_projection.cleanup.holes_filled ?? 0).toLocaleString()} holes / ${Number(parsed.depth_projection.cleanup.outliers_replaced ?? 0).toLocaleString()} outliers / ${Number(parsed.depth_projection.cleanup.temporally_blended ?? 0).toLocaleString()} stable` : ''}
+            {parsed.depth_projection.buffers_reused ? ' · buffers reused' : ''}
+            {` · color ${String(parsed.depth_projection.color_applied ?? 'depth').toUpperCase()}`}
             {finite(parsed.depth_projection.speedup) > 0 ? ` · ${finite(parsed.depth_projection.speedup).toFixed(1)}× CPU` : ''}
+          </span>
+        )}
+        {parsed.depth_projection?.color_error && (
+          <span style={{ color: '#ffbd6b' }}>
+            {String(parsed.depth_projection.color_error)} · using depth color
           </span>
         )}
         {parsed.reconstruction?.integration?.state === 'ready' && parsed.reconstruction.extraction?.state === 'ready' && (
@@ -1743,7 +2114,7 @@ export default function PointCloudViewer({
             {finite(parsed.sensor_fusion.speedup) > 0 ? ` · ${finite(parsed.sensor_fusion.speedup).toFixed(1)}× CPU` : ''}
           </span>
         )}
-        {parsed.trajectory_evaluation?.state === 'ready' && (
+        {showTrajectories && parsed.trajectory_evaluation?.state === 'ready' && (
           <span style={{ color: '#91f4ff' }}>
             Warp paths {Number(parsed.trajectory_evaluation.trajectory_count ?? 0).toLocaleString()} × {Number(parsed.trajectory_evaluation.time_steps ?? 0).toLocaleString()} steps = {Number(parsed.trajectory_evaluation.work_items ?? 0).toLocaleString()} evaluations · {finite(parsed.trajectory_evaluation.pipeline_ms).toFixed(3)} ms · best clearance {finite(parsed.trajectory_evaluation.best_minimum_clearance_m).toFixed(2)} m
             {finite(parsed.trajectory_evaluation.speedup) > 0 ? ` · ${finite(parsed.trajectory_evaluation.speedup).toFixed(1)}× CPU` : ''}
@@ -1760,15 +2131,15 @@ export default function PointCloudViewer({
         {showRobot && <span style={{ color: '#7cf4ff' }}>B robot {Math.round(finite(parsed.robot?.length_m, 0.25) * 100)}×{Math.round(finite(parsed.robot?.width_m, 0.22) * 100)} cm</span>}
         {!parsed.depth_projection && <span style={{ color: '#72ff9d' }}>— active beam</span>}
         {!parsed.depth_projection && !fullCircleScan && <span style={{ color: '#85a2b8' }}>┄ scan limits</span>}
-        <span style={{ color: '#32d8ef' }}>{parsed.sensor_fusion ? '● LiDAR cyan · RGB-D green aligned / red residual' : parsed.reconstruction ? '● reconstructed surface · aligned RGB when available' : parsed.depth_projection ? '● projected depth · brightness is surface confidence' : '● filtered laser returns'}</span>
+        <span style={{ color: '#32d8ef' }}>{parsed.sensor_fusion ? '● LiDAR cyan · RGB-D green aligned / red residual' : parsed.reconstruction ? '● reconstructed surface · aligned RGB when available' : parsed.depth_projection?.color_applied === 'rgb' ? '● projected depth · aligned RGB color' : parsed.depth_projection?.color_applied === 'ir' ? '● projected depth · aligned IR intensity' : parsed.depth_projection ? '● projected depth · distance and surface confidence color' : '● filtered laser returns'}</span>
         {parsed.sensor_fusion && <span style={{ color: '#91f4ff' }}>calibration Δ {finite(parsed.sensor_fusion.correction?.x_m).toFixed(3)} m X · {finite(parsed.sensor_fusion.correction?.y_m).toFixed(3)} m Y · {finite(parsed.sensor_fusion.correction?.yaw_deg).toFixed(2)}° yaw</span>}
         {mapFeatures && parsed.occupancy?.fixed_origin === true && <span style={{ color: '#486070' }}>■ unknown map extent</span>}
         {mapFeatures && parsed.map_render_mode === 'occupancy-texture' && <span style={{ color: '#74e7a5' }}>GPU map texture · all cells</span>}
         {mapFeatures && showFreeSpace && freeCellCount > 0 && <span style={{ color: '#4fc07a' }}>■ {freeCellCount.toLocaleString()} fixed free-floor cells</span>}
         {mapFeatures && occupiedCellCount > 0 && <span style={{ color: '#c7e0ef' }}>■ {occupiedCellCount.toLocaleString()} occupied wall cells</span>}
-        {particles.length > 0 && <span style={{ color: '#9df0c2' }}>● GPU pose hypotheses · purple low / green high confidence</span>}
+        {showLocalization && particles.length > 0 && <span style={{ color: '#9df0c2' }}>● GPU pose hypotheses · purple low / green high confidence</span>}
         {dynamicPoints.length > 0 && <span style={{ color: '#ffa940' }}>● coherent motion · orange points</span>}
-        {trajectoryPaths.length > 0 && <span><b style={{ color: '#66e091' }}>— safe</b> · <b style={{ color: '#ff5b5b' }}>— blocked</b> · <b style={{ color: '#5bebff' }}>— best GPU path</b></span>}
+        {showTrajectories && trajectoryPaths.length > 0 && <span><b style={{ color: '#66e091' }}>— safe</b> · <b style={{ color: '#ff5b5b' }}>— blocked</b> · <b style={{ color: '#5bebff' }}>— best GPU path</b></span>}
         {showAxes && <span>{mapFeatures ? 'map' : 'sensor'} <b style={{ color: '#ff6b6b' }}>X</b> / <b style={{ color: '#53e091' }}>Y</b> / <b style={{ color: '#539aff' }}>Z</b> axes</span>}
         {parsed.history_registered === true && <span style={{ color: '#74e7a5' }}>pose-registered history · {parsed.pose_source || 'pose stream'}</span>}
         {Array.isArray(parsed.registration?.tf_path) && parsed.registration.tf_path.length > 1 && (

--- a/editor/src/components/TemplateGallery.tsx
+++ b/editor/src/components/TemplateGallery.tsx
@@ -128,7 +128,12 @@ export default function TemplateGallery({
       await api.loadTemplate(template.slug)
       if (openInNewTab && previousGraph) {
         const templateGraph = await api.getGraph()
-        await api.setGraph(previousGraph.nodes, previousGraph.edges, previousGraph.metadata)
+        await api.setGraph(
+          previousGraph.nodes,
+          previousGraph.edges,
+          previousGraph.metadata,
+          previousGraph.entrypoint,
+        )
         await loadGraph()
         await openGraphAsTab(template.name, templateGraph)
         openedNewTab = true
@@ -161,7 +166,12 @@ export default function TemplateGallery({
         return
       }
       if (previousGraph && !openedNewTab) {
-        await api.setGraph(previousGraph.nodes, previousGraph.edges, previousGraph.metadata).catch(console.error)
+        await api.setGraph(
+          previousGraph.nodes,
+          previousGraph.edges,
+          previousGraph.metadata,
+          previousGraph.entrypoint,
+        ).catch(console.error)
         await loadGraph().catch(console.error)
       }
       window.dispatchEvent(new CustomEvent('blacknode:notice', {

--- a/editor/src/spatialCamera.ts
+++ b/editor/src/spatialCamera.ts
@@ -1,0 +1,21 @@
+// Shared orthographic camera basis for every Z-up spatial viewer.
+// World coordinates are +X forward, +Y left, +Z up. Upright orbit controls
+// keep pitch in the negative polar interval: -90° is a level/front view,
+// nearly 0° is overhead, and approaching -180° moves toward the underside.
+export function spatialCameraCoordinates(
+  x: number,
+  y: number,
+  z: number,
+  yaw: number,
+  pitch: number,
+): [number, number, number] {
+  const yawCosine = Math.cos(yaw)
+  const yawSine = Math.sin(yaw)
+  const yawX = yawCosine * x - yawSine * y
+  const yawY = yawSine * x + yawCosine * y
+  const pitchCosine = Math.cos(pitch)
+  const pitchSine = Math.sin(pitch)
+  const cameraY = pitchCosine * yawY - pitchSine * z
+  const cameraDepth = -pitchSine * yawY - pitchCosine * z
+  return [yawX, cameraY, cameraDepth]
+}

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -11,7 +11,7 @@ import { organizeFlowNodes } from './graphLayout'
 import { createVisualAgentLoopSubgraph } from './defaultSubgraphs'
 import type { GraphRunTarget } from './graphRun'
 import { LIVE_STREAM_NODE_TYPES } from './liveNodeTypes'
-import { VIEWER_NODE_TYPES } from './viewerTypes'
+import { MANAGED_SPATIAL_VIEWER_TYPES, VIEWER_NODE_TYPES } from './viewerTypes'
 
 const MODEL_NODE_TYPES  = new Set(['Model'])
 const OUTPUT_NODE_TYPES = new Set(['Output'])
@@ -21,6 +21,19 @@ const SUBGRAPH_NODE_TYPES = new Set(['Subnet', 'SubnetAsTool', 'VisualAgentLoop'
 
 // In-flight cook stream, so a Stop button can abort a running/stuck cook.
 let cookAbort: AbortController | null = null
+// Runtime status can be slow when remote devices are involved. Serialize its
+// polling and invalidate an older response as soon as Stop is requested so a
+// pre-stop snapshot cannot restore stale LIVE badges afterward.
+let runtimeOutputsPollInFlight = false
+let spatialViewerOutputsPollInFlight = false
+let runtimeOutputsEpoch = 0
+let runtimeStopInFlight = false
+
+const FAST_SPATIAL_VIEWER_TYPES = new Set([
+  ...MANAGED_SPATIAL_VIEWER_TYPES,
+  'SLAM',
+  'IMUViewer',
+])
 
 export interface WorkflowTab {
   id: string
@@ -220,6 +233,7 @@ interface Store {
   workflowRevision: number
   projectRevision: number
   workflowMetadata: WorkflowMetadata
+  workflowEntrypoint: GraphSnapshot['entrypoint']
   undoHistory: UndoSnapshot[]
   cookLog: CookLogEntry[]
   cookActive: boolean
@@ -234,6 +248,7 @@ interface Store {
   setApiKey: (provider: string, key: string) => Promise<void>
   loadDriverStatus: () => Promise<void>
   loadRuntimeNodeOutputs: () => Promise<void>
+  loadSpatialViewerNodeOutputs: () => Promise<void>
   reattachRuntimeState: () => Promise<void>
   restoreTabLiveState: (tabId: string) => void
   loadDrivers: () => Promise<void>
@@ -396,6 +411,28 @@ function makeReactNode(meta: BnNodeMeta): Node<NodeData> {
     ...(meta.type === 'ROS2GraphExplorer' ? { style: { width: 1040, height: 760 } } : {}),
     ...(meta.type === 'RobotMonitor' ? { style: { width: 760 } } : {}),
     ...(meta.type === 'RobotServo' ? { style: { width: 360 } } : {}),
+  }
+}
+
+function pinROS2NodeSize(node: Node<NodeData>): Node<NodeData> {
+  if (!node.data.type.startsWith('ROS2')) return node
+
+  // ROS2 cards gain live-state and telemetry rows while they cook. React Flow
+  // otherwise measures that content as a user resize, which permanently grows
+  // the card and moves nearby nodes. Pin the already-rendered dimensions before
+  // runtime state changes; NodeResizer still replaces these style values during
+  // an intentional drag.
+  const styleWidth = typeof node.style?.width === 'number' ? node.style.width : undefined
+  const styleHeight = typeof node.style?.height === 'number' ? node.style.height : undefined
+  const width = node.width ?? styleWidth
+  const height = node.height ?? styleHeight
+  if (width === undefined || height === undefined) return node
+
+  return {
+    ...node,
+    width,
+    height,
+    style: { ...(node.style ?? {}), width, height },
   }
 }
 
@@ -631,12 +668,19 @@ function clearCookResults(data: NodeData): NodeData {
 
 function clearRuntimeNodeData(data: NodeData): NodeData {
   const base = { ...data, cooking: false, cookError: undefined }
+  const stoppedResults = {
+    ...(data.portResults ?? {}),
+    running: false,
+    live: false,
+    streaming: false,
+    launched: false,
+  }
   if (LIVE_STREAM_NODE_TYPES.has(data.type)) {
     return {
       ...base,
       cookResult: undefined,
       portResults: {
-        ...(data.portResults ?? {}),
+        ...stoppedResults,
         preview: '',
         mask: '',
         streaming: false,
@@ -652,8 +696,7 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
     return {
       ...base,
       portResults: {
-        ...(data.portResults ?? {}),
-        live: false,
+        ...stoppedResults,
         updated_at: 'live monitoring stopped',
         report: 'live pose monitoring stopped; displayed values are the last snapshot',
       },
@@ -663,8 +706,7 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
     return {
       ...base,
       portResults: {
-        ...(data.portResults ?? {}),
-        live: false,
+        ...stoppedResults,
       },
     }
   }
@@ -672,8 +714,7 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
     return {
       ...base,
       portResults: {
-        ...(data.portResults ?? {}),
-        live: false,
+        ...stoppedResults,
       },
     }
   }
@@ -685,9 +726,9 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
     return {
       ...base,
       portResults: {
-        ...(data.portResults ?? {}),
-        running: false,
-        live: false,
+        ...stoppedResults,
+        scene: undefined,
+        preview: undefined,
         status: { ...status, state: 'stopped' },
         report: `${data.type} stopped by workflow control`,
       },
@@ -699,8 +740,7 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
     return {
       ...base,
       portResults: {
-        ...(data.portResults ?? {}),
-        running: false,
+        ...stoppedResults,
         report: 'continuous controller stopped by workflow control',
       },
     }
@@ -714,8 +754,7 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
       ...base,
       cookResult: undefined,
       portResults: {
-        ...(data.portResults ?? {}),
-        running: false,
+        ...stoppedResults,
         report: 'stopped by workflow control',
       },
     }
@@ -725,13 +764,12 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
       ...base,
       cookResult: undefined,
       portResults: {
-        ...(data.portResults ?? {}),
-        launched: false,
+        ...stoppedResults,
         report: 'stopped by workflow control',
       },
     }
   }
-  return base
+  return data.portResults ? { ...base, portResults: stoppedResults } : base
 }
 
 function flowEdgesToBackend(edges: Edge[]): any[] {
@@ -1109,6 +1147,7 @@ function graphSnapshotFromState(s: Store): GraphSnapshot {
     nodes: Object.values(current.node_meta),
     edges: current.edges,
     metadata: cloneDeep(s.workflowMetadata),
+    entrypoint: cloneDeep(s.workflowEntrypoint),
   }
 }
 
@@ -1417,7 +1456,7 @@ function cloneGraph(graph: GraphSnapshot): GraphSnapshot {
 }
 
 function blankGraph(): GraphSnapshot {
-  return { nodes: [], edges: [], metadata: {} }
+  return { nodes: [], edges: [], metadata: {}, entrypoint: null }
 }
 
 function cookStateFromTab(tab?: WorkflowTab): Pick<Store, 'cookLog' | 'cookActive' | 'cookStatusHidden'> {
@@ -1485,6 +1524,7 @@ export const useStore = create<Store>((set, get) => ({
   workflowRevision: 0,
   projectRevision: 0,
   workflowMetadata: {},
+  workflowEntrypoint: null,
   undoHistory: [],
   cookLog: [],
   cookActive: false,
@@ -1691,14 +1731,22 @@ export const useStore = create<Store>((set, get) => ({
   },
 
   loadRuntimeNodeOutputs: async () => {
+    if (runtimeOutputsPollInFlight || runtimeStopInFlight) return
+    runtimeOutputsPollInFlight = true
+    const requestEpoch = runtimeOutputsEpoch
     try {
       const status = await api.runtimeStatus()
+      if (requestEpoch !== runtimeOutputsEpoch) return
       const items = Object.values(status.modules ?? {}).flatMap(moduleStatus =>
         Array.isArray(moduleStatus?.node_outputs) ? moduleStatus.node_outputs : []
       )
       const managedRuns = Array.isArray(status.managed_runs) ? status.managed_runs : []
       set(s => ({
         nodes: propagateLiveTerminalValues(s.nodes.map(node => {
+          // High-rate spatial scenes have their own cached endpoint. Let that
+          // poll own these nodes so a slower, older control-plane response
+          // cannot move the cloud backward in time.
+          if (FAST_SPATIAL_VIEWER_TYPES.has(node.data.type)) return node
           const runId = node.data.type === 'ROS2TopicSubscriber' || node.data.type === 'ROS2'
             ? `topic-subscriber:${String(node.data.params?.topic ?? node.data.input_defaults?.topic ?? '/chatter')}`
             : String(node.data.params?.run_id ?? node.data.input_defaults?.run_id ?? 'robot_teach')
@@ -1732,26 +1780,22 @@ export const useStore = create<Store>((set, get) => ({
             rigid_bodies: managedRun.rigid_body_positions_m ?? {},
           } : {}
           if (Object.keys(liveOutputs).length === 0 && Object.keys(managedOutputs).length === 0) {
-            if (
-              VIEWER_NODE_TYPES.has(node.data.type)
-              && (node.data.portResults?.running === true || node.data.portResults?.live === true)
-            ) {
-              const previousStatus = node.data.portResults?.status
-              const status = previousStatus && typeof previousStatus === 'object' && !Array.isArray(previousStatus)
-                ? previousStatus as Record<string, unknown>
-                : {}
+            const runtimeWasActive = Boolean(
+              node.data.portResults?.running === true
+              || node.data.portResults?.live === true
+              || node.data.portResults?.streaming === true
+              || node.data.portResults?.launched === true
+            )
+            const managedRuntimeNode = Boolean(
+              node.data.live_capable === true
+              || LIVE_STREAM_NODE_TYPES.has(node.data.type)
+              || VIEWER_NODE_TYPES.has(node.data.type)
+              || node.data.type.startsWith('ROS2')
+            )
+            if (managedRuntimeNode && runtimeWasActive) {
               return {
                 ...node,
-                data: {
-                  ...node.data,
-                  cooking: false,
-                  portResults: {
-                    ...(node.data.portResults ?? {}),
-                    running: false,
-                    live: false,
-                    status: { ...status, state: 'stopped' },
-                  },
-                },
+                data: clearRuntimeNodeData(node.data),
               }
             }
             if (node.data.type !== 'NewtonSimulation' || !node.data.portResults?.viewer_url) return node
@@ -1780,6 +1824,57 @@ export const useStore = create<Store>((set, get) => ({
         }), s.edges),
       }))
     } catch {
+    } finally {
+      runtimeOutputsPollInFlight = false
+    }
+  },
+
+  loadSpatialViewerNodeOutputs: async () => {
+    if (spatialViewerOutputsPollInFlight || runtimeStopInFlight) return
+    spatialViewerOutputsPollInFlight = true
+    const requestEpoch = runtimeOutputsEpoch
+    try {
+      const status = await api.spatialViewerRuntimeStatus()
+      if (requestEpoch !== runtimeOutputsEpoch) return
+      const items = Object.values(status.modules ?? {}).flatMap(moduleStatus =>
+        Array.isArray(moduleStatus?.node_outputs) ? moduleStatus.node_outputs : []
+      )
+      set(s => ({
+        nodes: propagateLiveTerminalValues(s.nodes.map(node => {
+          if (!FAST_SPATIAL_VIEWER_TYPES.has(node.data.type)) return node
+          const item = items.find(raw => {
+            if (!raw || typeof raw !== 'object') return false
+            const record = raw as Record<string, unknown>
+            if (String(record.node_id ?? '') === node.id) return true
+            return String(record.node_type ?? '') === node.data.type
+          })
+          const outputs = item && typeof item === 'object'
+            ? (item as Record<string, unknown>).outputs
+            : undefined
+          if (!outputs || typeof outputs !== 'object' || Array.isArray(outputs)) {
+            const runtimeWasActive = Boolean(
+              node.data.portResults?.running === true
+              || node.data.portResults?.live === true
+            )
+            return runtimeWasActive
+              ? { ...node, data: clearRuntimeNodeData(node.data) }
+              : node
+          }
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              portResults: {
+                ...(node.data.portResults ?? {}),
+                ...(outputs as Record<string, unknown>),
+              },
+            },
+          }
+        }), s.edges),
+      }))
+    } catch {
+    } finally {
+      spatialViewerOutputsPollInFlight = false
     }
   },
 
@@ -1848,6 +1943,7 @@ export const useStore = create<Store>((set, get) => ({
       nodes: ensureConnectedToolBoxSlots(parsed.nodes, parsed.edges),
       edges: parsed.edges,
       workflowMetadata: graph.metadata ?? {},
+      workflowEntrypoint: graph.entrypoint ?? null,
       selectedId: null,
       ...(workflowName
         ? {
@@ -1923,7 +2019,7 @@ export const useStore = create<Store>((set, get) => ({
       cookStatusHidden: false,
     }))
     await api.reset()
-    set({ nodes: [], edges: [], workflowMetadata: {}, selectedId: null })
+    set({ nodes: [], edges: [], workflowMetadata: {}, workflowEntrypoint: null, selectedId: null })
   },
 
   insertTab: async (tabId) => {
@@ -1944,7 +2040,7 @@ export const useStore = create<Store>((set, get) => ({
       cookStatusHidden: false,
     })
     await api.reset()
-    set({ nodes: [], edges: [], workflowMetadata: {} })
+    set({ nodes: [], edges: [], workflowMetadata: {}, workflowEntrypoint: null })
   },
 
   switchTab: async (tabId) => {
@@ -1958,7 +2054,7 @@ export const useStore = create<Store>((set, get) => ({
     set({ activeTabId: tabId, selectedId: null, undoHistory: [], ...cookStateFromTab(tab) })
     if (tab.graph) {
       const graph = cloneGraph(tab.graph)
-      await api.setGraph(graph.nodes, graph.edges, graph.metadata)
+      await api.setGraph(graph.nodes, graph.edges, graph.metadata, graph.entrypoint)
       await get().loadGraph()
       get().restoreTabLiveState(tabId)
     } else if (tab.slug) {
@@ -1968,7 +2064,7 @@ export const useStore = create<Store>((set, get) => ({
       get().restoreTabLiveState(tabId)
     } else {
       await api.reset()
-      set({ nodes: [], edges: [], workflowMetadata: {}, selectedId: null })
+      set({ nodes: [], edges: [], workflowMetadata: {}, workflowEntrypoint: null, selectedId: null })
     }
   },
 
@@ -1985,6 +2081,7 @@ export const useStore = create<Store>((set, get) => ({
         nodes: [],
         edges: [],
         workflowMetadata: {},
+        workflowEntrypoint: null,
         selectedId: null,
         subnetStack: [],
         undoHistory: [],
@@ -2001,7 +2098,7 @@ export const useStore = create<Store>((set, get) => ({
       set({ tabs: newTabs, activeTabId: next.id, selectedId: null, undoHistory: [], ...cookStateFromTab(next) })
       if (next.graph) {
         const graph = cloneGraph(next.graph)
-        await api.setGraph(graph.nodes, graph.edges, graph.metadata)
+        await api.setGraph(graph.nodes, graph.edges, graph.metadata, graph.entrypoint)
         await get().loadGraph()
       } else if (next.slug) {
         const graph = await api.loadWorkflow(next.slug)
@@ -2009,7 +2106,7 @@ export const useStore = create<Store>((set, get) => ({
         await get().loadGraph()
       } else {
         await api.reset()
-        set({ nodes: [], edges: [], workflowMetadata: {}, selectedId: null })
+        set({ nodes: [], edges: [], workflowMetadata: {}, workflowEntrypoint: null, selectedId: null })
       }
     } else {
       set({ tabs: newTabs })
@@ -2050,7 +2147,7 @@ export const useStore = create<Store>((set, get) => ({
       cookActive: false,
       cookStatusHidden: false,
     })
-    await api.setGraph(graph.nodes, graph.edges, graph.metadata)
+    await api.setGraph(graph.nodes, graph.edges, graph.metadata, graph.entrypoint)
     await get().loadGraph()
   },
 
@@ -2089,7 +2186,7 @@ export const useStore = create<Store>((set, get) => ({
       cookActive: false,
       cookStatusHidden: false,
     }))
-    await api.setGraph(nextGraph.nodes, nextGraph.edges, nextGraph.metadata)
+    await api.setGraph(nextGraph.nodes, nextGraph.edges, nextGraph.metadata, nextGraph.entrypoint)
     await get().loadGraph()
   },
 
@@ -3522,21 +3619,24 @@ export const useStore = create<Store>((set, get) => ({
         currentEventType: 'queued',
         message: graphRun ? `Queued all ${targets.length} terminal nodes` : `Queued ${runLabel}.${port}`,
       },
-      nodes: s.nodes.map(n => ({
-        ...n,
-        data: targetIds.has(n.id)
-          ? {
-              ...clearReplayDataPreservingRuntime(n.data),
-              cooking: true,
-              cookError: undefined,
-              cookResult: undefined,
-              cookPort: targetPorts.get(n.id) ?? port,
-            }
-          : {
-              ...clearReplayDataPreservingRuntime(n.data),
-              cooking: false,
-            },
-      })),
+      nodes: s.nodes.map(n => {
+        const sizedNode = pinROS2NodeSize(n)
+        return {
+          ...sizedNode,
+          data: targetIds.has(sizedNode.id)
+            ? {
+                ...clearReplayDataPreservingRuntime(sizedNode.data),
+                cooking: true,
+                cookError: undefined,
+                cookResult: undefined,
+                cookPort: targetPorts.get(n.id) ?? port,
+              }
+            : {
+                ...clearReplayDataPreservingRuntime(sizedNode.data),
+                cooking: false,
+              },
+        }
+      }),
     }))
 
     cookAbort = new AbortController()
@@ -3613,24 +3713,22 @@ export const useStore = create<Store>((set, get) => ({
   },
 
   stopRuntimeServices: async () => {
+    runtimeOutputsEpoch += 1
+    runtimeStopInFlight = true
     cookAbort?.abort()
     cookAbort = null
-    let result: RuntimeStopResult
-    try {
-      result = await api.stopRuntime()
-    } catch (err) {
-      set({ serverOk: false, serverError: errorMessage(err) })
-      throw err
-    }
+    // Clear browser-side live state before waiting for device/package shutdown.
+    // The server keeps processing a stop even if a slow or unreachable device
+    // makes the browser request time out.
     set(s => ({
       ...syncTabCookState(s, s.activeTabId, {
         cookActive: false,
         cookStatusHidden: false,
         cookLog: appendCookLog(tabCookLog(s, s.activeTabId), {
-          id: `${Date.now()}-runtime-stopped`,
-          kind: result.ok ? 'info' : 'error',
+          id: `${Date.now()}-runtime-stop-requested`,
+          kind: 'info',
           label: 'Runtime',
-          message: result.report || result.error || 'Stopped workflow runtime services',
+          message: 'Stop requested; clearing live state while runtime services shut down',
           ts: Date.now(),
         }),
       }),
@@ -3660,6 +3758,24 @@ export const useStore = create<Store>((set, get) => ({
             ? clearRuntimeNodeData(clearReplayData(n.data))
             : { ...n.data, cooking: false },
         }
+      }),
+    }))
+    let result: RuntimeStopResult
+    try {
+      result = await api.stopRuntime()
+    } catch (err) {
+      runtimeStopInFlight = false
+      set({ serverOk: false, serverError: errorMessage(err) })
+      throw err
+    }
+    runtimeStopInFlight = false
+    set(s => syncTabCookState(s, s.activeTabId, {
+      cookLog: appendCookLog(tabCookLog(s, s.activeTabId), {
+        id: `${Date.now()}-runtime-stopped`,
+        kind: result.ok ? 'info' : 'error',
+        label: 'Runtime',
+        message: result.report || result.error || 'Stopped workflow runtime services',
+        ts: Date.now(),
       }),
     }))
     return result
@@ -3729,12 +3845,18 @@ export const useStore = create<Store>((set, get) => ({
     if (idx < 0) return
 
     const snapshot = undoHistory[idx]
-    await api.setGraph(snapshot.graph.nodes, snapshot.graph.edges, snapshot.graph.metadata)
+    await api.setGraph(
+      snapshot.graph.nodes,
+      snapshot.graph.edges,
+      snapshot.graph.metadata,
+      snapshot.graph.entrypoint,
+    )
     dragUndoActive = false
     set(s => ({
       nodes: cloneDeep(snapshot.nodes),
       edges: cloneDeep(snapshot.edges),
       workflowMetadata: cloneDeep(snapshot.graph.metadata),
+      workflowEntrypoint: cloneDeep(snapshot.graph.entrypoint),
       subnetStack: cloneDeep(snapshot.subnetStack),
       selectedId: snapshot.selectedId,
       undoHistory: undoHistory.slice(0, idx),
@@ -3749,6 +3871,7 @@ export const useStore = create<Store>((set, get) => ({
       nodes: [],
       edges: [],
       workflowMetadata: {},
+      workflowEntrypoint: null,
       selectedId: null,
       tabs: s.tabs.map(t =>
         t.id === s.activeTabId

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -940,16 +940,39 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                         "ACTPolicyExport",
                         "PolicyArtifactLoad"
                     ]
+                },
+                "reinforcement-learning": {
+                    "name": "reinforcement-learning",
+                    "default": False,
+                    "node_types": [
+                        "PPOTraining",
+                        "PPOCheckpointInspect",
+                        "PPOPolicyEvaluate",
+                        "PPOPolicyExport"
+                    ],
+                    "dependencies": {
+                        "requires": [
+                            {
+                                "package": "blacknode-newton",
+                                "component": "runtime",
+                                "version": ">=0.1,<1"
+                            }
+                        ]
+                    }
                 }
             },
             "git_url": "https://github.com/temiroff/blacknode-training.git",
-            "description": "Robot-policy dataset checks, managed PyTorch training, checkpoints, previews, and deployable policy artifacts.",
+            "description": "Robot-policy dataset checks, managed training, checkpoints, previews, reinforcement learning, and deployable policy artifacts.",
             "node_types": [
                 "ACTCheckpointInspect",
                 "ACTPolicyExport",
                 "ACTPolicyPreview",
                 "ACTPolicyReplay",
                 "ACTTraining",
+                "PPOCheckpointInspect",
+                "PPOPolicyEvaluate",
+                "PPOPolicyExport",
+                "PPOTraining",
                 "PolicyArtifactLoad",
                 "TrainingDatasetCheck"
             ]

--- a/templates/generic-viewer.json
+++ b/templates/generic-viewer.json
@@ -1,0 +1,126 @@
+{
+  "kind": "blacknode.workflow",
+  "schema_version": 1,
+  "name": "Generic Point Cloud Viewer",
+  "saved_at": "2026-08-05T00:00:00",
+  "entrypoint": {
+    "node_id": "viewer",
+    "port": "scene"
+  },
+  "metadata": {
+    "template": true,
+    "description": "Present a portable point-cloud frame in the neutral 3D GenericViewer with sensor axes and no map floor, occupancy, or robot geometry.",
+    "color": "#22d3ee",
+    "required_packages": []
+  },
+  "node_meta": {
+    "point_cloud": {
+      "id": "point_cloud",
+      "type": "Dict",
+      "params": {
+        "value": {
+          "kind": "blacknode.point-cloud-frame",
+          "schema_version": 1,
+          "frame": "sensor_frame",
+          "points_xyz": [
+            [0.0, 0.0, 0.0],
+            [0.25, 0.0, 0.0],
+            [0.5, 0.0, 0.0],
+            [0.75, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.25, 0.0],
+            [0.0, 0.5, 0.0],
+            [0.0, 0.75, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.25],
+            [0.0, 0.0, 0.5],
+            [0.0, 0.0, 0.75],
+            [0.0, 0.0, 1.0],
+            [0.35, 0.35, 0.25],
+            [0.5, 0.5, 0.5],
+            [0.65, 0.65, 0.75]
+          ],
+          "colors_rgb": [
+            [1.0, 1.0, 1.0],
+            [1.0, 0.25, 0.25],
+            [1.0, 0.25, 0.25],
+            [1.0, 0.25, 0.25],
+            [1.0, 0.25, 0.25],
+            [0.25, 1.0, 0.4],
+            [0.25, 1.0, 0.4],
+            [0.25, 1.0, 0.4],
+            [0.25, 1.0, 0.4],
+            [0.25, 0.55, 1.0],
+            [0.25, 0.55, 1.0],
+            [0.25, 0.55, 1.0],
+            [0.25, 0.55, 1.0],
+            [0.2, 0.85, 1.0],
+            [0.2, 0.85, 1.0],
+            [0.2, 0.85, 1.0]
+          ]
+        }
+      },
+      "pos": [
+        80,
+        220
+      ],
+      "inputs": [],
+      "outputs": [
+        "value"
+      ],
+      "input_types": {},
+      "output_types": {
+        "value": "Dict"
+      },
+      "input_defaults": {}
+    },
+    "viewer": {
+      "id": "viewer",
+      "type": "GenericViewer",
+      "params": {
+        "title": "Portable point cloud",
+        "frame": "sensor_frame",
+        "show_axes": true
+      },
+      "pos": [
+        430,
+        80
+      ],
+      "inputs": [
+        "source",
+        "title",
+        "frame",
+        "show_axes"
+      ],
+      "outputs": [
+        "scene",
+        "status",
+        "report"
+      ],
+      "input_types": {
+        "source": "Dict",
+        "title": "Text",
+        "frame": "Text",
+        "show_axes": "Bool"
+      },
+      "output_types": {
+        "scene": "Dict",
+        "status": "Dict",
+        "report": "Text"
+      },
+      "input_defaults": {
+        "title": "Sensor data",
+        "frame": "",
+        "show_axes": true
+      }
+    }
+  },
+  "edges": [
+    {
+      "from": "point_cloud",
+      "from_port": "value",
+      "to": "viewer",
+      "to_port": "source"
+    }
+  ]
+}

--- a/tests/test_editor_canvas_interactions.py
+++ b/tests/test_editor_canvas_interactions.py
@@ -57,3 +57,12 @@ def test_ros2_python_node_card_shows_managed_live_state_and_stop_control():
     assert "onStopROS2PythonNode" in node_source
     assert "n.data.type === 'ROS2PythonNode'" in store_source
     assert "node.data.params?.run_id ?? node.data.input_defaults?.run_id" in store_source
+
+
+def test_ros2_node_dimensions_are_pinned_before_runtime_content_is_rendered():
+    store_source = (ROOT / "editor" / "src" / "store.ts").read_text(encoding="utf-8")
+
+    assert "function pinROS2NodeSize" in store_source
+    assert "node.data.type.startsWith('ROS2')" in store_source
+    assert "style: { ...(node.style ?? {}), width, height }" in store_source
+    assert "const sizedNode = pinROS2NodeSize(n)" in store_source

--- a/tests/test_editor_depth_cloud_color_modes.py
+++ b/tests/test_editor_depth_cloud_color_modes.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_depth_cloud_viewer_exposes_depth_rgb_and_ir_controls():
+    viewer = (
+        ROOT / "editor" / "src" / "components" / "PointCloudViewer.tsx"
+    ).read_text(encoding="utf-8")
+    node = (
+        ROOT / "editor" / "src" / "components" / "BlackNode.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "Point color" in viewer
+    assert '<option value="depth">Depth</option>' in viewer
+    assert '<option value="rgb">RGB</option>' in viewer
+    assert '<option value="ir">IR</option>' in viewer
+    assert "color_error" in viewer
+    assert "using depth color" in viewer
+    assert "onDepthColorModeChange" in viewer
+    assert "data.type === 'DepthCloudViewer'" in node
+    assert "updateParam(id, 'color_mode', mode)" in node
+
+
+def test_depth_cloud_color_mode_is_pushed_to_the_live_viewer():
+    import sys
+
+    editor_server = ROOT / "editor-server"
+    if str(editor_server) not in sys.path:
+        sys.path.insert(0, str(editor_server))
+    import server
+
+    calls = []
+    with patch.object(
+        server,
+        "_runtime_callable",
+        return_value=lambda viewer_id, mode: calls.append((viewer_id, mode)) or {"ok": True},
+    ):
+        server._push_live_node_param_update(
+            {"type": "DepthCloudViewer", "params": {"viewer_id": "camera-cloud"}},
+            "color_mode",
+            "ir",
+            {"viewer_id": "camera-cloud", "color_mode": "rgb"},
+        )
+
+    assert calls == [("camera-cloud", "ir")]

--- a/tests/test_editor_depth_viewer.py
+++ b/tests/test_editor_depth_viewer.py
@@ -88,3 +88,19 @@ def test_depth_viewer_renders_raw_metric_frames_locally_without_recooking():
     assert "depthPreviewUrl" not in viewer
     assert "onDepthDisplayChange" in black_node
     assert "updateParam(id, key, value)" in black_node
+
+
+def test_depth_viewer_click_inspects_metric_distance_at_the_source_pixel():
+    viewer = (
+        ROOT / "editor" / "src" / "components" / "ImageSensorViewer.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "function depthPixelFromPointer" in viewer
+    assert "const scale = Math.min(rect.width / frame.width, rect.height / frame.height)" in viewer
+    assert "function sampleDepth" in viewer
+    assert "frame.values[pixel.y * frame.width + pixel.x] * depthScale" in viewer
+    assert "onClick={inspectDepth}" in viewer
+    assert 'title="Click to inspect metric distance"' in viewer
+    assert "Click image to measure" in viewer
+    assert "No depth · pixel" in viewer
+    assert "depthSample.distanceM.toFixed(3)" in viewer

--- a/tests/test_editor_devices_refined.py
+++ b/tests/test_editor_devices_refined.py
@@ -86,3 +86,13 @@ def test_missing_remote_hardware_package_offers_a_direct_install_action():
     assert 'installLabel="Install Hardware"' in devices
     assert "packageInstallAvailable" in devices
     assert "bn-local-package-install-available" in styles
+
+
+def test_device_check_skips_ros_diagnostics_when_no_robot_is_attached():
+    devices = (
+        ROOT / "editor" / "src" / "components" / "DevicesPanel.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "if (device.robots.length === 0)" in devices
+    assert "No robot attached · ROS 2 check not required" in devices
+    assert "No robot attached · ROS 2 check skipped" in devices

--- a/tests/test_editor_graph_run.py
+++ b/tests/test_editor_graph_run.py
@@ -159,6 +159,29 @@ class EditorGraphRunTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(seen, ["live"])
 
+    def test_graph_api_preserves_explicit_workflow_entrypoint(self):
+        session, left_id, _ = self._session()
+        session.entrypoint = {"node_id": left_id, "port": "value"}
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch.object(server, "_session", session),
+            patch.object(server, "_SAVE_PATH", str(Path(tmp) / "graph.json")),
+        ):
+            client = TestClient(server.app)
+            snapshot = client.get("/graph").json()
+            self.assertEqual(snapshot["entrypoint"], session.entrypoint)
+            for node_id, node in zip(session.node_meta, snapshot["nodes"]):
+                node.setdefault("id", node_id)
+                node.setdefault("params", {})
+                node.setdefault("pos", [0, 0])
+            response = client.post("/graph", json=snapshot)
+            validation = client.get("/validate").json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["entrypoint"], session.entrypoint)
+        self.assertTrue(validation["ok"], validation)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_editor_imu_viewer.py
+++ b/tests/test_editor_imu_viewer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SPATIAL_CAMERA = ROOT / "editor" / "src" / "spatialCamera.ts"
 
 
 def test_imu_viewer_has_quaternion_robot_axes_logo_and_live_telemetry():
@@ -13,6 +14,24 @@ def test_imu_viewer_has_quaternion_robot_axes_logo_and_live_telemetry():
     assert "drawArrow(bodyOrigin" in source
     assert "ROLL" in source and "PITCH" in source and "YAW" in source
     assert "ANGULAR" in source and "ACCEL" in source and "FRAME" in source
+    assert "multiplyQuaternion(rawQuaternion, inverseQuaternion(sensorMountQuaternion))" in source
+    assert "multiplyQuaternion(rawBodyQuaternion, inverseQuaternion(referenceQuaternion))" in source
+    assert "Zero pose" in source
+    assert "Absolute" in source
+    assert "startup-relative robot pose" in source
+    assert "IMU axes" in source
+    assert "IMU X" in source and "IMU Y" in source and "IMU Z" in source
+    assert "body_from_sensor_quaternion" in source
+    assert "spatialCameraCoordinates" in source
+    assert "const IMU_DEFAULT_CAMERA:" in source
+    assert "yaw: -0.68" in source
+    assert "pitch: -0.62" in source
+    assert "IMU_CAMERA_MIN_PITCH" in source and "IMU_CAMERA_MAX_PITCH" in source
+    assert "return depth(right) - depth(left)" in source
+
+    camera_source = SPATIAL_CAMERA.read_text(encoding="utf-8")
+    assert "World coordinates are +X forward, +Y left, +Z up" in camera_source
+    assert "const cameraDepth = -pitchSine * yawY - pitchCosine * z" in camera_source
 
 
 def test_imu_viewer_uses_the_managed_viewer_node_shell():

--- a/tests/test_editor_live_controls.py
+++ b/tests/test_editor_live_controls.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "editor" / "src" / "App.tsx"
+API = ROOT / "editor" / "src" / "api.ts"
+STORE = ROOT / "editor" / "src" / "store.ts"
+
+
+def test_top_live_control_tracks_generic_live_capable_runtime_nodes():
+    source = APP.read_text(encoding="utf-8")
+
+    assert "const liveCapableRuntimeCount" in source
+    assert "n.data.live_capable === true" in source
+    assert "n.data.portResults?.live === true" in source
+    assert "n.data.portResults?.running === true" in source
+    assert "n.data.portResults?.streaming === true" in source
+    assert "n.data.portResults?.launched === true" in source
+    assert "const runtimeActive = liveCapableRuntimeCount > 0" in source
+
+
+def test_stop_live_request_has_a_bounded_browser_wait():
+    source = API.read_text(encoding="utf-8")
+
+    assert "stopRuntime: () => req<RuntimeStopResult>('POST', '/runtime/stop', undefined, 15000)" in source
+
+
+def test_stop_live_clears_browser_state_before_waiting_for_remote_shutdown():
+    app_source = APP.read_text(encoding="utf-8")
+    store_source = STORE.read_text(encoding="utf-8")
+
+    handler = app_source.index("const handleStopRuntime = useCallback")
+    clear_mode = app_source.index("setActiveRunMode(null)", handler)
+    pending = app_source.index("setRuntimeStopPending(true)", handler)
+    clear_state = store_source.index("Stop requested; clearing live state")
+    stop_request = store_source.index("result = await api.stopRuntime()", clear_state)
+
+    assert clear_mode < pending
+    assert clear_state < stop_request
+
+
+def test_stop_live_cannot_be_reactivated_by_a_stale_runtime_status_poll():
+    source = STORE.read_text(encoding="utf-8")
+
+    assert "let runtimeOutputsPollInFlight = false" in source
+    assert "let runtimeOutputsEpoch = 0" in source
+    assert "if (runtimeOutputsPollInFlight || runtimeStopInFlight) return" in source
+    assert "const requestEpoch = runtimeOutputsEpoch" in source
+    assert "if (requestEpoch !== runtimeOutputsEpoch) return" in source
+    assert "runtimeOutputsEpoch += 1" in source
+    assert "runtimeOutputsPollInFlight = false" in source
+
+
+def test_spatial_viewer_frames_use_the_fast_cached_runtime_path():
+    app_source = APP.read_text(encoding="utf-8")
+    api_source = API.read_text(encoding="utf-8")
+    store_source = STORE.read_text(encoding="utf-8")
+
+    assert "'/runtime/spatial-viewers'" in api_source
+    assert "setInterval(loadSpatialViewerNodeOutputs, 100)" in app_source
+    assert "if (FAST_SPATIAL_VIEWER_TYPES.has(node.data.type)) return node" in store_source
+    assert "if (spatialViewerOutputsPollInFlight || runtimeStopInFlight) return" in store_source
+    assert "'IMUViewer'," in store_source
+
+
+def test_stop_live_clears_all_ros2_and_viewer_live_fields_and_stale_frames():
+    source = STORE.read_text(encoding="utf-8")
+
+    assert "const stoppedResults = {" in source
+    assert "running: false," in source
+    assert "live: false," in source
+    assert "streaming: false," in source
+    assert "launched: false," in source
+    assert "scene: undefined," in source
+    assert "preview: undefined," in source
+    assert "data: clearRuntimeNodeData(node.data)," in source
+    assert "node.data.type.startsWith('ROS2')" in source

--- a/tests/test_editor_point_cloud_viewer.py
+++ b/tests/test_editor_point_cloud_viewer.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 VIEWER = ROOT / "editor" / "src" / "components" / "PointCloudViewer.tsx"
+SPATIAL_CAMERA = ROOT / "editor" / "src" / "spatialCamera.ts"
 BLACK_NODE = ROOT / "editor" / "src" / "components" / "BlackNode.tsx"
 APP = ROOT / "editor" / "src" / "App.tsx"
 INDEX_CSS = ROOT / "editor" / "src" / "index.css"
@@ -10,6 +11,7 @@ INDEX_CSS = ROOT / "editor" / "src" / "index.css"
 
 def test_point_cloud_viewer_exposes_spatial_orientation_and_scale():
     source = VIEWER.read_text(encoding="utf-8")
+    camera_source = SPATIAL_CAMERA.read_text(encoding="utf-8")
 
     assert "Robot forward" not in source
     assert "const [showAxes, setShowAxes] = useState(viewerRole !== 'map' && viewerRole !== 'legacy')" in source
@@ -30,13 +32,14 @@ def test_point_cloud_viewer_exposes_spatial_orientation_and_scale():
     assert "const logoWorldScale = Math.min(" in source
     assert "const logoWidth = ROBOT_LOGO_SOURCE.width * logoWorldScale / visualRobotWidth" in source
     assert "const logoHeight = ROBOT_LOGO_SOURCE.height * logoWorldScale / visualRobotLength" in source
-    assert "(forwardUnit[0] - sensorScreen[0]) * visualRobotLength" in source
-    assert "(lateralUnit[0] - sensorScreen[0]) * visualRobotWidth" in source
+    assert "(forwardUnit[0] - robotScreen[0]) * visualRobotLength" in source
+    assert "(lateralUnit[0] - robotScreen[0]) * visualRobotWidth" in source
     assert "context.rotate(ROBOT_LOGO_ROTATION_RAD)" in source
     assert "context.rotate(-robotHeadingYaw" not in source
     assert "projectedHeading" not in source
     assert "rgba(30, 199, 220, 0.3)" in source
     assert "robotHeadingYaw" in source
+    assert "finite(parsed.robot?.yaw_rad, inferredRobotHeadingYaw)" in source
     assert "robotCorners" in source
     assert "finite(parsed.robot?.length_m, 0.25)" in source
     assert "finite(parsed.robot?.width_m, 0.22)" in source
@@ -76,6 +79,9 @@ def test_point_cloud_viewer_exposes_spatial_orientation_and_scale():
     assert "matching_kernel_ms" in source
     assert "fixed map grid" in source
     assert "#72ff9d" in source
+    assert "blacknode.numeric-rows" in source
+    assert "float32-le-base64" in source
+    assert "uint8-normalized-base64" in source
     assert ") % 1" not in source
     assert "real_scan_pulse" not in source
     assert "Accumulate:" in source
@@ -101,6 +107,7 @@ def test_point_cloud_viewer_exposes_spatial_orientation_and_scale():
 
 def test_point_cloud_viewer_has_direct_camera_navigation():
     source = VIEWER.read_text(encoding="utf-8")
+    camera_source = SPATIAL_CAMERA.read_text(encoding="utf-8")
 
     assert "onWheel" in source
     assert 'className="bn-viewer-wheel-capture"' in source
@@ -120,30 +127,82 @@ def test_point_cloud_viewer_has_direct_camera_navigation():
     assert "const ROBOT_FIT_RADIUS_MULTIPLIER = 1.65" in source
     assert "const MAX_CAMERA_ZOOM = 120" in source
     assert "const TOP_VIEW_YAW = Math.PI / 2" in source
+    assert "const DEPTH_CAMERA_VIEW_PITCH = -Math.PI / 2 + Math.PI / 18" in source
     assert "yaw: TOP_VIEW_YAW" in source
     assert "pitch: 0" in source
     assert "const initialResetPendingRef = useRef(true)" in source
+    assert "const cameraAnchorReady = viewerRole === 'depth-cloud'" in source
+    assert "? renderedPoints.length > 0" in source
+    assert "|| !cameraAnchorReady" in source
     assert "initialResetPendingRef.current = false" in source
     assert "resetCamera()" in source
     assert "const focusRadius = Math.max(0.35" in source
     assert "const resetYaw = TOP_VIEW_YAW - robotHeadingYaw" in source
     assert "yaw: resetYaw" in source
     assert "const [gridFrame, setGridFrame] = useState<GridFrame>({ x: 0, y: 0, yaw: 0 })" in source
-    assert "setGridFrame({ x: sensor.x, y: sensor.y, yaw: robotHeadingYaw })" in source
+    assert "setGridFrame({ x: robot.x, y: robot.y, yaw: robotHeadingYaw })" in source
     assert "pitch: 0" in source
-    assert "const focusedSensorX = resetYawCosine * sensor.x - resetYawSine * sensor.y" in source
-    assert "const focusedSensorY = resetYawSine * sensor.x + resetYawCosine * sensor.y" in source
-    assert "panX: -focusedSensorX * appliedPixelsPerMeter" in source
-    assert "panY: focusedSensorY * appliedPixelsPerMeter" in source
+    assert "const focusedRobotX = resetYawCosine * robot.x - resetYawSine * robot.y" in source
+    assert "const focusedRobotY = resetYawSine * robot.x + resetYawCosine * robot.y" in source
+    assert "panX: -focusedRobotX * appliedPixelsPerMeter" in source
+    assert "panY: focusedRobotY * appliedPixelsPerMeter" in source
     assert 'title="Top view with world +X (red axis) pointing up"' in source
-    assert "title={mapFeatures ? 'Capture and align the map grid at the current robot pose' : 'Reset the sensor view'}" in source
-    assert ">Reset</button>" in source
+    assert "const fitPointCloudCamera = (yaw: number, pitch: number): CameraState" in source
+    assert "Math.max(1, viewport.width * 0.9) / spanX" in source
+    assert "Math.max(1, viewport.height * 0.9) / spanY" in source
+    assert "panX: -(minimumX + maximumX) / 2 * appliedPixelsPerMeter" in source
+    assert "setCamera(fitPointCloudCamera(" in source
+    assert "function wrapAngle(value: number): number" in source
+    assert "const orbitPointCloudCamera = (" in source
+    assert "panX: value.panX + (oldX - nextX) * appliedPixelsPerMeter" in source
+    assert "pitch: clamp(drag.camera.pitch" not in source
+    assert "const UPRIGHT_ORBIT_POLE_MARGIN = Math.PI / 180" in source
+    assert "const UPRIGHT_ORBIT_MIN_PITCH = -Math.PI + UPRIGHT_ORBIT_POLE_MARGIN" in source
+    assert "const UPRIGHT_ORBIT_MAX_PITCH = -UPRIGHT_ORBIT_POLE_MARGIN" in source
+    assert "UPRIGHT_ORBIT_MIN_PITCH," in source
+    assert "UPRIGHT_ORBIT_MAX_PITCH," in source
+    assert "-sin(pitch) > 0" in source
+    assert "Tilt camera up to the stable overhead limit" in source
+    assert "Tilt camera down to the stable underside limit" in source
+    assert "spatialCameraCoordinates as cameraCoordinates" in source
+    assert "const cameraDepth = -pitchSine * yawY - pitchCosine * z" in camera_source
+    assert "gl.enable(gl.DEPTH_TEST)" in source
+    assert "gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)" in source
+    assert "attribute vec3 a_position;" in source
+    assert "gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, 0, 0)" in source
+    assert "const [frozenDepthScene, setFrozenDepthScene] = useState<ViewerScene | null>(null)" in source
+    assert "const viewFrozen = viewerRole === 'depth-cloud' && frozenDepthScene !== null" in source
+    assert "event.button === 2 && !viewFrozen" not in source
+    assert "View: {viewFrozen ? 'Frozen' : 'Live'}" in source
+    assert "Points: {depthOcclusion ? 'Solid' : 'X-ray'}" in source
+    assert "const xrayPointCloud = viewerRole === 'depth-cloud' && !depthOcclusion" in source
+    assert "gl.disable(gl.DEPTH_TEST)" in source
+    assert "gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)" in source
+    assert "uniform float u_alpha;" in source
+    assert "gl_FragColor = vec4(v_color, u_alpha);" in source
+    assert "const renderOrder = Array.from({ length: vertexCount }, (_, index) => index)" in source
+    assert "if (xrayPointCloud)" in source
+    assert "renderOrder.sort((left, right) => (" in source
+    assert "cameraDepths[right] - cameraDepths[left] || left - right" in source
+    assert "renderOrder.forEach((sourceIndex, vertexIndex) =>" in source
+    assert "const point = renderedPoints[sourceIndex]" in source
+    assert "cameraDepths[sourceIndex]" in source
+    assert "viewerRole === 'depth-cloud' ? DEPTH_CAMERA_VIEW_PITCH : UPRIGHT_ORBIT_MAX_PITCH" in source
+    assert "fitPointCloudCamera(TOP_VIEW_YAW, UPRIGHT_ORBIT_MAX_PITCH)" in source
+    assert "viewerRole === 'depth-cloud' && (" in source
+    assert "Upright front camera view with image right pointing right and world +Z pointing up" in source
+    assert "onClick={alignDepthCameraView}" in source
+    assert "? 'Reset to the upright front camera view'" in source
+    assert "          Reset\n        </button>" in source
+    assert "Center the B robot and point its forward direction toward the top of the view" in source
+    assert "Robot ↑" in source
     assert "const ROBOT_LOGO_ROTATION_RAD = -Math.PI / 2" in source
     assert "const gridFrameToScreen = (forward: number, lateral: number, z: number)" in source
     assert "gridFrame.x + gridHeadingCosine * forward - gridHeadingSine * lateral" in source
     assert "const [x1, y1] = gridFrameToScreen(value, -reach, 0)" in source
     assert "const [x3, y3] = gridFrameToScreen(-reach, value, 0)" in source
-    assert "title={`Show fixed ${mapFeatures ? 'map' : 'sensor'} X, Y, and Z axes with metric tick labels`}" in source
+    assert "title={`Show or hide the fixed ${mapFeatures ? 'map' : 'sensor'} grid, X/Y/Z axes, and metric tick labels`}" in source
+    assert "if (showAxes) {\n      context.strokeStyle = 'rgba(117, 155, 181, 0.14)'" in source
     assert "event.button === 2 ? 'rotate' : 'pan'" in source
     assert "event.preventDefault()" in source
     assert "event.stopPropagation()" in source
@@ -216,6 +275,10 @@ def test_trajectory_evaluation_draws_safe_blocked_and_best_paths_without_motion_
     assert "WARP PATHS" in viewer_source
     assert "best GPU path" in viewer_source
     assert "Warp paths" in viewer_source
+    assert "Paths: {showTrajectories ? 'On' : 'Off'}" in viewer_source
+    assert "Localization: {showLocalization ? 'On' : 'Off'}" in viewer_source
+    assert "showTrajectories && trajectoryPaths.length > 0" in viewer_source
+    assert "showLocalization && particles.length > 0" in viewer_source
 
 
 def test_slam_viewer_shift_click_sets_connected_warp_trajectory_goal_without_recook():
@@ -244,6 +307,11 @@ def test_shared_viewer_surfaces_live_warp_depth_projection_metrics():
     assert "METRIC DEPTH" in source
     assert "Warp depth" in source
     assert "calibrated metric surface" in source
+    assert "candidate_points" in source
+    assert "holes_filled" in source
+    assert "outliers_replaced" in source
+    assert "temporally_blended" in source
+    assert "buffers reused" in source
 
 
 def test_shared_viewer_surfaces_persistent_rgbd_reconstruction_controls_and_metrics():

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import sys
 import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -250,6 +252,44 @@ class EditorRuntimeTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"ranges": [1.0, None, None]})
 
+    def test_spatial_viewer_status_skips_remote_runtime_probes(self):
+        calls = []
+
+        def fake_status(label, module_name):
+            calls.append((label, module_name))
+            outputs = {
+                "live": True,
+                "scene": {
+                    "points": [[float(index), 0.0, 1.0] for index in range(64)],
+                    "colors": [[1.0, 0.5, 0.0] for _ in range(64)],
+                },
+            }
+            return {
+                "ok": True,
+                "active": label == "viewer",
+                "node_outputs": [{"node_type": "Viewer", "node_id": "cloud", "outputs": outputs}]
+                if label == "viewer"
+                else [],
+                "report": f"{label} ready",
+            }
+
+        with (
+            patch.object(server, "_runtime_module_status", side_effect=fake_status),
+            patch.object(server, "_remote_ros2_runtime_status") as remote_ros2,
+            patch.object(server, "_remote_ros2_image_runtime_status") as remote_images,
+        ):
+            response = TestClient(server.app).get("/runtime/spatial-viewers")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["active"])
+        self.assertEqual([label for label, _ in calls], ["viewer", "slam", "imu_viewer"])
+        scene = response.json()["modules"]["viewer"]["node_outputs"][0]["outputs"]["scene"]
+        self.assertEqual(scene["points"]["encoding"], "float32-le-base64")
+        self.assertEqual(scene["points"]["count"], 64)
+        self.assertEqual(scene["colors"]["encoding"], "uint8-normalized-base64")
+        remote_ros2.assert_not_called()
+        remote_images.assert_not_called()
+
     def test_remote_ros2_action_routes_through_paired_runtime_and_reports_live_outputs(self):
         calls = []
 
@@ -421,6 +461,32 @@ class EditorRuntimeTests(unittest.TestCase):
         finally:
             server._remote_ros2_image_runs.clear()
 
+    def test_remote_ros2_image_stop_runs_concurrently_and_clears_local_state_first(self):
+        barrier = threading.Barrier(3)
+        worker_threads = []
+        server._remote_ros2_image_runs.clear()
+        server._remote_ros2_image_runs.update({
+            node_id: {"node_id": node_id, "device_id": "jetson"}
+            for node_id in ("rgb", "depth", "ir")
+        })
+
+        def stop_action(_request):
+            with server._remote_ros2_image_lock:
+                self.assertEqual(server._remote_ros2_image_runs, {})
+            worker_threads.append(threading.get_ident())
+            barrier.wait(timeout=1.0)
+            return {"stream": {"running": False, "error": ""}}
+
+        try:
+            with patch.object(server, "_remote_ros2_image_action", side_effect=stop_action):
+                result = server._stop_remote_ros2_image_services()
+
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["stopped"]["streams"], 3)
+            self.assertEqual(len(set(worker_threads)), 3)
+        finally:
+            server._remote_ros2_image_runs.clear()
+
     def test_stop_runtime_services_aggregates_package_runtime_modules(self):
         def fake_stop(label, _module_name):
             if label == "ros2":
@@ -451,6 +517,57 @@ class EditorRuntimeTests(unittest.TestCase):
         })
         self.assertIn("stopped ros", result["report"])
         self.assertIn("stopped cv2 and reasoning", result["report"])
+
+    def test_stop_runtime_services_stops_independent_modules_concurrently(self):
+        barrier = threading.Barrier(3)
+        worker_threads = []
+
+        def fake_stop(_label, _module_name):
+            worker_threads.append(threading.get_ident())
+            barrier.wait(timeout=1.0)
+            return {"ok": True, "stopped": {"streams": 1}}
+
+        no_remote = lambda: {"ok": True, "stopped": {"streams": 0}}
+        with (
+            patch.object(server, "_RUNTIME_MODULES", {
+                "camera": "camera_runtime",
+                "depth": "depth_runtime",
+                "infrared": "infrared_runtime",
+            }),
+            patch.object(server, "_stop_runtime_module", side_effect=fake_stop),
+            patch.object(server, "_stop_remote_ros2_services", side_effect=no_remote),
+            patch.object(server, "_stop_remote_ros2_image_services", side_effect=no_remote),
+        ):
+            result = server._stop_runtime_services()
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["stopped"]["streams"], 3)
+        self.assertEqual(len(set(worker_threads)), 3)
+
+    def test_stop_runtime_services_returns_when_a_package_stop_hangs(self):
+        release = threading.Event()
+
+        def slow_stop(_label, _module_name):
+            release.wait(timeout=2.0)
+            return {"ok": True, "stopped": {"streams": 1}}
+
+        no_remote = lambda: {"ok": True, "stopped": {"streams": 0}}
+        started = time.monotonic()
+        try:
+            with (
+                patch.object(server, "_RUNTIME_MODULES", {"camera": "camera_runtime"}),
+                patch.object(server, "_RUNTIME_STOP_TIMEOUT_SECONDS", 0.05),
+                patch.object(server, "_stop_runtime_module", side_effect=slow_stop),
+                patch.object(server, "_stop_remote_ros2_services", side_effect=no_remote),
+                patch.object(server, "_stop_remote_ros2_image_services", side_effect=no_remote),
+            ):
+                result = server._stop_runtime_services()
+        finally:
+            release.set()
+
+        self.assertLess(time.monotonic() - started, 0.5)
+        self.assertFalse(result["ok"])
+        self.assertIn("still completing in the background", result["modules"]["camera"]["error"])
 
     def test_stop_runtime_services_tolerates_nested_package_counter(self):
         with (
@@ -696,6 +813,48 @@ class EditorRuntimeTests(unittest.TestCase):
             self.assertEqual(stopped.status_code, 200)
             self.assertEqual(stopped.json()["outputs"]["phase"], "stopped")
             self.assertEqual(calls, [("act-test", "status"), ("act-test", "stop")])
+            self.assertNotIn(node_id, server._session.graph._dirty)
+            prepare_cook.assert_not_called()
+        finally:
+            server._session.node_meta.pop(node_id, None)
+            server._session.graph._dirty.discard(node_id)
+            for key in [key for key in server._session.graph._cache if key[0] == node_id]:
+                server._session.graph._cache.pop(key, None)
+
+    def test_ppo_training_control_reports_updates_and_stops_without_cooking_graph(self):
+        node_id = "ppo-training-control-test"
+        server._session.node_meta[node_id] = {
+            "id": node_id, "type": "PPOTraining", "params": {"run_id": "so101-test"},
+        }
+        server._session.graph._dirty.add(node_id)
+        calls: list[tuple[str, str]] = []
+
+        def control(run_id, action):
+            calls.append((run_id, action))
+            return {
+                "ok": True, "running": action == "status",
+                "phase": "running" if action == "status" else "stopped",
+                "update": 7, "status": {"updates": 100},
+                "dashboard": "data:image/svg+xml;base64,test", "checkpoint": "",
+                "viewer": {"running": True, "viewer_url": "http://127.0.0.1:8091"},
+                "viewer_url": "http://127.0.0.1:8091",
+                "report": f"{run_id}:{action}",
+            }
+
+        try:
+            with (
+                patch.object(server, "_runtime_callable", return_value=control),
+                patch.object(server, "_prepare_cook") as prepare_cook,
+            ):
+                client = TestClient(server.app)
+                status = client.post(f"/nodes/{node_id}/control", json={"action": "status"})
+                stopped = client.post(f"/nodes/{node_id}/control", json={"action": "stop"})
+            self.assertEqual(status.status_code, 200)
+            self.assertEqual(status.json()["outputs"]["update"], 7)
+            self.assertEqual(status.json()["outputs"]["viewer_url"], "http://127.0.0.1:8091")
+            self.assertEqual(stopped.status_code, 200)
+            self.assertEqual(stopped.json()["outputs"]["phase"], "stopped")
+            self.assertEqual(calls, [("so101-test", "status"), ("so101-test", "stop")])
             self.assertNotIn(node_id, server._session.graph._dirty)
             prepare_cook.assert_not_called()
         finally:

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -290,6 +290,16 @@ def test_core_index_maps_official_node_types_to_git_packages():
     }
     assert payload["nodes"]["ACTPolicyExport"]["package"] == "blacknode-training"
     assert payload["nodes"]["ACTPolicyReplay"]["package"] == "blacknode-training"
+    assert payload["nodes"]["PPOTraining"]["package"] == "blacknode-training"
+    assert payload["packages"]["blacknode-training"]["components"]["reinforcement-learning"]["dependencies"] == {
+        "requires": [
+            {
+                "package": "blacknode-newton",
+                "component": "runtime",
+                "version": ">=0.1,<1",
+            }
+        ]
+    }
     assert payload["nodes"]["PolicyArtifactLoad"]["package"] == "blacknode-training"
     assert not any(
         component["default"]


### PR DESCRIPTION
## Summary
- add live depth, point-cloud, IMU, and spatial viewer controls in the editor
- add fast spatial-scene polling, bounded live shutdown, and PPO training controls
- add the portable generic viewer template and update operator documentation
- ignore generated local training run state

## Why
Sensor visualization and managed training need a consistent live operator surface with explicit start, stop, camera, color, and inspection controls.

## Impact
Operators can inspect and control live spatial streams and managed PPO jobs directly in the Blacknode editor.

## Verification
- `python -m pytest tests/test_editor_canvas_interactions.py tests/test_editor_depth_viewer.py tests/test_editor_devices_refined.py tests/test_editor_graph_run.py tests/test_editor_imu_viewer.py tests/test_editor_point_cloud_viewer.py tests/test_editor_runtime.py tests/test_editor_depth_cloud_color_modes.py tests/test_editor_live_controls.py -q` (78 passed)
- `python -m unittest discover -s tests` (545 passed, 8 skipped)
- `npm run build`
- changed workflow templates validated with `blacknode validate`

## Managed Runtime release
No Runtime release is required for this core PR because it changes the editor, editor-server orchestration, templates, tests, and documentation only. A separate Runtime 0.4.12 release is part of the coordinated publish for its own service-update fix.