### PR TITLE
Pin Runtime 0.4.12 device sources

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,10 +3,10 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "61358c4f70c68ec6ffdcd0150d6a802d64af0818"
+    "commit": "f6fc5b8fea9d4ac8318930acee792c73c3ae00f4"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "72ea5b6e6b32f7bc48c9476c9da8bec1b5378933"
+    "commit": "e5f909e3849e7769cbd395dce45a6de6bb67a599"
   }
 }


### PR DESCRIPTION
## Summary
- pin merged blacknode-runtime 0.4.12 commit `f6fc5b8fea9d4ac8318930acee792c73c3ae00f4`
- pin merged Blacknode core commit `e5f909e3849e7769cbd395dce45a6de6bb67a599`

## Why
Managed-device updates must build from merged, immutable Runtime and Core commits after a Runtime release.

## Impact
Devices → Software → Check updates → Update all can publish the new **Latest** Runtime bundle while installed devices remain on **Current** until the operator chooses the update.

## Verification
- `python -m pytest tests/test_editor_devices.py -q` (139 passed, 2 subtests passed)
- `python -m unittest discover -s tests` (545 passed, 8 skipped)

## Managed Runtime release
Yes. This completes the source-lock step for blacknode-runtime 0.4.12.