### PR TITLE
Add Run on Cloud editor workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ blacknode packages install https://github.com/temiroff/blacknode-robot.git
 Workflow templates declare the packages they need, so missing nodes can be
 resolved before a run or deployment.
 
+## Open source and business model
+
+Blacknode is Apache-2.0 software with a usage-based cloud service. The editor,
+runtime, workflow format, package system, and device deployment tools remain
+available for local and self-hosted operation.
+
+Blacknode Cloud provides optional hosted execution for portable workflows that
+need on-demand GPU compute. Cloud accounts use compute credits measured in
+GPU-seconds: a job reserves its runtime limit, charges measured GPU time, and
+returns progress, logs, metrics, and downloadable artifacts to the editor. The
+same workflow format runs locally, on paired devices, and in Blacknode Cloud.
+
+Cloud usage funds the hosted compute infrastructure, security maintenance,
+release engineering, and continued development of the open-source project.
+
 ## Learn more
 
 - [Beginner Walkthrough](docs/walkthrough.md)

--- a/docs/quickstart-mcp.md
+++ b/docs/quickstart-mcp.md
@@ -28,6 +28,11 @@ chmod +x start.sh
 
 These launchers install local dependencies if needed, start the FastAPI backend at `http://127.0.0.1:7777`, restart an old Blacknode editor on port 3000 if needed, start the Vite editor at `http://localhost:3000`, and open the browser. On Windows, `.\start.bat` keeps one launcher window open and writes service logs to `.local-logs/`.
 
+The launchers connect **Run on Cloud** to
+`https://cloud.blacknoderobotics.com` by default. Set
+`BLACKNODE_CLOUD_URL` before launching to use a staging or local Cloud API;
+an explicit value takes precedence over the default.
+
 If you see `Stopping existing visual editor on port 3000...`, the launcher
 found an old Blacknode Vite server and restarted it so the editor stays on
 `http://localhost:3000`.

--- a/editor-server/cloud_client.py
+++ b/editor-server/cloud_client.py
@@ -18,7 +18,11 @@ class CloudConfiguration:
 
     @property
     def configured(self) -> bool:
-        return self.base_url.startswith(("http://", "https://")) and len(self.api_key) >= 24
+        return self.available and len(self.api_key) >= 24
+
+    @property
+    def available(self) -> bool:
+        return self.base_url.startswith(("http://", "https://"))
 
 
 class CloudClientError(RuntimeError):
@@ -40,8 +44,17 @@ def json_request(
     payload: dict[str, Any] | None = None,
     *,
     timeout: float = 30.0,
+    authorization: str | None = None,
+    allow_admin: bool = True,
 ) -> dict[str, Any]:
-    response = _open(method, path, payload, timeout=timeout)
+    response = _open(
+        method,
+        path,
+        payload,
+        timeout=timeout,
+        authorization=authorization,
+        allow_admin=allow_admin,
+    )
     with response:
         try:
             value = json.loads(response.read().decode("utf-8"))
