### PR TITLE
Lock Cloud runs until email verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ need on-demand GPU compute. Cloud accounts use compute credits measured in
 GPU-seconds: a job reserves its runtime limit, charges measured GPU time, and
 returns progress, logs, metrics, and downloadable artifacts to the editor. The
 same workflow format runs locally, on paired devices, and in Blacknode Cloud.
+Signup credits remain visible but locked until email verification succeeds;
+the editor and Cloud API both block job submission before verification.
 
 Cloud usage funds the hosted compute infrastructure, security maintenance,
 release engineering, and continued development of the open-source project.

--- a/docs/quickstart-mcp.md
+++ b/docs/quickstart-mcp.md
@@ -32,6 +32,8 @@ The launchers connect **Run on Cloud** to
 `https://cloud.blacknoderobotics.com` by default. Set
 `BLACKNODE_CLOUD_URL` before launching to use a staging or local Cloud API;
 an explicit value takes precedence over the default.
+After signup, verify the account email to unlock promotional GPU-second credits
+and enable **Run on Cloud**.
 
 If you see `Stopping existing visual editor on port 3000...`, the launcher
 found an old Blacknode Vite server and restarted it so the editor stays on

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1538,6 +1538,10 @@ function WorkspaceApp() {
         return
       }
       if (!accountStatus.authenticated) return
+      if (!accountStatus.account?.email_verified_at) {
+        setCloudJobError('Verify your email address before running workflows on Blacknode Cloud.')
+        return
+      }
       setCloudJob(null)
       const created = await api.createCloudJob(
         { node_id: target.id, port: target.port },

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1059,6 +1059,7 @@ export interface CloudCredits {
   balance: number
   reserved: number
   available: number
+  locked?: number
 }
 
 export interface CloudCreditEntry {

--- a/editor/src/components/CloudRunPanel.tsx
+++ b/editor/src/components/CloudRunPanel.tsx
@@ -196,9 +196,26 @@ export default function CloudRunPanel({
     }
   }
 
+  const refreshVerification = async () => {
+    setAuthPending(true)
+    setAuthError('')
+    try {
+      await refreshAccount()
+    } catch (cause) {
+      setAuthError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setAuthPending(false)
+    }
+  }
+
   if (!open) return null
   const credits = accountStatus?.credits
   const account = accountStatus?.account
+  const emailVerified = Boolean(account?.email_verified_at)
+  const availableCredits = emailVerified ? credits?.available ?? 0 : 0
+  const lockedCredits = emailVerified
+    ? credits?.locked ?? 0
+    : Math.max(credits?.locked ?? 0, credits?.available ?? 0)
   const activeJob = job && !TERMINAL.has(job.status)
   const visibleJob = view === 'job' ? job : null
 
@@ -282,13 +299,23 @@ export default function CloudRunPanel({
                 <button type="button" onClick={() => void logout()} disabled={authPending}>Log out</button>
               </header>
               <div className="bn-cloud-credit-grid">
-                <div><span>Available</span><strong>{credits.available.toLocaleString()}</strong></div>
+                <div><span>Available</span><strong>{availableCredits.toLocaleString()}</strong></div>
+                <div><span>Locked</span><strong>{lockedCredits.toLocaleString()}</strong></div>
                 <div><span>Reserved</span><strong>{credits.reserved.toLocaleString()}</strong></div>
                 <div><span>Balance</span><strong>{credits.balance.toLocaleString()}</strong></div>
               </div>
               <small>Credits are GPU-seconds. This job reserves its runtime limit and charges measured GPU time.</small>
-              <button type="button" className="is-primary bn-cloud-submit" onClick={onRun} disabled={pending}>
-                Run workflow on NVIDIA L40S
+              {!emailVerified && (
+                <div className="bn-cloud-verification-lock" role="status">
+                  <strong>Verify your email to unlock Cloud runs</strong>
+                  <span>Your signup credits are saved and will become available after verification.</span>
+                  <button type="button" onClick={() => void refreshVerification()} disabled={authPending}>
+                    {authPending ? 'Refreshing…' : 'I verified — refresh status'}
+                  </button>
+                </div>
+              )}
+              <button type="button" className="is-primary bn-cloud-submit" onClick={onRun} disabled={pending || !emailVerified}>
+                {emailVerified ? 'Run workflow on NVIDIA L40S' : 'Email verification required'}
               </button>
             </div>
 
@@ -311,7 +338,7 @@ export default function CloudRunPanel({
 
         {visibleJob && credits && (
           <div className="bn-cloud-job-credits">
-            <span>{credits.available.toLocaleString()} available</span>
+            <span>{availableCredits.toLocaleString()} available</span>
             <span>{credits.reserved.toLocaleString()} reserved</span>
           </div>
         )}

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -11957,7 +11957,7 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
 
 .bn-cloud-credit-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 8px;
   margin-top: 18px;
 }
@@ -11998,6 +11998,26 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   width: 100%;
   margin-top: 16px;
 }
+
+.bn-cloud-verification-lock {
+  display: grid;
+  gap: 6px;
+  margin-top: 14px;
+  padding: 11px;
+  color: var(--warn);
+  background: color-mix(in srgb, var(--warn) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warn) 38%, var(--line2));
+  border-radius: 6px;
+}
+
+.bn-cloud-verification-lock strong,
+.bn-cloud-verification-lock span {
+  display: block;
+}
+
+.bn-cloud-verification-lock strong { font-size: 12px; }
+.bn-cloud-verification-lock span { color: var(--tx2); font-size: 11px; line-height: 1.45; }
+.bn-cloud-verification-lock button { justify-self: start; margin-top: 3px; }
 
 .bn-cloud-credit-history {
   display: grid;

--- a/tests/test_editor_cloud.py
+++ b/tests/test_editor_cloud.py
@@ -107,7 +107,13 @@ class EditorCloudTests(unittest.TestCase):
                     "email_verified_at": datetime.now(UTC).isoformat(),
                 }
             if path == "/v1/credits":
-                return {"unit": "gpu-second", "balance": 7200, "reserved": 0, "available": 7200}
+                return {
+                    "unit": "gpu-second",
+                    "balance": 7200,
+                    "reserved": 0,
+                    "available": 7200,
+                    "locked": 0,
+                }
             raise AssertionError(path)
 
         with patch.object(server, "_cloud_call", side_effect=cloud_call):
@@ -115,6 +121,7 @@ class EditorCloudTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(response.json()["account"]["email_verified_at"])
+        self.assertEqual(response.json()["credits"]["locked"], 0)
 
     def test_login_keeps_cloud_token_in_http_only_server_session(self):
         auth = {


### PR DESCRIPTION
## What changed

- show promotional GPU seconds as locked until email verification
- disable the account-panel Cloud run action while verification is pending
- stop the top-bar Cloud run path before submission when the account is unverified
- add a refresh-verification action after the user follows the email link
- document the verification requirement

## Root cause

The Editor displayed the account verification state but did not use it to control credit availability or Cloud execution.

## Validation

- focused Editor Cloud tests: 8 passed
- full Blacknode suite: 553 passed, 8 skipped
- `npm run build`

## Managed Runtime release

No Runtime release is required. This change is limited to the Editor UI and editor-server Cloud contract presentation.