@@ -52,8 +65,19 @@ def json_request(
     return value
 
 
-def download(path: str, *, timeout: float = 30.0) -> tuple[Iterator[bytes], str, str]:
-    response = _open("GET", path, timeout=timeout)
+def download(
+    path: str,
+    *,
+    authorization: str,
+    timeout: float = 30.0,
+) -> tuple[Iterator[bytes], str, str]:
+    response = _open(
+        "GET",
+        path,
+        timeout=timeout,
+        authorization=authorization,
+        allow_admin=False,
+    )
     media_type = response.headers.get_content_type() or "application/octet-stream"
     disposition = response.headers.get("Content-Disposition", "")
 
@@ -74,18 +98,20 @@ def _open(
     payload: dict[str, Any] | None = None,
     *,
     timeout: float,
+    authorization: str | None = None,
+    allow_admin: bool = True,
 ):
     config = configuration()
-    if not config.configured:
+    if not config.available:
         raise CloudClientError(
             503,
-            "Configure BLACKNODE_CLOUD_URL and BLACKNODE_CLOUD_API_KEY on the editor server.",
+            "Configure BLACKNODE_CLOUD_URL on the editor server.",
         )
     body = json.dumps(payload).encode("utf-8") if payload is not None else None
-    headers = {
-        "Accept": "application/json",
-        "Authorization": f"Bearer {config.api_key}",
-    }
+    headers = {"Accept": "application/json"}
+    bearer = authorization or (config.api_key if allow_admin else "")
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
     if body is not None:
         headers["Content-Type"] = "application/json"
     request = urllib.request.Request(

--- a/editor-server/cloud_client.py
+++ b/editor-server/cloud_client.py
@@ -1,0 +1,117 @@
+"""Thin public client for the private Blacknode Cloud HTTP API."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CloudConfiguration:
+    base_url: str
+    api_key: str
+
+    @property
+    def configured(self) -> bool:
+        return self.base_url.startswith(("http://", "https://")) and len(self.api_key) >= 24
+
+
+class CloudClientError(RuntimeError):
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def configuration() -> CloudConfiguration:
+    return CloudConfiguration(
+        base_url=os.environ.get("BLACKNODE_CLOUD_URL", "").strip().rstrip("/"),
+        api_key=os.environ.get("BLACKNODE_CLOUD_API_KEY", "").strip(),
+    )
+
+
+def json_request(
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    response = _open(method, path, payload, timeout=timeout)
+    with response:
+        try:
+            value = json.loads(response.read().decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise CloudClientError(502, "Blacknode Cloud returned invalid JSON.") from exc
+    if not isinstance(value, dict):
+        raise CloudClientError(502, "Blacknode Cloud returned an invalid response.")
+    return value
+
+
+def download(path: str, *, timeout: float = 30.0) -> tuple[Iterator[bytes], str, str]:
+    response = _open("GET", path, timeout=timeout)
+    media_type = response.headers.get_content_type() or "application/octet-stream"
+    disposition = response.headers.get("Content-Disposition", "")
+
+    def chunks() -> Iterator[bytes]:
+        with response:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                yield chunk
+
+    return chunks(), media_type, disposition
+
+
+def _open(
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout: float,
+):
+    config = configuration()
+    if not config.configured:
+        raise CloudClientError(
+            503,
+            "Configure BLACKNODE_CLOUD_URL and BLACKNODE_CLOUD_API_KEY on the editor server.",
+        )
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {config.api_key}",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(
+        f"{config.base_url}{path}",
+        data=body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        return urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        message = _error_message(exc)
+        exc.close()
+        raise CloudClientError(exc.code, message) from exc
+    except (OSError, urllib.error.URLError) as exc:
+        raise CloudClientError(502, "Blacknode Cloud is unreachable.") from exc
+
+
+def _error_message(response: urllib.error.HTTPError) -> str:
+    try:
+        payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return "Blacknode Cloud rejected the request."
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if isinstance(detail, str):
+        return detail[:500]
+    if isinstance(detail, dict) and isinstance(detail.get("message"), str):
+        return detail["message"][:500]
+    return "Blacknode Cloud rejected the request."

--- a/editor-server/cloud_client.py
+++ b/editor-server/cloud_client.py
@@ -140,4 +140,18 @@ def _error_message(response: urllib.error.HTTPError) -> str:
         return detail[:500]
     if isinstance(detail, dict) and isinstance(detail.get("message"), str):
         return detail["message"][:500]
+    if isinstance(detail, list):
+        messages: list[str] = []
+        for issue in detail:
+            if not isinstance(issue, dict) or not isinstance(issue.get("msg"), str):
+                continue
+            location = issue.get("loc")
+            field = ""
+            if isinstance(location, list):
+                parts = [str(part) for part in location if str(part) != "body"]
+                field = ".".join(parts)
+            message = issue["msg"].strip()
+            messages.append(f"{field}: {message}" if field else message)
+        if messages:
+            return "; ".join(messages)[:500]
     return "Blacknode Cloud rejected the request."

--- a/editor-server/cloud_sessions.py
+++ b/editor-server/cloud_sessions.py
@@ -1,0 +1,63 @@
+"""Server-side sessions for Blacknode Cloud accounts in the local editor."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CloudSession:
+    token: str
+    expires_at: datetime
+    account: dict[str, Any]
+
+
+class CloudSessionStore:
+    """Keep Cloud bearer tokens out of browser storage and JavaScript."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, CloudSession] = {}
+        self._lock = threading.RLock()
+
+    def create(
+        self,
+        token: str,
+        expires_at: str,
+        account: dict[str, Any],
+    ) -> tuple[str, CloudSession]:
+        expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=UTC)
+        session_id = secrets.token_urlsafe(32)
+        session = CloudSession(token=token, expires_at=expiry, account=dict(account))
+        with self._lock:
+            self._purge_locked()
+            self._sessions[session_id] = session
+        return session_id, session
+
+    def get(self, session_id: str | None) -> CloudSession | None:
+        if not session_id:
+            return None
+        with self._lock:
+            self._purge_locked()
+            return self._sessions.get(session_id)
+
+    def pop(self, session_id: str | None) -> CloudSession | None:
+        if not session_id:
+            return None
+        with self._lock:
+            return self._sessions.pop(session_id, None)
+
+    def _purge_locked(self) -> None:
+        now = datetime.now(UTC)
+        expired = [
+            session_id
+            for session_id, session in self._sessions.items()
+            if session.expires_at <= now
+        ]
+        for session_id in expired:
+            self._sessions.pop(session_id, None)

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -372,6 +372,11 @@ class CloudRegisterReq(CloudLoginReq):
     password: str = Field(min_length=10, max_length=200)
     display_name: str = Field(default="", max_length=100)
 
+
+class CloudEmailVerificationReq(BaseModel):
+    token: str = Field(min_length=32, max_length=500)
+
+
 class SetGraphReq(BaseModel):
     nodes: list[dict[str, Any]] = []
     edges: list[dict[str, Any]] = []
@@ -4115,6 +4120,12 @@ def _cloud_status_payload(request: Request, response: Response) -> dict[str, Any
             _clear_cloud_cookie(request, response)
         return status_payload
     try:
+        account = _cloud_call(
+            "GET",
+            "/v1/account",
+            authorization=session.token,
+            allow_admin=False,
+        )
         credits = _cloud_call(
             "GET",
             "/v1/credits",
@@ -4129,7 +4140,7 @@ def _cloud_status_payload(request: Request, response: Response) -> dict[str, Any
         raise
     status_payload.update(
         authenticated=True,
-        account=session.account,
+        account=account,
         credits=credits,
     )
     response.headers["Cache-Control"] = "no-store"
@@ -4203,6 +4214,16 @@ def login_cloud_account(req: CloudLoginReq, request: Request, response: Response
         response,
         "/v1/auth/login",
         {"email": req.email, "password": req.password},
+    )
+
+
+@app.post("/cloud/auth/verify-email")
+def verify_cloud_email(req: CloudEmailVerificationReq):
+    return _cloud_call(
+        "POST",
+        "/v1/auth/verify-email",
+        {"token": req.token},
+        allow_admin=False,
     )
 
 

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
-from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
@@ -85,6 +85,7 @@ from artifact_store import ArtifactStore, ArtifactStoreError
 from project_store import ProjectStore, ProjectStoreError
 from run_store import RunStore
 import cloud_client
+import cloud_sessions
 
 
 def package_index_payload(*args, **kwargs):
@@ -113,6 +114,9 @@ def workflow_node_types(*args, **kwargs):
 
 app = FastAPI(title="Blacknode Editor Server")
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+_CLOUD_SESSION_COOKIE = "blacknode_cloud_session"
+_cloud_sessions = cloud_sessions.CloudSessionStore()
 
 
 def _reap_orphaned_stream_servers() -> None:
@@ -357,6 +361,16 @@ class CloudJobReq(BaseModel):
     workflow_name: str = "Current Graph"
     project_ref: str | None = None
     max_runtime_seconds: int = Field(default=3600, ge=60, le=86_400)
+
+
+class CloudLoginReq(BaseModel):
+    email: str = Field(min_length=3, max_length=254)
+    password: str = Field(min_length=1, max_length=200)
+
+
+class CloudRegisterReq(CloudLoginReq):
+    password: str = Field(min_length=10, max_length=200)
+    display_name: str = Field(default="", max_length=100)
 
 class SetGraphReq(BaseModel):
     nodes: list[dict[str, Any]] = []
@@ -4007,11 +4021,119 @@ def cook_graph_stream(req: CookGraphReq):
     )
 
 
-def _cloud_call(method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+def _cloud_call(
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    authorization: str | None = None,
+    allow_admin: bool = True,
+) -> dict[str, Any]:
     try:
-        return cloud_client.json_request(method, path, payload)
+        return cloud_client.json_request(
+            method,
+            path,
+            payload,
+            authorization=authorization,
+            allow_admin=allow_admin,
+        )
     except cloud_client.CloudClientError as exc:
         raise HTTPException(exc.status, str(exc)) from exc
+
+
+def _cloud_session(request: Request) -> cloud_sessions.CloudSession:
+    session = _cloud_sessions.get(request.cookies.get(_CLOUD_SESSION_COOKIE))
+    if session is None:
+        raise HTTPException(401, "Sign in to Blacknode Cloud to continue.")
+    return session
+
+
+def _cloud_user_call(
+    request: Request,
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _cloud_call(
+        method,
+        path,
+        payload,
+        authorization=_cloud_session(request).token,
+        allow_admin=False,
+    )
+
+
+def _cloud_cookie_secure(request: Request) -> bool:
+    forwarded = request.headers.get("x-forwarded-proto", "").split(",", 1)[0].strip()
+    return request.url.scheme == "https" or forwarded == "https"
+
+
+def _set_cloud_cookie(
+    request: Request,
+    response: Response,
+    session_id: str,
+    session: cloud_sessions.CloudSession,
+) -> None:
+    max_age = max(0, int(session.expires_at.timestamp() - time.time()))
+    response.set_cookie(
+        _CLOUD_SESSION_COOKIE,
+        session_id,
+        max_age=max_age,
+        httponly=True,
+        secure=_cloud_cookie_secure(request),
+        samesite="strict",
+        path="/",
+    )
+    response.headers["Cache-Control"] = "no-store"
+
+
+def _clear_cloud_cookie(request: Request, response: Response) -> None:
+    response.delete_cookie(
+        _CLOUD_SESSION_COOKIE,
+        httponly=True,
+        secure=_cloud_cookie_secure(request),
+        samesite="strict",
+        path="/",
+    )
+    response.headers["Cache-Control"] = "no-store"
+
+
+def _cloud_status_payload(request: Request, response: Response) -> dict[str, Any]:
+    config = cloud_client.configuration()
+    status_payload: dict[str, Any] = {
+        "configured": config.available,
+        "gpu": "NVIDIA L40S",
+        "url": config.base_url if config.available else "",
+        "authenticated": False,
+        "account": None,
+        "credits": None,
+    }
+    session_id = request.cookies.get(_CLOUD_SESSION_COOKIE)
+    session = _cloud_sessions.get(session_id)
+    if session is None:
+        if session_id:
+            _clear_cloud_cookie(request, response)
+        return status_payload
+    try:
+        credits = _cloud_call(
+            "GET",
+            "/v1/credits",
+            authorization=session.token,
+            allow_admin=False,
+        )
+    except HTTPException as exc:
+        if exc.status_code == 401:
+            _cloud_sessions.pop(session_id)
+            _clear_cloud_cookie(request, response)
+            return status_payload
+        raise
+    status_payload.update(
+        authenticated=True,
+        account=session.account,
+        credits=credits,
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return status_payload
 
 
 def _cloud_job_id(value: str) -> str:
@@ -4021,17 +4143,96 @@ def _cloud_job_id(value: str) -> str:
 
 
 @app.get("/cloud/status")
-def cloud_status():
+def cloud_status(request: Request, response: Response):
+    return _cloud_status_payload(request, response)
+
+
+def _cloud_authenticate(
+    request: Request,
+    response: Response,
+    path: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    auth = _cloud_call("POST", path, payload, allow_admin=False)
+    token = str(auth.get("token") or "")
+    expires_at = str(auth.get("expires_at") or "")
+    account = auth.get("account")
+    if len(token) < 24 or not expires_at or not isinstance(account, dict):
+        raise HTTPException(502, "Blacknode Cloud returned an invalid login session.")
+    session_id, session = _cloud_sessions.create(token, expires_at, account)
+    _set_cloud_cookie(request, response, session_id, session)
     config = cloud_client.configuration()
+    credits = _cloud_call(
+        "GET",
+        "/v1/credits",
+        authorization=session.token,
+        allow_admin=False,
+    )
     return {
-        "configured": config.configured,
+        "configured": config.available,
         "gpu": "NVIDIA L40S",
-        "url": config.base_url if config.configured else "",
+        "url": config.base_url if config.available else "",
+        "authenticated": True,
+        "account": session.account,
+        "credits": credits,
     }
 
 
+@app.post("/cloud/auth/register")
+def register_cloud_account(
+    req: CloudRegisterReq,
+    request: Request,
+    response: Response,
+):
+    return _cloud_authenticate(
+        request,
+        response,
+        "/v1/auth/register",
+        {
+            "email": req.email,
+            "password": req.password,
+            "display_name": req.display_name,
+        },
+    )
+
+
+@app.post("/cloud/auth/login")
+def login_cloud_account(req: CloudLoginReq, request: Request, response: Response):
+    return _cloud_authenticate(
+        request,
+        response,
+        "/v1/auth/login",
+        {"email": req.email, "password": req.password},
+    )
+
+
+@app.post("/cloud/auth/logout")
+def logout_cloud_account(request: Request, response: Response):
+    session_id = request.cookies.get(_CLOUD_SESSION_COOKIE)
+    session = _cloud_sessions.pop(session_id)
+    revoked = session is None
+    if session is not None:
+        try:
+            _cloud_call(
+                "POST",
+                "/v1/auth/logout",
+                authorization=session.token,
+                allow_admin=False,
+            )
+            revoked = True
+        except HTTPException:
+            revoked = False
+    _clear_cloud_cookie(request, response)
+    return {"ok": True, "revoked": revoked}
+
+
+@app.get("/cloud/credits/history")
+def get_cloud_credit_history(request: Request, limit: int = Query(default=100, ge=1, le=200)):
+    return _cloud_user_call(request, "GET", f"/v1/credits/history?limit={limit}")
+
+
 @app.post("/cloud/jobs")
-def create_cloud_job(req: CloudJobReq):
+def create_cloud_job(req: CloudJobReq, request: Request):
     node_id = str(req.entrypoint.get("node_id") or "").strip()
     port = str(req.entrypoint.get("port") or "").strip()
     if node_id not in _session.node_meta or not port:
@@ -4051,7 +4252,8 @@ def create_cloud_job(req: CloudJobReq):
                 "validation": validation.to_dict(),
             },
         )
-    return _cloud_call(
+    return _cloud_user_call(
+        request,
         "POST",
         "/v1/jobs",
         {
@@ -4069,38 +4271,44 @@ def create_cloud_job(req: CloudJobReq):
 
 
 @app.get("/cloud/jobs/{job_id}")
-def get_cloud_job(job_id: str):
-    return _cloud_call("GET", f"/v1/jobs/{_cloud_job_id(job_id)}")
+def get_cloud_job(job_id: str, request: Request):
+    return _cloud_user_call(request, "GET", f"/v1/jobs/{_cloud_job_id(job_id)}")
 
 
 @app.delete("/cloud/jobs/{job_id}")
-def cancel_cloud_job(job_id: str):
-    return _cloud_call("DELETE", f"/v1/jobs/{_cloud_job_id(job_id)}")
+def cancel_cloud_job(job_id: str, request: Request):
+    return _cloud_user_call(request, "DELETE", f"/v1/jobs/{_cloud_job_id(job_id)}")
 
 
 @app.get("/cloud/jobs/{job_id}/logs")
 def get_cloud_job_logs(
     job_id: str,
+    request: Request,
     after_seq: int = Query(default=0, ge=0),
     limit: int = Query(default=200, ge=1, le=1000),
 ):
     path = f"/v1/jobs/{_cloud_job_id(job_id)}/logs?after_seq={after_seq}&limit={limit}"
-    return _cloud_call("GET", path)
+    return _cloud_user_call(request, "GET", path)
 
 
 @app.get("/cloud/jobs/{job_id}/artifacts")
-def get_cloud_job_artifacts(job_id: str):
-    return _cloud_call("GET", f"/v1/jobs/{_cloud_job_id(job_id)}/artifacts")
+def get_cloud_job_artifacts(job_id: str, request: Request):
+    return _cloud_user_call(
+        request,
+        "GET",
+        f"/v1/jobs/{_cloud_job_id(job_id)}/artifacts",
+    )
 
 
 @app.get("/cloud/jobs/{job_id}/artifacts/{artifact_id}/download")
-def download_cloud_job_artifact(job_id: str, artifact_id: str):
+def download_cloud_job_artifact(job_id: str, artifact_id: str, request: Request):
     clean_job_id = _cloud_job_id(job_id)
     if not re.fullmatch(r"artifact_[0-9a-f]{28}", artifact_id):
         raise HTTPException(400, "Invalid Blacknode Cloud artifact ID.")
     try:
         chunks, media_type, disposition = cloud_client.download(
             f"/v1/jobs/{clean_job_id}/artifacts/{artifact_id}/download",
+            authorization=_cloud_session(request).token,
         )
     except cloud_client.CloudClientError as exc:
         raise HTTPException(exc.status, str(exc)) from exc

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
-from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
@@ -84,6 +84,7 @@ from local_runtime import (
 from artifact_store import ArtifactStore, ArtifactStoreError
 from project_store import ProjectStore, ProjectStoreError
 from run_store import RunStore
+import cloud_client
 
 
 def package_index_payload(*args, **kwargs):
@@ -350,6 +351,12 @@ class CookTargetReq(BaseModel):
 class CookGraphReq(BaseModel):
     targets: list[CookTargetReq]
     run_mode: str = "once"
+
+class CloudJobReq(BaseModel):
+    entrypoint: dict[str, str]
+    workflow_name: str = "Current Graph"
+    project_ref: str | None = None
+    max_runtime_seconds: int = Field(default=3600, ge=60, le=86_400)
 
 class SetGraphReq(BaseModel):
     nodes: list[dict[str, Any]] = []
@@ -3998,6 +4005,107 @@ def cook_graph_stream(req: CookGraphReq):
         media_type="application/x-ndjson",
         headers=headers,
     )
+
+
+def _cloud_call(method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    try:
+        return cloud_client.json_request(method, path, payload)
+    except cloud_client.CloudClientError as exc:
+        raise HTTPException(exc.status, str(exc)) from exc
+
+
+def _cloud_job_id(value: str) -> str:
+    if not re.fullmatch(r"job_[0-9a-f]{32}", value):
+        raise HTTPException(400, "Invalid Blacknode Cloud job ID.")
+    return value
+
+
+@app.get("/cloud/status")
+def cloud_status():
+    config = cloud_client.configuration()
+    return {
+        "configured": config.configured,
+        "gpu": "NVIDIA L40S",
+        "url": config.base_url if config.configured else "",
+    }
+
+
+@app.post("/cloud/jobs")
+def create_cloud_job(req: CloudJobReq):
+    node_id = str(req.entrypoint.get("node_id") or "").strip()
+    port = str(req.entrypoint.get("port") or "").strip()
+    if node_id not in _session.node_meta or not port:
+        raise HTTPException(400, "Choose a valid workflow output before running on Cloud.")
+    workflow = _workflow_payload(
+        req.workflow_name.strip()[:200] or "Current Graph",
+        entrypoint={"node_id": node_id, "port": port},
+        metadata={"source": "blacknode-editor"},
+    )
+    workflow = _redact_run_snapshot_secrets(workflow)
+    validation = validate_bn_workflow(workflow)
+    if not validation.ok:
+        raise HTTPException(
+            400,
+            {
+                "message": "The workflow is not ready for Cloud execution.",
+                "validation": validation.to_dict(),
+            },
+        )
+    return _cloud_call(
+        "POST",
+        "/v1/jobs",
+        {
+            "contract_version": "blacknode.cloud.jobs/v1",
+            "project_ref": req.project_ref,
+            "workflow": workflow,
+            "compute": {
+                "gpu_class": "l40s",
+                "gpu_count": 1,
+                "max_runtime_seconds": req.max_runtime_seconds,
+            },
+            "runtime": {"release": "gpu-development"},
+        },
+    )
+
+
+@app.get("/cloud/jobs/{job_id}")
+def get_cloud_job(job_id: str):
+    return _cloud_call("GET", f"/v1/jobs/{_cloud_job_id(job_id)}")
+
+
+@app.delete("/cloud/jobs/{job_id}")
+def cancel_cloud_job(job_id: str):
+    return _cloud_call("DELETE", f"/v1/jobs/{_cloud_job_id(job_id)}")
+
+
+@app.get("/cloud/jobs/{job_id}/logs")
+def get_cloud_job_logs(
+    job_id: str,
+    after_seq: int = Query(default=0, ge=0),
+    limit: int = Query(default=200, ge=1, le=1000),
+):
+    path = f"/v1/jobs/{_cloud_job_id(job_id)}/logs?after_seq={after_seq}&limit={limit}"
+    return _cloud_call("GET", path)
+
+
+@app.get("/cloud/jobs/{job_id}/artifacts")
+def get_cloud_job_artifacts(job_id: str):
+    return _cloud_call("GET", f"/v1/jobs/{_cloud_job_id(job_id)}/artifacts")
+
+
+@app.get("/cloud/jobs/{job_id}/artifacts/{artifact_id}/download")
+def download_cloud_job_artifact(job_id: str, artifact_id: str):
+    clean_job_id = _cloud_job_id(job_id)
+    if not re.fullmatch(r"artifact_[0-9a-f]{28}", artifact_id):
+        raise HTTPException(400, "Invalid Blacknode Cloud artifact ID.")
+    try:
+        chunks, media_type, disposition = cloud_client.download(
+            f"/v1/jobs/{clean_job_id}/artifacts/{artifact_id}/download",
+        )
+    except cloud_client.CloudClientError as exc:
+        raise HTTPException(exc.status, str(exc)) from exc
+    headers = {"Content-Disposition": disposition} if disposition else None
+    return StreamingResponse(chunks, media_type=media_type, headers=headers)
 
 
 @app.post("/cook/stop")

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -16,6 +16,7 @@ import OutputNode from './components/OutputNode'
 import ComputeDeviceNode from './components/ComputeDeviceNode'
 import ROS2GraphExplorerNode from './components/ROS2GraphExplorerNode'
 import SimulationViewerPane from './components/SimulationViewerPane'
+import CloudRunPanel from './components/CloudRunPanel'
 import LocalFilePicker from './components/LocalFilePicker'
 import RobotMonitorNode from './components/RobotMonitorNode'
 import RobotServoNode from './components/RobotServoNode'
@@ -29,7 +30,7 @@ import NodeSearch from './components/NodeSearch'
 import { portColor, portVisualColor, portsCompatible } from './portColors'
 import { PYTHON_TOOL_TYPES, resolvePythonToolPreset } from './pythonToolPresets'
 import type { BnNodeDef, ConnectionDraft } from './types'
-import { api, type FrameworkExportTarget, type NewtonWorkspaceStatus, type WorkflowMetadata } from './api'
+import { api, type CloudJob, type FrameworkExportTarget, type NewtonWorkspaceStatus, type WorkflowMetadata } from './api'
 import { inferGraphRunTargets } from './graphRun'
 import { copyTextToClipboard } from './clipboard'
 
@@ -209,6 +210,11 @@ export default function App() {
   const [importingFile, setImportingFile] = useState(false)
   const [runtimeStopPending, setRuntimeStopPending] = useState(false)
   const [activeRunMode, setActiveRunMode] = useState<'once' | 'live' | null>(null)
+  const [executionTarget, setExecutionTarget] = useState<'local' | 'cloud'>('local')
+  const [cloudPanelOpen, setCloudPanelOpen] = useState(false)
+  const [cloudJobPending, setCloudJobPending] = useState(false)
+  const [cloudJob, setCloudJob] = useState<CloudJob | null>(null)
+  const [cloudJobError, setCloudJobError] = useState('')
   const [refreshingCanvas, setRefreshingCanvas] = useState(false)
   const [openingUsd, setOpeningUsd] = useState(false)
   const [usdPickerInitialPath, setUsdPickerInitialPath] = useState<string | null>(null)
@@ -1473,6 +1479,43 @@ export default function App() {
     }
   }, [cookNode, edges, fitCurrentCanvas, nodes, workflowEntrypoint])
 
+  const handleCloudRun = useCallback(async () => {
+    if (cloudJobPending) return
+    const explicit = workflowEntrypoint && nodes.some(node => (
+      node.id === workflowEntrypoint.node_id
+      && (node.data.outputs.includes(workflowEntrypoint.port) || node.data.inputs.includes(workflowEntrypoint.port))
+    ))
+      ? { id: workflowEntrypoint.node_id, port: workflowEntrypoint.port }
+      : null
+    const target = explicit ?? inferGraphRunTargets(nodes, edges)[0]
+    if (!target) {
+      window.dispatchEvent(new CustomEvent('blacknode:notice', {
+        detail: {
+          kind: 'warning',
+          title: 'Run on Cloud',
+          message: 'No runnable workflow output was found. Add an Output node or select an entrypoint.',
+        },
+      }))
+      return
+    }
+    setCloudPanelOpen(true)
+    setCloudJobPending(true)
+    setCloudJob(null)
+    setCloudJobError('')
+    try {
+      const created = await api.createCloudJob(
+        { node_id: target.id, port: target.port },
+        activeTab?.name || 'Current Graph',
+        activeProject?.id ?? activeTab?.slug ?? null,
+      )
+      setCloudJob(created)
+    } catch (cause) {
+      setCloudJobError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setCloudJobPending(false)
+    }
+  }, [activeProject?.id, activeTab?.name, activeTab?.slug, cloudJobPending, edges, nodes, workflowEntrypoint])
+
   const handleResetRun = useCallback(() => {
     stopCook()
     setActiveRunMode(null)
@@ -1749,19 +1792,39 @@ export default function App() {
 
             <div className="bn-topbar-group bn-topbar-run-group" aria-label="Run controls">
               <span className="bn-topbar-group-label">Run</span>
+              <select
+                className="bn-top-select"
+                value={executionTarget}
+                disabled={onceRunActive || liveRunActive || cloudJobPending}
+                onChange={event => setExecutionTarget(event.target.value === 'cloud' ? 'cloud' : 'local')}
+                title="Choose where this graph executes"
+              >
+                <option value="local">Local</option>
+                <option value="cloud">Blacknode Cloud · L40S</option>
+              </select>
               <button
                 className="bn-top-button bn-top-run-button"
-                onClick={() => (onceRunActive ? stopCook() : void handleRunGraph('once'))}
+                onClick={() => {
+                  if (executionTarget === 'cloud') void handleCloudRun()
+                  else if (onceRunActive) stopCook()
+                  else void handleRunGraph('once')
+                }}
                 disabled={!serverOk || liveRunActive || (!onceRunActive && nodes.length === 0)}
-                title={onceRunActive ? 'Stop the current one-time evaluation' : 'Evaluate the graph once. Live-capable nodes return one snapshot and do not keep streaming.'}
+                title={executionTarget === 'cloud'
+                  ? 'Submit this graph to Blacknode Cloud on one NVIDIA L40S.'
+                  : onceRunActive
+                    ? 'Stop the current one-time evaluation'
+                    : 'Evaluate the graph once. Live-capable nodes return one snapshot and do not keep streaming.'}
               >
-                {onceRunActive ? '■ Stop once' : '▶ Run once'}
+                {executionTarget === 'cloud'
+                  ? cloudJobPending ? 'Submitting…' : '☁ Run on Cloud'
+                  : onceRunActive ? '■ Stop once' : '▶ Run once'}
               </button>
 
               <button
                 className={`bn-top-button bn-top-run-button bn-top-live-button${liveRunActive ? ' is-stop-live' : ' is-start-live'}`}
                 onClick={() => (liveRunActive ? void handleStopRuntime() : void handleRunGraph('live'))}
-                disabled={!serverOk || runtimeStopPending || onceRunActive || (!liveRunActive && nodes.length === 0)}
+                disabled={executionTarget === 'cloud' || !serverOk || runtimeStopPending || onceRunActive || (!liveRunActive && nodes.length === 0)}
                 title={liveRunActive
                   ? 'Stop the live graph and its managed runtime services.'
                   : liveCapableCount > 0
@@ -2478,6 +2541,14 @@ export default function App() {
           hidden={cookStatusHidden}
           raised={Boolean(notice)}
           onDismiss={dismissCookStatus}
+        />
+
+        <CloudRunPanel
+          open={cloudPanelOpen}
+          pending={cloudJobPending}
+          initialJob={cloudJob}
+          error={cloudJobError}
+          onClose={() => setCloudPanelOpen(false)}
         />
 
         {notice && (

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -17,6 +17,7 @@ import ComputeDeviceNode from './components/ComputeDeviceNode'
 import ROS2GraphExplorerNode from './components/ROS2GraphExplorerNode'
 import SimulationViewerPane from './components/SimulationViewerPane'
 import CloudRunPanel from './components/CloudRunPanel'
+import EmailVerificationPage from './components/EmailVerificationPage'
 import LocalFilePicker from './components/LocalFilePicker'
 import RobotMonitorNode from './components/RobotMonitorNode'
 import RobotServoNode from './components/RobotServoNode'
@@ -171,6 +172,13 @@ function nodeIdAtScreenPoint(point: { x: number; y: number }): string | null {
 }
 
 export default function App() {
+  if (window.location.pathname.replace(/\/+$/, '') === '/verify-email') {
+    return <EmailVerificationPage />
+  }
+  return <WorkspaceApp />
+}
+
+function WorkspaceApp() {
   const {
     nodes, edges, nodeTypes, nodeDefs, selectedId, serverOk, serverError, cookLog, cookActive, cookStatusHidden,
     tabs, activeTabId, activeProject, workflowEntrypoint,
@@ -216,6 +224,7 @@ export default function App() {
   const [cloudJob, setCloudJob] = useState<CloudJob | null>(null)
   const [cloudJobError, setCloudJobError] = useState('')
   const [cloudAccountStatus, setCloudAccountStatus] = useState<CloudStatus | null>(null)
+  const [cloudPanelView, setCloudPanelView] = useState<'account' | 'job'>('account')
   const [refreshingCanvas, setRefreshingCanvas] = useState(false)
   const [openingUsd, setOpeningUsd] = useState(false)
   const [usdPickerInitialPath, setUsdPickerInitialPath] = useState<string | null>(null)
@@ -428,6 +437,24 @@ export default function App() {
     setHdriPickerInitialPath(null)
     if (selected) void controlNewtonWorkspace('set_environment', { hdri: 'custom', hdri_path: selected })
   }, [controlNewtonWorkspace])
+
+  useEffect(() => {
+    if (!serverOk) {
+      setCloudAccountStatus(null)
+      return
+    }
+    let cancelled = false
+    void api.cloudStatus()
+      .then(status => {
+        if (!cancelled) setCloudAccountStatus(status)
+      })
+      .catch(() => {
+        if (!cancelled) setCloudAccountStatus(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [serverOk])
 
   useEffect(() => {
     if (!nodeTypes.includes('NewtonSimulation')) {
@@ -1499,9 +1526,9 @@ export default function App() {
       }))
       return
     }
+    setCloudPanelView('account')
     setCloudPanelOpen(true)
     setCloudJobPending(true)
-    setCloudJob(null)
     setCloudJobError('')
     try {
       const accountStatus = await api.cloudStatus()
@@ -1511,12 +1538,14 @@ export default function App() {
         return
       }
       if (!accountStatus.authenticated) return
+      setCloudJob(null)
       const created = await api.createCloudJob(
         { node_id: target.id, port: target.port },
         activeTab?.name || 'Current Graph',
         activeProject?.id ?? activeTab?.slug ?? null,
       )
       setCloudJob(created)
+      setCloudPanelView('job')
       void api.cloudStatus().then(setCloudAccountStatus).catch(() => undefined)
     } catch (cause) {
       setCloudJobError(cause instanceof Error ? cause.message : String(cause))
@@ -1524,6 +1553,21 @@ export default function App() {
       setCloudJobPending(false)
     }
   }, [activeProject?.id, activeTab?.name, activeTab?.slug, cloudJobPending, edges, nodes, workflowEntrypoint])
+
+  const handleCloudAccountOpen = useCallback(async () => {
+    if (cloudJobPending || !serverOk) return
+    setCloudPanelView('account')
+    setCloudPanelOpen(true)
+    setCloudJobError('')
+    setCloudJobPending(true)
+    try {
+      setCloudAccountStatus(await api.cloudStatus())
+    } catch (cause) {
+      setCloudJobError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setCloudJobPending(false)
+    }
+  }, [cloudJobPending, serverOk])
 
   const handleResetRun = useCallback(() => {
     stopCook()
@@ -2083,6 +2127,36 @@ export default function App() {
             </span>
           </span>
           </div>
+
+          <button
+            type="button"
+            className={`bn-cloud-account-trigger${cloudAccountStatus?.authenticated ? ' is-authenticated' : ''}`}
+            onClick={() => void handleCloudAccountOpen()}
+            disabled={!serverOk || cloudJobPending}
+            aria-haspopup="dialog"
+            aria-expanded={cloudPanelOpen && cloudPanelView === 'account'}
+            title={cloudAccountStatus?.authenticated
+              ? `Open Blacknode Cloud account for ${cloudAccountStatus.account?.email ?? 'signed-in user'}`
+              : serverOk ? 'Sign in to Blacknode Cloud' : 'Backend connection required'}
+          >
+            <span className="bn-cloud-account-avatar" aria-hidden="true">
+              {cloudAccountStatus?.authenticated
+                ? String(cloudAccountStatus.account?.display_name || cloudAccountStatus.account?.email || '?').trim().charAt(0).toUpperCase()
+                : '☁'}
+            </span>
+            <span className="bn-cloud-account-trigger-copy">
+              <strong>
+                {cloudAccountStatus?.authenticated && cloudAccountStatus.credits
+                  ? `${cloudAccountStatus.credits.available.toLocaleString()} GPU-s`
+                  : cloudAccountStatus?.configured === false ? 'Cloud unavailable' : 'Sign in'}
+              </strong>
+              <small>
+                {cloudAccountStatus?.authenticated
+                  ? cloudAccountStatus.account?.display_name || cloudAccountStatus.account?.email
+                  : 'Blacknode Cloud'}
+              </small>
+            </span>
+          </button>
         </div>
 
         {/* ── workflow tab bar ── */}
@@ -2559,6 +2633,7 @@ export default function App() {
 
         <CloudRunPanel
           open={cloudPanelOpen}
+          view={cloudPanelView}
           pending={cloudJobPending}
           initialJob={cloudJob}
           error={cloudJobError}

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -30,7 +30,7 @@ import NodeSearch from './components/NodeSearch'
 import { portColor, portVisualColor, portsCompatible } from './portColors'
 import { PYTHON_TOOL_TYPES, resolvePythonToolPreset } from './pythonToolPresets'
 import type { BnNodeDef, ConnectionDraft } from './types'
-import { api, type CloudJob, type FrameworkExportTarget, type NewtonWorkspaceStatus, type WorkflowMetadata } from './api'
+import { api, type CloudJob, type CloudStatus, type FrameworkExportTarget, type NewtonWorkspaceStatus, type WorkflowMetadata } from './api'
 import { inferGraphRunTargets } from './graphRun'
 import { copyTextToClipboard } from './clipboard'
 
@@ -215,6 +215,7 @@ export default function App() {
   const [cloudJobPending, setCloudJobPending] = useState(false)
   const [cloudJob, setCloudJob] = useState<CloudJob | null>(null)
   const [cloudJobError, setCloudJobError] = useState('')
+  const [cloudAccountStatus, setCloudAccountStatus] = useState<CloudStatus | null>(null)
   const [refreshingCanvas, setRefreshingCanvas] = useState(false)
   const [openingUsd, setOpeningUsd] = useState(false)
   const [usdPickerInitialPath, setUsdPickerInitialPath] = useState<string | null>(null)
@@ -1503,12 +1504,20 @@ export default function App() {
     setCloudJob(null)
     setCloudJobError('')
     try {
+      const accountStatus = await api.cloudStatus()
+      setCloudAccountStatus(accountStatus)
+      if (!accountStatus.configured) {
+        setCloudJobError('Configure the Blacknode Cloud URL on the editor server.')
+        return
+      }
+      if (!accountStatus.authenticated) return
       const created = await api.createCloudJob(
         { node_id: target.id, port: target.port },
         activeTab?.name || 'Current Graph',
         activeProject?.id ?? activeTab?.slug ?? null,
       )
       setCloudJob(created)
+      void api.cloudStatus().then(setCloudAccountStatus).catch(() => undefined)
     } catch (cause) {
       setCloudJobError(cause instanceof Error ? cause.message : String(cause))
     } finally {
@@ -1802,6 +1811,11 @@ export default function App() {
                 <option value="local">Local</option>
                 <option value="cloud">Blacknode Cloud · L40S</option>
               </select>
+              {executionTarget === 'cloud' && cloudAccountStatus?.credits && (
+                <span className="bn-cloud-credit-badge" title="Available Blacknode Cloud GPU-second credits">
+                  {cloudAccountStatus.credits.available.toLocaleString()} credits
+                </span>
+              )}
               <button
                 className="bn-top-button bn-top-run-button"
                 onClick={() => {
@@ -2548,6 +2562,9 @@ export default function App() {
           pending={cloudJobPending}
           initialJob={cloudJob}
           error={cloudJobError}
+          accountStatus={cloudAccountStatus}
+          onAccountStatus={setCloudAccountStatus}
+          onRun={() => void handleCloudRun()}
           onClose={() => setCloudPanelOpen(false)}
         />
 

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1040,6 +1040,37 @@ export interface CloudStatus {
   configured: boolean
   gpu: string
   url: string
+  authenticated: boolean
+  account: CloudAccount | null
+  credits: CloudCredits | null
+}
+
+export interface CloudAccount {
+  id: string
+  organization_id: string
+  email: string
+  display_name: string
+  created_at: string
+}
+
+export interface CloudCredits {
+  unit: 'gpu-second'
+  balance: number
+  reserved: number
+  available: number
+}
+
+export interface CloudCreditEntry {
+  id: string
+  delta_seconds: number
+  reason: string
+  reference_id: string
+  created_at: string
+}
+
+export interface CloudCreditHistory {
+  unit: 'gpu-second'
+  entries: CloudCreditEntry[]
 }
 
 export interface CloudJob {
@@ -1672,6 +1703,18 @@ export const api = {
   deletePackage: (name: string)              => req<{ ok: boolean }>('DELETE', `/packages/${encodeURIComponent(name)}`),
   getGraph:  ()                              => req<GraphSnapshot>('GET', '/graph'),
   cloudStatus: ()                            => req<CloudStatus>('GET', '/cloud/status'),
+  registerCloudAccount: (email: string, password: string, displayName: string) =>
+    req<CloudStatus>('POST', '/cloud/auth/register', {
+      email,
+      password,
+      display_name: displayName,
+    }),
+  loginCloudAccount: (email: string, password: string) =>
+    req<CloudStatus>('POST', '/cloud/auth/login', { email, password }),
+  logoutCloudAccount: () =>
+    req<{ ok: boolean; revoked: boolean }>('POST', '/cloud/auth/logout'),
+  getCloudCreditHistory: () =>
+    req<CloudCreditHistory>('GET', '/cloud/credits/history'),
   createCloudJob: (
     entrypoint: { node_id: string; port: string },
     workflowName: string,

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1051,6 +1051,7 @@ export interface CloudAccount {
   email: string
   display_name: string
   created_at: string
+  email_verified_at?: string | null
 }
 
 export interface CloudCredits {
@@ -1711,6 +1712,8 @@ export const api = {
     }),
   loginCloudAccount: (email: string, password: string) =>
     req<CloudStatus>('POST', '/cloud/auth/login', { email, password }),
+  verifyCloudEmail: (token: string) =>
+    req<{ verified: boolean; account: CloudAccount }>('POST', '/cloud/auth/verify-email', { token }),
   logoutCloudAccount: () =>
     req<{ ok: boolean; revoked: boolean }>('POST', '/cloud/auth/logout'),
   getCloudCreditHistory: () =>

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1026,6 +1026,58 @@ export interface WorkflowSnapshot {
   edges?: Array<Record<string, unknown>>
 }
 
+export type CloudJobStatus =
+  | 'QUEUED'
+  | 'PROVISIONING'
+  | 'STARTING'
+  | 'RUNNING'
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'CANCELED'
+  | 'TIMED_OUT'
+
+export interface CloudStatus {
+  configured: boolean
+  gpu: string
+  url: string
+}
+
+export interface CloudJob {
+  id: string
+  project_ref: string | null
+  workflow_name: string
+  status: CloudJobStatus
+  cleanup_status: string
+  progress: number
+  compute: { gpu_class: 'l40s'; gpu_count: 1; max_runtime_seconds: number }
+  runtime: { release: string }
+  error_code: string | null
+  error_message: string | null
+  result: unknown
+  created_at: string
+  updated_at: string
+  started_at: string | null
+  finished_at: string | null
+}
+
+export interface CloudJobEvent {
+  seq: number
+  type: 'state' | 'log' | 'progress' | 'metric' | 'artifact'
+  created_at: string
+  payload: Record<string, unknown>
+}
+
+export interface CloudArtifact {
+  id: string
+  name: string
+  kind: string
+  size_bytes: number
+  sha256: string
+  media_type: string
+  locator: string
+  created_at: string
+}
+
 export interface RunRecord extends RunSummary {
   events: Array<Record<string, unknown> & { type: string; ts?: string | number }>
   workflow?: WorkflowSnapshot
@@ -1619,6 +1671,32 @@ export const api = {
     }>('GET', `/packages/${encodeURIComponent(name)}/components/${encodeURIComponent(component)}/dependencies`),
   deletePackage: (name: string)              => req<{ ok: boolean }>('DELETE', `/packages/${encodeURIComponent(name)}`),
   getGraph:  ()                              => req<GraphSnapshot>('GET', '/graph'),
+  cloudStatus: ()                            => req<CloudStatus>('GET', '/cloud/status'),
+  createCloudJob: (
+    entrypoint: { node_id: string; port: string },
+    workflowName: string,
+    projectRef?: string | null,
+  ) => req<CloudJob>('POST', '/cloud/jobs', {
+    entrypoint,
+    workflow_name: workflowName,
+    project_ref: projectRef ?? null,
+  }),
+  getCloudJob: (jobId: string) =>
+    req<CloudJob>('GET', `/cloud/jobs/${encodeURIComponent(jobId)}`),
+  cancelCloudJob: (jobId: string) =>
+    req<CloudJob>('DELETE', `/cloud/jobs/${encodeURIComponent(jobId)}`),
+  getCloudJobLogs: (jobId: string, afterSeq = 0) =>
+    req<{ job_id: string; events: CloudJobEvent[]; next_seq: number }>(
+      'GET',
+      `/cloud/jobs/${encodeURIComponent(jobId)}/logs?after_seq=${afterSeq}`,
+    ),
+  getCloudJobArtifacts: (jobId: string) =>
+    req<{ job_id: string; artifacts: CloudArtifact[] }>(
+      'GET',
+      `/cloud/jobs/${encodeURIComponent(jobId)}/artifacts`,
+    ),
+  cloudArtifactDownloadUrl: (jobId: string, artifactId: string) =>
+    `${BASE}/cloud/jobs/${encodeURIComponent(jobId)}/artifacts/${encodeURIComponent(artifactId)}/download`,
   setGraph:  (
     nodes: any[],
     edges: any[],

--- a/editor/src/components/CloudRunPanel.tsx
+++ b/editor/src/components/CloudRunPanel.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  api,
+  type CloudArtifact,
+  type CloudJob,
+  type CloudJobEvent,
+} from '../api'
+
+const TERMINAL = new Set(['COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'])
+
+interface Props {
+  open: boolean
+  pending: boolean
+  initialJob: CloudJob | null
+  error: string
+  onClose: () => void
+}
+
+function elapsed(job: CloudJob): string {
+  const start = job.started_at || job.created_at
+  const end = job.finished_at || new Date().toISOString()
+  const seconds = Math.max(0, Math.floor((Date.parse(end) - Date.parse(start)) / 1000))
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const rest = seconds % 60
+  return [hours, minutes, rest].map(value => String(value).padStart(2, '0')).join(':')
+}
+
+function bytes(value: number): string {
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KiB`
+  if (value < 1024 * 1024 * 1024) return `${(value / 1024 / 1024).toFixed(1)} MiB`
+  return `${(value / 1024 / 1024 / 1024).toFixed(2)} GiB`
+}
+
+export default function CloudRunPanel({ open, pending, initialJob, error, onClose }: Props) {
+  const [job, setJob] = useState<CloudJob | null>(initialJob)
+  const [events, setEvents] = useState<CloudJobEvent[]>([])
+  const [artifacts, setArtifacts] = useState<CloudArtifact[]>([])
+  const [pollError, setPollError] = useState('')
+  const nextSeq = useRef(0)
+
+  useEffect(() => {
+    setJob(initialJob)
+    setEvents([])
+    setArtifacts([])
+    setPollError('')
+    nextSeq.current = 0
+  }, [initialJob?.id])
+
+  useEffect(() => {
+    if (!open || !initialJob) return undefined
+    let stopped = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const poll = async () => {
+      try {
+        const [nextJob, logPage, artifactPage] = await Promise.all([
+          api.getCloudJob(initialJob.id),
+          api.getCloudJobLogs(initialJob.id, nextSeq.current),
+          api.getCloudJobArtifacts(initialJob.id),
+        ])
+        if (stopped) return
+        setJob(nextJob)
+        if (logPage.events.length) {
+          setEvents(current => [...current, ...logPage.events].slice(-1000))
+          nextSeq.current = logPage.next_seq
+        }
+        setArtifacts(artifactPage.artifacts)
+        setPollError('')
+        if (!TERMINAL.has(nextJob.status)) timer = setTimeout(poll, 1000)
+      } catch (cause) {
+        if (stopped) return
+        setPollError(cause instanceof Error ? cause.message : String(cause))
+        timer = setTimeout(poll, 2000)
+      }
+    }
+
+    void poll()
+    return () => {
+      stopped = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [initialJob, open])
+
+  const metrics = useMemo(() => events
+    .filter(event => event.type === 'metric')
+    .map(event => ({
+      name: String(event.payload.name ?? 'metric'),
+      value: Number(event.payload.value ?? 0),
+      step: Number(event.payload.step ?? 0),
+    }))
+    .filter(metric => Number.isFinite(metric.value)), [events])
+  const reward = metrics.filter(metric => metric.name.toLowerCase().includes('reward')).slice(-60)
+  const rewardPoints = useMemo(() => {
+    if (reward.length < 2) return ''
+    const values = reward.map(item => item.value)
+    const low = Math.min(...values)
+    const high = Math.max(...values)
+    const span = Math.max(0.0001, high - low)
+    return values.map((value, index) => {
+      const x = (index / (values.length - 1)) * 300
+      const y = 76 - ((value - low) / span) * 68
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    }).join(' ')
+  }, [reward])
+  const logs = events.filter(event => event.type === 'log').slice(-300)
+
+  if (!open) return null
+  return (
+    <div className="bn-cloud-run-backdrop" role="presentation">
+      <section className="bn-cloud-run-panel" role="dialog" aria-modal="true" aria-label="Blacknode Cloud job">
+        <header>
+          <div>
+            <span>BLACKNODE CLOUD</span>
+            <strong>{job ? job.workflow_name : 'Submitting workflow'}</strong>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close Cloud job">×</button>
+        </header>
+
+        {(pending || (!job && !error)) && <div className="bn-cloud-run-message">Creating NVIDIA L40S job…</div>}
+        {(error || pollError) && <div className="bn-cloud-run-error">{error || pollError}</div>}
+
+        {job && (
+          <>
+            <div className="bn-cloud-run-facts">
+              <div><span>Job</span><strong>{job.id}</strong></div>
+              <div><span>GPU</span><strong>NVIDIA L40S</strong></div>
+              <div><span>Status</span><strong className={`is-${job.status.toLowerCase()}`}>● {job.status}</strong></div>
+              <div><span>Runtime</span><strong>{elapsed(job)}</strong></div>
+            </div>
+            <div className="bn-cloud-progress" aria-label={`${job.progress}% complete`}>
+              <i style={{ width: `${job.progress}%` }} />
+            </div>
+            <div className="bn-cloud-progress-label"><span>Progress</span><strong>{job.progress}%</strong></div>
+
+            {rewardPoints && (
+              <div className="bn-cloud-metric-chart">
+                <header><span>Reward</span><strong>{reward[reward.length - 1]?.value.toFixed(3)}</strong></header>
+                <svg viewBox="0 0 300 84" preserveAspectRatio="none" aria-label="Reward metric">
+                  <polyline points={rewardPoints} fill="none" stroke="currentColor" strokeWidth="2" />
+                </svg>
+              </div>
+            )}
+
+            <div className="bn-cloud-run-section">
+              <header><strong>Logs</strong><span>{logs.length} events</span></header>
+              <pre>{logs.length
+                ? logs.map(event => `[${String(event.payload.stream ?? 'stdout')}] ${String(event.payload.text ?? '')}`).join('\n')
+                : 'Waiting for executor output…'}</pre>
+            </div>
+
+            <div className="bn-cloud-run-section">
+              <header><strong>Artifacts</strong><span>{artifacts.length}</span></header>
+              <div className="bn-cloud-artifact-list">
+                {artifacts.map(artifact => (
+                  <a
+                    key={artifact.id}
+                    href={api.cloudArtifactDownloadUrl(job.id, artifact.id)}
+                    download={artifact.name}
+                  >
+                    <span>{artifact.name}</span><small>{bytes(artifact.size_bytes)} · download</small>
+                  </a>
+                ))}
+                {artifacts.length === 0 && <p>Artifacts appear here as the job completes.</p>}
+              </div>
+            </div>
+
+            {job.result !== null && job.result !== undefined && (
+              <div className="bn-cloud-run-section">
+                <header><strong>Result</strong></header>
+                <pre>{JSON.stringify(job.result, null, 2)}</pre>
+              </div>
+            )}
+            {job.error_message && <div className="bn-cloud-run-error">{job.error_message}</div>}
+            {!TERMINAL.has(job.status) && (
+              <footer>
+                <button type="button" onClick={() => void api.cancelCloudJob(job.id).then(setJob)}>
+                  Cancel job
+                </button>
+              </footer>
+            )}
+          </>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/editor/src/components/CloudRunPanel.tsx
+++ b/editor/src/components/CloudRunPanel.tsx
@@ -13,6 +13,7 @@ const TERMINAL = new Set(['COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'])
 
 interface Props {
   open: boolean
+  view: 'account' | 'job'
   pending: boolean
   initialJob: CloudJob | null
   error: string
@@ -47,6 +48,7 @@ function creditReason(entry: CloudCreditEntry): string {
 
 export default function CloudRunPanel({
   open,
+  view,
   pending,
   initialJob,
   error,
@@ -100,7 +102,7 @@ export default function CloudRunPanel({
   }, [job?.status, refreshAccount])
 
   useEffect(() => {
-    if (!open || !initialJob) return undefined
+    if (!open || view !== 'job' || !initialJob) return undefined
     let stopped = false
     let timer: ReturnType<typeof setTimeout> | null = null
 
@@ -132,7 +134,7 @@ export default function CloudRunPanel({
       stopped = true
       if (timer) clearTimeout(timer)
     }
-  }, [initialJob, open])
+  }, [initialJob, open, view])
 
   const metrics = useMemo(() => events
     .filter(event => event.type === 'metric')
@@ -198,6 +200,7 @@ export default function CloudRunPanel({
   const credits = accountStatus?.credits
   const account = accountStatus?.account
   const activeJob = job && !TERMINAL.has(job.status)
+  const visibleJob = view === 'job' ? job : null
 
   return (
     <div className="bn-cloud-run-backdrop" role="presentation">
@@ -205,15 +208,18 @@ export default function CloudRunPanel({
         <header>
           <div>
             <span>BLACKNODE CLOUD</span>
-            <strong>{job ? job.workflow_name : account?.display_name || 'Cloud account'}</strong>
+            <strong>{visibleJob ? visibleJob.workflow_name : account?.display_name || 'Cloud account'}</strong>
           </div>
           <button type="button" onClick={onClose} aria-label="Close Blacknode Cloud">×</button>
         </header>
 
         {(pending || (!accountStatus && !error)) && <div className="bn-cloud-run-message">Connecting to Blacknode Cloud…</div>}
         {(error || pollError || authError) && <div className="bn-cloud-run-error">{error || pollError || authError}</div>}
+        {!pending && accountStatus && !accountStatus.configured && !error && (
+          <div className="bn-cloud-run-error">Blacknode Cloud is not configured on this editor server.</div>
+        )}
 
-        {!pending && accountStatus?.configured && !accountStatus.authenticated && !job && (
+        {!pending && accountStatus?.configured && !accountStatus.authenticated && !visibleJob && (
           <div className="bn-cloud-auth">
             <div className="bn-cloud-auth-tabs">
               <button type="button" className={authMode === 'login' ? 'is-active' : ''} onClick={() => setAuthMode('login')}>
@@ -255,15 +261,24 @@ export default function CloudRunPanel({
                 {authPending ? 'Connecting…' : authMode === 'register' ? 'Create account' : 'Log in'}
               </button>
             </form>
-            <p>Your Cloud session stays on this editor server and is not placed in browser storage or workflow payloads.</p>
+            <p>
+              Your Cloud session stays on this editor server and is not placed in browser storage or workflow payloads.
+              {authMode === 'register' && ' An unverified account can sign up again with the same password to receive a fresh verification email.'}
+            </p>
           </div>
         )}
 
-        {!job && accountStatus?.authenticated && account && credits && (
+        {!visibleJob && accountStatus?.authenticated && account && credits && (
           <>
             <div className="bn-cloud-account">
               <header>
-                <div><strong>{account.display_name}</strong><span>{account.email}</span></div>
+                <div>
+                  <strong>{account.display_name}</strong>
+                  <span>{account.email}</span>
+                  <small className={account.email_verified_at ? 'is-verified' : 'is-unverified'}>
+                    {account.email_verified_at ? 'Email verified' : 'Email verification pending'}
+                  </small>
+                </div>
                 <button type="button" onClick={() => void logout()} disabled={authPending}>Log out</button>
               </header>
               <div className="bn-cloud-credit-grid">
@@ -294,25 +309,25 @@ export default function CloudRunPanel({
           </>
         )}
 
-        {job && credits && (
+        {visibleJob && credits && (
           <div className="bn-cloud-job-credits">
             <span>{credits.available.toLocaleString()} available</span>
             <span>{credits.reserved.toLocaleString()} reserved</span>
           </div>
         )}
 
-        {job && (
+        {visibleJob && (
           <>
             <div className="bn-cloud-run-facts">
-              <div><span>Job</span><strong>{job.id}</strong></div>
+              <div><span>Job</span><strong>{visibleJob.id}</strong></div>
               <div><span>GPU</span><strong>NVIDIA L40S</strong></div>
-              <div><span>Status</span><strong className={`is-${job.status.toLowerCase()}`}>● {job.status}</strong></div>
-              <div><span>Runtime</span><strong>{elapsed(job)}</strong></div>
+              <div><span>Status</span><strong className={`is-${visibleJob.status.toLowerCase()}`}>● {visibleJob.status}</strong></div>
+              <div><span>Runtime</span><strong>{elapsed(visibleJob)}</strong></div>
             </div>
-            <div className="bn-cloud-progress" aria-label={`${job.progress}% complete`}>
-              <i style={{ width: `${job.progress}%` }} />
+            <div className="bn-cloud-progress" aria-label={`${visibleJob.progress}% complete`}>
+              <i style={{ width: `${visibleJob.progress}%` }} />
             </div>
-            <div className="bn-cloud-progress-label"><span>Progress</span><strong>{job.progress}%</strong></div>
+            <div className="bn-cloud-progress-label"><span>Progress</span><strong>{visibleJob.progress}%</strong></div>
 
             {rewardPoints && (
               <div className="bn-cloud-metric-chart">
@@ -334,7 +349,7 @@ export default function CloudRunPanel({
               <header><strong>Artifacts</strong><span>{artifacts.length}</span></header>
               <div className="bn-cloud-artifact-list">
                 {artifacts.map(artifact => (
-                  <a key={artifact.id} href={api.cloudArtifactDownloadUrl(job.id, artifact.id)} download={artifact.name}>
+                  <a key={artifact.id} href={api.cloudArtifactDownloadUrl(visibleJob.id, artifact.id)} download={artifact.name}>
                     <span>{artifact.name}</span><small>{bytes(artifact.size_bytes)} · download</small>
                   </a>
                 ))}
@@ -342,16 +357,16 @@ export default function CloudRunPanel({
               </div>
             </div>
 
-            {job.result !== null && job.result !== undefined && (
+            {visibleJob.result !== null && visibleJob.result !== undefined && (
               <div className="bn-cloud-run-section">
                 <header><strong>Result</strong></header>
-                <pre>{JSON.stringify(job.result, null, 2)}</pre>
+                <pre>{JSON.stringify(visibleJob.result, null, 2)}</pre>
               </div>
             )}
-            {job.error_message && <div className="bn-cloud-run-error">{job.error_message}</div>}
+            {visibleJob.error_message && <div className="bn-cloud-run-error">{visibleJob.error_message}</div>}
             {activeJob && (
               <footer>
-                <button type="button" onClick={() => void api.cancelCloudJob(job.id).then(setJob)}>
+                <button type="button" onClick={() => void api.cancelCloudJob(visibleJob.id).then(setJob)}>
                   Cancel job
                 </button>
               </footer>

--- a/editor/src/components/CloudRunPanel.tsx
+++ b/editor/src/components/CloudRunPanel.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   api,
   type CloudArtifact,
+  type CloudCreditEntry,
   type CloudJob,
   type CloudJobEvent,
+  type CloudStatus,
 } from '../api'
 
 const TERMINAL = new Set(['COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'])
@@ -14,6 +16,9 @@ interface Props {
   pending: boolean
   initialJob: CloudJob | null
   error: string
+  accountStatus: CloudStatus | null
+  onAccountStatus: (status: CloudStatus) => void
+  onRun: () => void
   onClose: () => void
 }
 
@@ -34,12 +39,46 @@ function bytes(value: number): string {
   return `${(value / 1024 / 1024 / 1024).toFixed(2)} GiB`
 }
 
-export default function CloudRunPanel({ open, pending, initialJob, error, onClose }: Props) {
+function creditReason(entry: CloudCreditEntry): string {
+  if (entry.reason === 'signup-credit') return 'Signup credits'
+  if (entry.reason === 'gpu-job') return 'NVIDIA GPU job'
+  return entry.reason.split('-').join(' ')
+}
+
+export default function CloudRunPanel({
+  open,
+  pending,
+  initialJob,
+  error,
+  accountStatus,
+  onAccountStatus,
+  onRun,
+  onClose,
+}: Props) {
   const [job, setJob] = useState<CloudJob | null>(initialJob)
   const [events, setEvents] = useState<CloudJobEvent[]>([])
   const [artifacts, setArtifacts] = useState<CloudArtifact[]>([])
+  const [history, setHistory] = useState<CloudCreditEntry[]>([])
   const [pollError, setPollError] = useState('')
+  const [authMode, setAuthMode] = useState<'login' | 'register'>('login')
+  const [email, setEmail] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [authPending, setAuthPending] = useState(false)
+  const [authError, setAuthError] = useState('')
   const nextSeq = useRef(0)
+
+  const refreshAccount = useCallback(async () => {
+    const nextStatus = await api.cloudStatus()
+    onAccountStatus(nextStatus)
+    if (nextStatus.authenticated) {
+      const page = await api.getCloudCreditHistory()
+      setHistory(page.entries)
+    } else {
+      setHistory([])
+    }
+  }, [onAccountStatus])
 
   useEffect(() => {
     setJob(initialJob)
@@ -48,6 +87,17 @@ export default function CloudRunPanel({ open, pending, initialJob, error, onClos
     setPollError('')
     nextSeq.current = 0
   }, [initialJob?.id])
+
+  useEffect(() => {
+    if (!open || !accountStatus?.authenticated) return
+    void api.getCloudCreditHistory()
+      .then(page => setHistory(page.entries))
+      .catch(cause => setAuthError(cause instanceof Error ? cause.message : String(cause)))
+  }, [accountStatus?.authenticated, accountStatus?.account?.id, open])
+
+  useEffect(() => {
+    if (job && TERMINAL.has(job.status)) void refreshAccount()
+  }, [job?.status, refreshAccount])
 
   useEffect(() => {
     if (!open || !initialJob) return undefined
@@ -107,20 +157,149 @@ export default function CloudRunPanel({ open, pending, initialJob, error, onClos
   }, [reward])
   const logs = events.filter(event => event.type === 'log').slice(-300)
 
+  const submitAuth = async (event: FormEvent) => {
+    event.preventDefault()
+    if (authMode === 'register' && password !== confirmPassword) {
+      setAuthError('Passwords do not match.')
+      return
+    }
+    setAuthPending(true)
+    setAuthError('')
+    try {
+      const nextStatus = authMode === 'register'
+        ? await api.registerCloudAccount(email, password, displayName)
+        : await api.loginCloudAccount(email, password)
+      onAccountStatus(nextStatus)
+      setPassword('')
+      setConfirmPassword('')
+      const page = await api.getCloudCreditHistory()
+      setHistory(page.entries)
+    } catch (cause) {
+      setAuthError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setAuthPending(false)
+    }
+  }
+
+  const logout = async () => {
+    setAuthPending(true)
+    setAuthError('')
+    try {
+      await api.logoutCloudAccount()
+      await refreshAccount()
+    } catch (cause) {
+      setAuthError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setAuthPending(false)
+    }
+  }
+
   if (!open) return null
+  const credits = accountStatus?.credits
+  const account = accountStatus?.account
+  const activeJob = job && !TERMINAL.has(job.status)
+
   return (
     <div className="bn-cloud-run-backdrop" role="presentation">
-      <section className="bn-cloud-run-panel" role="dialog" aria-modal="true" aria-label="Blacknode Cloud job">
+      <section className="bn-cloud-run-panel" role="dialog" aria-modal="true" aria-label="Blacknode Cloud">
         <header>
           <div>
             <span>BLACKNODE CLOUD</span>
-            <strong>{job ? job.workflow_name : 'Submitting workflow'}</strong>
+            <strong>{job ? job.workflow_name : account?.display_name || 'Cloud account'}</strong>
           </div>
-          <button type="button" onClick={onClose} aria-label="Close Cloud job">×</button>
+          <button type="button" onClick={onClose} aria-label="Close Blacknode Cloud">×</button>
         </header>
 
-        {(pending || (!job && !error)) && <div className="bn-cloud-run-message">Creating NVIDIA L40S job…</div>}
-        {(error || pollError) && <div className="bn-cloud-run-error">{error || pollError}</div>}
+        {(pending || (!accountStatus && !error)) && <div className="bn-cloud-run-message">Connecting to Blacknode Cloud…</div>}
+        {(error || pollError || authError) && <div className="bn-cloud-run-error">{error || pollError || authError}</div>}
+
+        {!pending && accountStatus?.configured && !accountStatus.authenticated && !job && (
+          <div className="bn-cloud-auth">
+            <div className="bn-cloud-auth-tabs">
+              <button type="button" className={authMode === 'login' ? 'is-active' : ''} onClick={() => setAuthMode('login')}>
+                Log in
+              </button>
+              <button type="button" className={authMode === 'register' ? 'is-active' : ''} onClick={() => setAuthMode('register')}>
+                Sign up
+              </button>
+            </div>
+            <form onSubmit={event => void submitAuth(event)}>
+              {authMode === 'register' && (
+                <label>
+                  <span>Display name</span>
+                  <input value={displayName} onChange={event => setDisplayName(event.target.value)} autoComplete="name" maxLength={100} />
+                </label>
+              )}
+              <label>
+                <span>Email</span>
+                <input type="email" required value={email} onChange={event => setEmail(event.target.value)} autoComplete="email" maxLength={254} />
+              </label>
+              <label>
+                <span>Password</span>
+                <input
+                  type="password"
+                  required
+                  minLength={authMode === 'register' ? 10 : 1}
+                  value={password}
+                  onChange={event => setPassword(event.target.value)}
+                  autoComplete={authMode === 'register' ? 'new-password' : 'current-password'}
+                />
+              </label>
+              {authMode === 'register' && (
+                <label>
+                  <span>Confirm password</span>
+                  <input type="password" required minLength={10} value={confirmPassword} onChange={event => setConfirmPassword(event.target.value)} autoComplete="new-password" />
+                </label>
+              )}
+              <button type="submit" className="is-primary" disabled={authPending}>
+                {authPending ? 'Connecting…' : authMode === 'register' ? 'Create account' : 'Log in'}
+              </button>
+            </form>
+            <p>Your Cloud session stays on this editor server and is not placed in browser storage or workflow payloads.</p>
+          </div>
+        )}
+
+        {!job && accountStatus?.authenticated && account && credits && (
+          <>
+            <div className="bn-cloud-account">
+              <header>
+                <div><strong>{account.display_name}</strong><span>{account.email}</span></div>
+                <button type="button" onClick={() => void logout()} disabled={authPending}>Log out</button>
+              </header>
+              <div className="bn-cloud-credit-grid">
+                <div><span>Available</span><strong>{credits.available.toLocaleString()}</strong></div>
+                <div><span>Reserved</span><strong>{credits.reserved.toLocaleString()}</strong></div>
+                <div><span>Balance</span><strong>{credits.balance.toLocaleString()}</strong></div>
+              </div>
+              <small>Credits are GPU-seconds. This job reserves its runtime limit and charges measured GPU time.</small>
+              <button type="button" className="is-primary bn-cloud-submit" onClick={onRun} disabled={pending}>
+                Run workflow on NVIDIA L40S
+              </button>
+            </div>
+
+            <div className="bn-cloud-run-section">
+              <header><strong>Credit history</strong><span>{history.length}</span></header>
+              <div className="bn-cloud-credit-history">
+                {history.map(entry => (
+                  <div key={entry.id}>
+                    <span>{creditReason(entry)}<small>{new Date(entry.created_at).toLocaleString()}</small></span>
+                    <strong className={entry.delta_seconds >= 0 ? 'is-credit' : 'is-charge'}>
+                      {entry.delta_seconds >= 0 ? '+' : ''}{entry.delta_seconds.toLocaleString()}
+                    </strong>
+                  </div>
+                ))}
+                {history.length === 0 && <p>No credit activity yet.</p>}
+              </div>
+            </div>
+          </>
+        )}
+
+        {job && credits && (
+          <div className="bn-cloud-job-credits">
+            <span>{credits.available.toLocaleString()} available</span>
+            <span>{credits.reserved.toLocaleString()} reserved</span>
+          </div>
+        )}
 
         {job && (
           <>
@@ -155,11 +334,7 @@ export default function CloudRunPanel({ open, pending, initialJob, error, onClos
               <header><strong>Artifacts</strong><span>{artifacts.length}</span></header>
               <div className="bn-cloud-artifact-list">
                 {artifacts.map(artifact => (
-                  <a
-                    key={artifact.id}
-                    href={api.cloudArtifactDownloadUrl(job.id, artifact.id)}
-                    download={artifact.name}
-                  >
+                  <a key={artifact.id} href={api.cloudArtifactDownloadUrl(job.id, artifact.id)} download={artifact.name}>
                     <span>{artifact.name}</span><small>{bytes(artifact.size_bytes)} · download</small>
                   </a>
                 ))}
@@ -174,7 +349,7 @@ export default function CloudRunPanel({ open, pending, initialJob, error, onClos
               </div>
             )}
             {job.error_message && <div className="bn-cloud-run-error">{job.error_message}</div>}
-            {!TERMINAL.has(job.status) && (
+            {activeJob && (
               <footer>
                 <button type="button" onClick={() => void api.cancelCloudJob(job.id).then(setJob)}>
                   Cancel job

--- a/editor/src/components/EmailVerificationPage.tsx
+++ b/editor/src/components/EmailVerificationPage.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+
+import { api } from '../api'
+
+type VerificationState = 'checking' | 'verified' | 'invalid'
+
+function fragmentToken(): string {
+  const fragment = window.location.hash.startsWith('#')
+    ? window.location.hash.slice(1)
+    : window.location.hash
+  return new URLSearchParams(fragment).get('token')?.trim() ?? ''
+}
+
+export default function EmailVerificationPage() {
+  const [state, setState] = useState<VerificationState>('checking')
+  const [message, setMessage] = useState('Verifying your Blacknode Cloud email…')
+
+  useEffect(() => {
+    const token = fragmentToken()
+    window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`)
+    if (!token) {
+      setState('invalid')
+      setMessage('This verification link is missing its secure token.')
+      return
+    }
+    let cancelled = false
+    void api.verifyCloudEmail(token)
+      .then(result => {
+        if (cancelled) return
+        setState('verified')
+        setMessage(`${result.account.email} is verified.`)
+      })
+      .catch(error => {
+        if (cancelled) return
+        setState('invalid')
+        setMessage(error instanceof Error ? error.message : 'This verification link is invalid or expired.')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <main className="bn-cloud-verification-page">
+      <section className={`bn-cloud-verification-card is-${state}`} aria-live="polite">
+        <div className="bn-cloud-verification-mark" aria-hidden="true">BN</div>
+        <p className="bn-cloud-verification-eyebrow">Blacknode Robotics</p>
+        <h1>{state === 'verified' ? 'Email verified' : state === 'invalid' ? 'Verification failed' : 'Verifying email'}</h1>
+        <p>{message}</p>
+        {state === 'verified' && <p>You can close this page and return to the Blacknode Editor.</p>}
+        {state === 'invalid' && <p>Request a new verification email from your Cloud account settings.</p>}
+      </section>
+    </main>
+  )
+}

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -11541,3 +11541,177 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   cursor: default;
   opacity: 0.55;
 }
+
+.bn-cloud-run-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 95;
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-end;
+  background: rgba(0, 0, 0, 0.38);
+}
+
+.bn-cloud-run-panel {
+  box-sizing: border-box;
+  width: min(520px, 96vw);
+  height: 100%;
+  overflow: auto;
+  padding: 20px;
+  color: var(--tx1);
+  background: var(--panel);
+  border-left: 1px solid var(--line2);
+  box-shadow: -18px 0 54px rgba(0, 0, 0, 0.38);
+}
+
+.bn-cloud-run-panel > header,
+.bn-cloud-run-section > header,
+.bn-cloud-metric-chart > header,
+.bn-cloud-run-panel > footer,
+.bn-cloud-progress-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.bn-cloud-run-panel > header span,
+.bn-cloud-run-panel > header strong {
+  display: block;
+}
+
+.bn-cloud-run-panel > header span {
+  margin-bottom: 5px;
+  color: var(--accent);
+  font: 700 11px var(--font-mono);
+  letter-spacing: 0.12em;
+}
+
+.bn-cloud-run-panel > header strong {
+  font-size: 18px;
+}
+
+.bn-cloud-run-panel button {
+  padding: 7px 11px;
+  color: var(--tx1);
+  background: var(--lift);
+  border: 1px solid var(--line2);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.bn-cloud-run-panel > header button {
+  padding: 2px 8px;
+  font-size: 20px;
+}
+
+.bn-cloud-run-message,
+.bn-cloud-run-error {
+  margin-top: 18px;
+  padding: 12px;
+  border-radius: 7px;
+  font-size: 13px;
+}
+
+.bn-cloud-run-message { background: var(--lift); }
+.bn-cloud-run-error { color: var(--err); background: color-mix(in srgb, var(--err) 10%, transparent); }
+
+.bn-cloud-run-facts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.bn-cloud-run-facts span,
+.bn-cloud-run-facts strong {
+  display: block;
+}
+
+.bn-cloud-run-facts span {
+  margin-bottom: 4px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-cloud-run-facts strong {
+  overflow: hidden;
+  font: 12px var(--font-mono);
+  text-overflow: ellipsis;
+}
+
+.bn-cloud-run-facts strong.is-running,
+.bn-cloud-run-facts strong.is-completed { color: var(--ok); }
+.bn-cloud-run-facts strong.is-failed,
+.bn-cloud-run-facts strong.is-timed_out { color: var(--err); }
+
+.bn-cloud-progress {
+  height: 8px;
+  margin-top: 22px;
+  overflow: hidden;
+  background: var(--lift);
+  border-radius: 999px;
+}
+
+.bn-cloud-progress i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  transition: width 250ms ease;
+}
+
+.bn-cloud-progress-label {
+  margin-top: 7px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-cloud-metric-chart,
+.bn-cloud-run-section {
+  margin-top: 22px;
+  padding: 12px;
+  background: var(--lift);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.bn-cloud-metric-chart { color: var(--accent); }
+.bn-cloud-metric-chart header { color: var(--tx2); font-size: 12px; }
+.bn-cloud-metric-chart svg { width: 100%; height: 84px; margin-top: 8px; }
+
+.bn-cloud-run-section > header {
+  margin-bottom: 10px;
+  color: var(--tx2);
+  font-size: 12px;
+}
+
+.bn-cloud-run-section pre {
+  max-height: 260px;
+  margin: 0;
+  overflow: auto;
+  color: var(--tx2);
+  font: 11px/1.5 var(--font-mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.bn-cloud-artifact-list {
+  display: grid;
+  gap: 7px;
+}
+
+.bn-cloud-artifact-list a {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px;
+  color: var(--tx1);
+  background: var(--panel);
+  border-radius: 5px;
+  text-decoration: none;
+}
+
+.bn-cloud-artifact-list a:hover { color: var(--accent); }
+.bn-cloud-artifact-list small,
+.bn-cloud-artifact-list p { color: var(--tx3); font-size: 11px; }
+.bn-cloud-run-panel > footer { margin-top: 18px; justify-content: flex-end; }

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -702,7 +702,7 @@ html[data-theme="light"] .bn-logo-image-light {
   flex-shrink: 0;
   gap: 10px;
   height: 100%;
-  padding-right: 18px;
+  padding-right: 210px;
 }
 
 .bn-topbar-controls > * {
@@ -6178,7 +6178,7 @@ html[data-ui-test="refined"] .bn-topbar-controls {
   flex: 1;
   gap: 0 !important;
   margin-right: 10px;
-  padding: 4px 10px 4px 14px !important;
+  padding: 4px 210px 4px 14px !important;
   background: transparent;
 }
 
@@ -11552,6 +11552,106 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   background: rgba(0, 0, 0, 0.38);
 }
 
+.bn-cloud-account-trigger {
+  position: fixed;
+  top: 8px;
+  right: 12px;
+  z-index: 70;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  max-width: 190px;
+  padding: 4px 10px 4px 5px;
+  color: var(--tx1);
+  background: color-mix(in srgb, var(--panel) 92%, var(--lift));
+  border: 1px solid var(--line2);
+  border-radius: 999px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+}
+
+.bn-cloud-account-trigger:hover:not(:disabled),
+.bn-cloud-account-trigger.is-authenticated {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line2));
+}
+
+.bn-cloud-account-trigger:hover:not(:disabled) {
+  background: var(--hover);
+}
+
+.bn-cloud-account-trigger:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.bn-cloud-account-avatar {
+  display: inline-grid;
+  flex: 0 0 26px;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--lift));
+  border-radius: 50%;
+  font: 750 12px var(--font-mono);
+}
+
+.bn-cloud-account-trigger.is-authenticated .bn-cloud-account-avatar {
+  color: var(--action-ink);
+  background: var(--accent);
+}
+
+.bn-cloud-account-trigger-copy,
+.bn-cloud-account-trigger-copy strong,
+.bn-cloud-account-trigger-copy small {
+  display: block;
+  min-width: 0;
+}
+
+.bn-cloud-account-trigger-copy {
+  overflow: hidden;
+  text-align: left;
+}
+
+.bn-cloud-account-trigger-copy strong,
+.bn-cloud-account-trigger-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bn-cloud-account-trigger-copy strong {
+  color: var(--tx1);
+  font: 700 11px var(--font-mono);
+}
+
+.bn-cloud-account-trigger-copy small {
+  margin-top: 1px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+@media (max-width: 860px) {
+  .bn-topbar-controls {
+    padding-right: 108px;
+  }
+
+  html[data-ui-test="refined"] .bn-topbar-controls {
+    padding-right: 108px !important;
+  }
+
+  .bn-cloud-account-trigger {
+    right: 8px;
+    max-width: 96px;
+  }
+
+  .bn-cloud-account-trigger-copy small {
+    display: none;
+  }
+}
+
 .bn-cloud-run-panel {
   box-sizing: border-box;
   width: min(520px, 96vw);
@@ -11740,6 +11840,54 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   gap: 10px;
 }
 
+.bn-cloud-verification-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  color: var(--tx1);
+  background:
+    radial-gradient(circle at 50% 20%, color-mix(in srgb, var(--accent) 15%, transparent), transparent 42%),
+    var(--bg);
+}
+
+.bn-cloud-verification-card {
+  width: min(480px, 100%);
+  padding: 34px;
+  border: 1px solid var(--line2);
+  border-radius: 12px;
+  background: var(--panel);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.bn-cloud-verification-card.is-verified { border-color: var(--ok); }
+.bn-cloud-verification-card.is-invalid { border-color: var(--err); }
+
+.bn-cloud-verification-mark {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 18px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  color: #fff;
+  background: var(--accent);
+  font: 800 15px var(--font-mono);
+}
+
+.bn-cloud-verification-eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.bn-cloud-verification-card h1 { margin: 0 0 14px; }
+.bn-cloud-verification-card p { margin: 8px 0 0; color: var(--tx2); line-height: 1.55; }
+
 .bn-cloud-auth-tabs {
   justify-content: flex-start;
   margin-bottom: 16px;
@@ -11813,6 +11961,17 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   gap: 8px;
   margin-top: 18px;
 }
+
+.bn-cloud-account small.is-verified,
+.bn-cloud-account small.is-unverified {
+  display: block;
+  margin-top: 5px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.bn-cloud-account small.is-verified { color: var(--ok); }
+.bn-cloud-account small.is-unverified { color: var(--warn); }
 
 .bn-cloud-credit-grid > div {
   padding: 10px;

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -11715,3 +11715,171 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
 .bn-cloud-artifact-list small,
 .bn-cloud-artifact-list p { color: var(--tx3); font-size: 11px; }
 .bn-cloud-run-panel > footer { margin-top: 18px; justify-content: flex-end; }
+
+.bn-cloud-credit-badge {
+  color: var(--ok);
+  font: 700 11px var(--font-mono);
+  white-space: nowrap;
+}
+
+.bn-cloud-auth,
+.bn-cloud-account {
+  margin-top: 24px;
+  padding: 16px;
+  background: var(--lift);
+  border: 1px solid var(--line2);
+  border-radius: 9px;
+}
+
+.bn-cloud-auth-tabs,
+.bn-cloud-account > header,
+.bn-cloud-job-credits {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.bn-cloud-auth-tabs {
+  justify-content: flex-start;
+  margin-bottom: 16px;
+}
+
+.bn-cloud-auth-tabs button.is-active {
+  color: #fff;
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.bn-cloud-auth form {
+  display: grid;
+  gap: 12px;
+}
+
+.bn-cloud-auth label,
+.bn-cloud-auth label > span {
+  display: block;
+}
+
+.bn-cloud-auth label > span {
+  margin-bottom: 5px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-cloud-auth input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 9px 10px;
+  color: var(--tx1);
+  background: var(--panel);
+  border: 1px solid var(--line2);
+  border-radius: 6px;
+  font-size: 13px;
+  outline: none;
+}
+
+.bn-cloud-auth input:focus { border-color: var(--accent); }
+.bn-cloud-auth button.is-primary,
+.bn-cloud-account button.is-primary {
+  color: #fff;
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.bn-cloud-auth > p,
+.bn-cloud-account > small {
+  display: block;
+  margin: 12px 0 0;
+  color: var(--tx3);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.bn-cloud-account > header strong,
+.bn-cloud-account > header span {
+  display: block;
+}
+
+.bn-cloud-account > header span {
+  margin-top: 3px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-cloud-credit-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.bn-cloud-credit-grid > div {
+  padding: 10px;
+  background: var(--panel);
+  border-radius: 6px;
+}
+
+.bn-cloud-credit-grid span,
+.bn-cloud-credit-grid strong {
+  display: block;
+}
+
+.bn-cloud-credit-grid span {
+  margin-bottom: 5px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-cloud-credit-grid strong {
+  font: 700 15px var(--font-mono);
+}
+
+.bn-cloud-submit {
+  width: 100%;
+  margin-top: 16px;
+}
+
+.bn-cloud-credit-history {
+  display: grid;
+  gap: 6px;
+}
+
+.bn-cloud-credit-history > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px;
+  background: var(--panel);
+  border-radius: 5px;
+  font-size: 12px;
+}
+
+.bn-cloud-credit-history span,
+.bn-cloud-credit-history small {
+  display: block;
+}
+
+.bn-cloud-credit-history small {
+  margin-top: 3px;
+  color: var(--tx3);
+  font-size: 11px;
+}
+
+.bn-cloud-credit-history strong {
+  font-family: var(--font-mono);
+}
+
+.bn-cloud-credit-history strong.is-credit { color: var(--ok); }
+.bn-cloud-credit-history strong.is-charge { color: var(--warn); }
+.bn-cloud-credit-history > p { color: var(--tx3); font-size: 11px; }
+
+.bn-cloud-job-credits {
+  margin-top: 18px;
+  padding: 9px 11px;
+  color: var(--tx2);
+  background: var(--lift);
+  border-radius: 6px;
+  font: 11px var(--font-mono);
+}

--- a/start.ps1
+++ b/start.ps1
@@ -8,6 +8,10 @@ $EditorOut = Join-Path $LogDir "editor.out.log"
 $EditorErr = Join-Path $LogDir "editor.err.log"
 $LauncherOwner = Join-Path $LogDir "launcher.owner"
 $VenvDir = if ($env:BLACKNODE_VENV) { $env:BLACKNODE_VENV } else { Join-Path $Root ".venv" }
+$DefaultCloudUrl = "https://cloud.blacknoderobotics.com"
+if ([string]::IsNullOrWhiteSpace($env:BLACKNODE_CLOUD_URL)) {
+    $env:BLACKNODE_CLOUD_URL = $DefaultCloudUrl
+}
 
 $BackendProcess = $null
 $FrontendProcess = $null

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,7 @@ EDITOR_OUT="$LOG_DIR/editor.out.log"
 EDITOR_ERR="$LOG_DIR/editor.err.log"
 PYTHON_BIN="${PYTHON:-}"
 VENV_DIR="${BLACKNODE_VENV:-$ROOT_DIR/.venv}"
+export BLACKNODE_CLOUD_URL="${BLACKNODE_CLOUD_URL:-https://cloud.blacknoderobotics.com}"
 BACKEND_PID=""
 FRONTEND_PID=""
 BACKEND_PORT=7777

--- a/tests/test_editor_cloud.py
+++ b/tests/test_editor_cloud.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 import unittest
@@ -17,6 +18,7 @@ if str(EDITOR_SERVER_DIR) not in sys.path:
     sys.path.insert(0, str(EDITOR_SERVER_DIR))
 
 import server  # noqa: E402
+import cloud_client  # noqa: E402
 import cloud_sessions  # noqa: E402
 
 
@@ -61,6 +63,58 @@ class EditorCloudTests(unittest.TestCase):
         self.assertEqual(response.json()["gpu"], "NVIDIA L40S")
         self.assertFalse(response.json()["authenticated"])
         self.assertNotIn("private-cloud-key", response.text)
+
+    def test_cloud_validation_errors_name_the_invalid_fields(self):
+        response = SimpleNamespace(
+            read=lambda: json.dumps(
+                {
+                    "detail": [
+                        {
+                            "loc": ["body", "password"],
+                            "msg": "String should have at least 10 characters",
+                            "type": "string_too_short",
+                        },
+                        {
+                            "loc": ["body", "email"],
+                            "msg": "Value error, enter a valid email address",
+                            "type": "value_error",
+                        },
+                    ]
+                }
+            ).encode("utf-8")
+        )
+
+        message = cloud_client._error_message(response)
+
+        self.assertEqual(
+            message,
+            "password: String should have at least 10 characters; "
+            "email: Value error, enter a valid email address",
+        )
+
+    def test_authenticated_cloud_status_refreshes_verification_state(self):
+        client = self.authenticated_client()
+
+        def cloud_call(method, path, payload=None, **kwargs):
+            self.assertEqual(kwargs["authorization"], "registered-user-cloud-token-0123456789")
+            if path == "/v1/account":
+                return {
+                    "id": "user_123",
+                    "organization_id": "org_123",
+                    "email": "robot@example.com",
+                    "display_name": "Robot Builder",
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "email_verified_at": datetime.now(UTC).isoformat(),
+                }
+            if path == "/v1/credits":
+                return {"unit": "gpu-second", "balance": 7200, "reserved": 0, "available": 7200}
+            raise AssertionError(path)
+
+        with patch.object(server, "_cloud_call", side_effect=cloud_call):
+            response = client.get("/cloud/status")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.json()["account"]["email_verified_at"])
 
     def test_login_keeps_cloud_token_in_http_only_server_session(self):
         auth = {
@@ -181,6 +235,25 @@ class EditorCloudTests(unittest.TestCase):
         self.assertEqual(user_call.call_args.args[2], "/v1/credits/history?limit=100")
         self.assertTrue(logged_out.json()["revoked"])
         self.assertIn("Max-Age=0", logged_out.headers["set-cookie"])
+
+    def test_email_verification_proxy_never_uses_admin_or_user_credentials(self):
+        token = "email_verify_" + "a" * 48
+
+        def cloud_call(method, path, payload=None, **kwargs):
+            self.assertEqual((method, path), ("POST", "/v1/auth/verify-email"))
+            self.assertEqual(payload, {"token": token})
+            self.assertFalse(kwargs["allow_admin"])
+            self.assertNotIn("authorization", kwargs)
+            return {"verified": True, "account": {"email": "robot@example.com"}}
+
+        with patch.object(server, "_cloud_call", side_effect=cloud_call):
+            response = TestClient(server.app).post(
+                "/cloud/auth/verify-email",
+                json={"token": token},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["verified"])
 
 
 if __name__ == "__main__":

--- a/tests/test_editor_cloud.py
+++ b/tests/test_editor_cloud.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITOR_SERVER_DIR = ROOT / "editor-server"
+if str(EDITOR_SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(EDITOR_SERVER_DIR))
+
+import server  # noqa: E402
+
+
+class EditorCloudTests(unittest.TestCase):
+    def test_cloud_status_reports_configuration_without_exposing_key(self):
+        with patch.dict(
+            os.environ,
+            {
+                "BLACKNODE_CLOUD_URL": "https://cloud.blacknode.example",
+                "BLACKNODE_CLOUD_API_KEY": "private-cloud-key-with-24-characters",
+            },
+            clear=False,
+        ):
+            response = TestClient(server.app).get("/cloud/status")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["configured"])
+        self.assertEqual(response.json()["gpu"], "NVIDIA L40S")
+        self.assertNotIn("private-cloud-key", response.text)
+
+    def test_create_cloud_job_sends_portable_workflow_to_private_api(self):
+        session = server.Session()
+        session.node_meta = {"out": {"type": "Output"}}
+        calls: list[tuple[str, str, dict]] = []
+        workflow = {
+            "kind": "blacknode.workflow",
+            "schema_version": 1,
+            "name": "Cloud graph",
+            "entrypoint": {"node_id": "out", "port": "value"},
+            "node_meta": {"out": {"type": "Output"}},
+            "edges": [],
+            "metadata": {},
+        }
+
+        def cloud_call(method, path, payload=None):
+            calls.append((method, path, payload))
+            return {"id": "job_" + "a" * 32, "status": "QUEUED"}
+
+        with (
+            patch.object(server, "_session", session),
+            patch.object(server, "_workflow_payload", return_value=workflow),
+            patch.object(
+                server,
+                "validate_bn_workflow",
+                return_value=SimpleNamespace(ok=True, to_dict=lambda: {"ok": True}),
+            ),
+            patch.object(server, "_cloud_call", side_effect=cloud_call),
+        ):
+            response = TestClient(server.app).post(
+                "/cloud/jobs",
+                json={
+                    "entrypoint": {"node_id": "out", "port": "value"},
+                    "workflow_name": "Cloud graph",
+                    "project_ref": "robot-project",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        method, path, payload = calls[0]
+        self.assertEqual((method, path), ("POST", "/v1/jobs"))
+        self.assertEqual(payload["compute"]["gpu_class"], "l40s")
+        self.assertEqual(payload["compute"]["gpu_count"], 1)
+        self.assertEqual(payload["workflow"]["entrypoint"]["node_id"], "out")
+        self.assertNotIn("image", payload["runtime"])
+
+    def test_invalid_job_id_never_reaches_cloud(self):
+        with patch.object(server, "_cloud_call") as cloud_call:
+            response = TestClient(server.app).get("/cloud/jobs/../../secrets")
+
+        self.assertIn(response.status_code, {400, 404})
+        cloud_call.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_editor_cloud.py
+++ b/tests/test_editor_cloud.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -16,9 +17,34 @@ if str(EDITOR_SERVER_DIR) not in sys.path:
     sys.path.insert(0, str(EDITOR_SERVER_DIR))
 
 import server  # noqa: E402
+import cloud_sessions  # noqa: E402
 
 
 class EditorCloudTests(unittest.TestCase):
+    def setUp(self):
+        self.session_store = cloud_sessions.CloudSessionStore()
+        self.session_patch = patch.object(server, "_cloud_sessions", self.session_store)
+        self.session_patch.start()
+
+    def tearDown(self):
+        self.session_patch.stop()
+
+    def authenticated_client(self) -> TestClient:
+        session_id, _ = self.session_store.create(
+            "registered-user-cloud-token-0123456789",
+            (datetime.now(UTC) + timedelta(days=1)).isoformat(),
+            {
+                "id": "user_123",
+                "organization_id": "org_123",
+                "email": "robot@example.com",
+                "display_name": "Robot Builder",
+                "created_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        client = TestClient(server.app)
+        client.cookies.set(server._CLOUD_SESSION_COOKIE, session_id)
+        return client
+
     def test_cloud_status_reports_configuration_without_exposing_key(self):
         with patch.dict(
             os.environ,
@@ -33,7 +59,46 @@ class EditorCloudTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["configured"])
         self.assertEqual(response.json()["gpu"], "NVIDIA L40S")
+        self.assertFalse(response.json()["authenticated"])
         self.assertNotIn("private-cloud-key", response.text)
+
+    def test_login_keeps_cloud_token_in_http_only_server_session(self):
+        auth = {
+            "token": "registered-user-cloud-token-0123456789",
+            "expires_at": (datetime.now(UTC) + timedelta(days=30)).isoformat(),
+            "account": {
+                "id": "user_123",
+                "organization_id": "org_123",
+                "email": "robot@example.com",
+                "display_name": "Robot Builder",
+                "created_at": datetime.now(UTC).isoformat(),
+            },
+        }
+
+        def cloud_call(method, path, payload=None, **kwargs):
+            if path == "/v1/auth/login":
+                self.assertFalse(kwargs["allow_admin"])
+                return auth
+            if path == "/v1/credits":
+                self.assertEqual(kwargs["authorization"], auth["token"])
+                return {"unit": "gpu-second", "balance": 7200, "reserved": 0, "available": 7200}
+            raise AssertionError(path)
+
+        with (
+            patch.dict(os.environ, {"BLACKNODE_CLOUD_URL": "https://cloud.blacknode.example"}),
+            patch.object(server, "_cloud_call", side_effect=cloud_call),
+        ):
+            response = TestClient(server.app).post(
+                "/cloud/auth/login",
+                json={"email": "robot@example.com", "password": "correct-password"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["authenticated"])
+        self.assertNotIn("token", response.text)
+        cookie = response.headers["set-cookie"]
+        self.assertIn("HttpOnly", cookie)
+        self.assertIn("SameSite=strict", cookie)
 
     def test_create_cloud_job_sends_portable_workflow_to_private_api(self):
         session = server.Session()
@@ -49,7 +114,8 @@ class EditorCloudTests(unittest.TestCase):
             "metadata": {},
         }
 
-        def cloud_call(method, path, payload=None):
+        def cloud_call(request, method, path, payload=None):
+            self.assertIsNotNone(request.cookies.get(server._CLOUD_SESSION_COOKIE))
             calls.append((method, path, payload))
             return {"id": "job_" + "a" * 32, "status": "QUEUED"}
 
@@ -61,9 +127,9 @@ class EditorCloudTests(unittest.TestCase):
                 "validate_bn_workflow",
                 return_value=SimpleNamespace(ok=True, to_dict=lambda: {"ok": True}),
             ),
-            patch.object(server, "_cloud_call", side_effect=cloud_call),
+            patch.object(server, "_cloud_user_call", side_effect=cloud_call),
         ):
-            response = TestClient(server.app).post(
+            response = self.authenticated_client().post(
                 "/cloud/jobs",
                 json={
                     "entrypoint": {"node_id": "out", "port": "value"},
@@ -81,11 +147,40 @@ class EditorCloudTests(unittest.TestCase):
         self.assertNotIn("image", payload["runtime"])
 
     def test_invalid_job_id_never_reaches_cloud(self):
-        with patch.object(server, "_cloud_call") as cloud_call:
-            response = TestClient(server.app).get("/cloud/jobs/../../secrets")
+        with patch.object(server, "_cloud_user_call") as cloud_call:
+            response = self.authenticated_client().get("/cloud/jobs/../../secrets")
 
         self.assertIn(response.status_code, {400, 404})
         cloud_call.assert_not_called()
+
+    def test_credit_history_and_logout_use_registered_session(self):
+        client = self.authenticated_client()
+
+        def cloud_call(method, path, payload=None, **kwargs):
+            self.assertEqual(kwargs["authorization"], "registered-user-cloud-token-0123456789")
+            if path == "/v1/auth/logout":
+                return {"ok": True}
+            raise AssertionError(path)
+
+        with (
+            patch.object(
+                server,
+                "_cloud_user_call",
+                return_value={
+                    "unit": "gpu-second",
+                    "entries": [{"id": "credit_1", "delta_seconds": 7200}],
+                },
+            ) as user_call,
+            patch.object(server, "_cloud_call", side_effect=cloud_call),
+        ):
+            history = client.get("/cloud/credits/history")
+            logged_out = client.post("/cloud/auth/logout")
+
+        self.assertEqual(history.status_code, 200)
+        self.assertEqual(history.json()["entries"][0]["delta_seconds"], 7200)
+        self.assertEqual(user_call.call_args.args[2], "/v1/credits/history?limit=100")
+        self.assertTrue(logged_out.json()["revoked"])
+        self.assertIn("Max-Age=0", logged_out.headers["set-cookie"])
 
 
 if __name__ == "__main__":

--- a/tests/test_editor_point_cloud_viewer.py
+++ b/tests/test_editor_point_cloud_viewer.py
@@ -388,8 +388,9 @@ def test_go_live_button_becomes_stop_live_for_viewer_and_slam_sessions():
     assert "const liveRunActive" in source
     assert "liveRunActive ? '■ Stop live' : '● Go live'" in source
     assert "onceRunActive ? '■ Stop once' : '▶ Run once'" in source
-    assert """className="bn-top-button bn-top-run-button"
-                onClick={() => (onceRunActive ? stopCook() : void handleRunGraph('once'))}""" in source
+    assert "if (executionTarget === 'cloud') void handleCloudRun()" in source
+    assert "else if (onceRunActive) stopCook()" in source
+    assert "else void handleRunGraph('once')" in source
     assert """className={`bn-top-button bn-top-run-button bn-top-live-button${liveRunActive ? ' is-stop-live' : ' is-start-live'}`}
                 onClick={() => (liveRunActive ? void handleStopRuntime() : void handleRunGraph('live'))}""" in source
     assert 'className="bn-top-button bn-top-reset-button"' in source

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -26,6 +26,17 @@ def test_core_launchers_do_not_install_optional_cuda_dependencies():
     assert "pip_install cupy" not in shell.lower()
 
 
+def test_launchers_default_to_the_public_cloud_url_and_allow_overrides():
+    powershell = (ROOT / "start.ps1").read_text(encoding="utf-8")
+    shell = (ROOT / "start.sh").read_text(encoding="utf-8")
+
+    cloud_url = "https://cloud.blacknoderobotics.com"
+    assert f'$DefaultCloudUrl = "{cloud_url}"' in powershell
+    assert '[string]::IsNullOrWhiteSpace($env:BLACKNODE_CLOUD_URL)' in powershell
+    assert '$env:BLACKNODE_CLOUD_URL = $DefaultCloudUrl' in powershell
+    assert f'export BLACKNODE_CLOUD_URL="${{BLACKNODE_CLOUD_URL:-{cloud_url}}}"' in shell
+
+
 def test_launchers_stream_extension_dependency_setup_output():
     powershell = (ROOT / "start.ps1").read_text(encoding="utf-8")
     shell = (ROOT / "start.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
## Outcome

Adds the open-source Run on Cloud boundary and complete Editor account experience: Local/Cloud selection, signup, login, logout, top-right profile, wallet and credit history, email-verification landing page, server-side HttpOnly Cloud sessions, safe workflow submission, polling status, progress, logs, metrics, cancellation, and artifact downloads.

Cloud bearer tokens remain on the editor server and are not placed in browser storage or serialized workflow payloads. Signup validation now reports the actual invalid field, and an unverified account can repeat signup with the same password to request a fresh verification email.

Linux and Windows launchers default to `https://cloud.blacknoderobotics.com` while still allowing an environment override.

## Verification

- Cloud API: 56 tests passed, 2 skipped; Ruff passed
- Blacknode: 553 unittest checks passed, 8 skipped
- Editor production build passed

## Managed Runtime release

No Runtime release is required. This is Editor UI and editor-server orchestration and does not alter the managed-device bundle.
