### PR TITLE
Add safe hosted Editor preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ returns progress, logs, metrics, and downloadable artifacts to the editor. The
 same workflow format runs locally, on paired devices, and in Blacknode Cloud.
 Signup credits remain visible but locked until email verification succeeds;
 the editor and Cloud API both block job submission before verification.
+The hosted Editor preview and its cloud-only security boundary are documented
+in [`docs/hosted-preview.md`](docs/hosted-preview.md).
 
 Cloud usage funds the hosted compute infrastructure, security maintenance,
 release engineering, and continued development of the open-source project.

--- a/docker/nginx.editor.conf
+++ b/docker/nginx.editor.conf
@@ -1,3 +1,8 @@
+map $http_x_forwarded_proto $blacknode_forwarded_proto {
+    default $scheme;
+    https https;
+}
+
 server {
     listen 3000;
     server_name _;
@@ -13,7 +18,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $blacknode_forwarded_proto;
         proxy_buffering off;
     }
 

--- a/docs/hosted-preview.md
+++ b/docs/hosted-preview.md
@@ -1,0 +1,35 @@
+# Hosted Editor preview
+
+The Blacknode hosted preview provides the visual workflow canvas and Blacknode
+Cloud execution at `https://app.blacknoderobotics.com`. Each browser receives
+an isolated, process-local graph workspace. The preview supports core node
+schemas, graph editing, templates, Cloud account access, GPU-second credits,
+job submission, progress, logs, and artifact downloads.
+
+Set these values only on the hosted Editor server:
+
+```text
+BLACKNODE_HOSTED_MODE=1
+BLACKNODE_HOSTED_PUBLIC_ORIGIN=https://app.blacknoderobotics.com
+BLACKNODE_CLOUD_URL=https://cloud.blacknoderobotics.com
+```
+
+Hosted workspaces expire after 24 hours and reset when the Editor server
+restarts. Durable Cloud jobs and artifacts remain attached to the signed-in
+Blacknode Cloud account.
+
+## Security boundary
+
+Hosted mode uses a strict backend allowlist. It accepts graph editing, template,
+read-only package metadata, and Cloud routes. It rejects local cook and live
+runtime operations, console execution, filesystem browsing, custom-node and
+package mutation, device and SSH management, drivers, local imports, and local
+workflow execution. Unsafe HTTP methods require the configured same-origin
+`Origin` header. Workspace and Cloud credentials use separate HttpOnly,
+Secure, SameSite=Strict cookies.
+
+Customer workflows execute through the Blacknode Cloud job boundary. They do
+not execute in the hosted Editor service.
+
+The installed Editor remains the operator surface for local files, packages,
+devices, ROS 2, cameras, local CUDA, and managed robot hardware.

--- a/editor-server/hosted_mode.py
+++ b/editor-server/hosted_mode.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import re
+import secrets
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+_CLOUD_JOB_PATH = re.compile(r"^/cloud/jobs/[^/]+$")
+_CLOUD_JOB_LOGS_PATH = re.compile(r"^/cloud/jobs/[^/]+/logs$")
+_CLOUD_JOB_ARTIFACTS_PATH = re.compile(r"^/cloud/jobs/[^/]+/artifacts$")
+_CLOUD_ARTIFACT_DOWNLOAD_PATH = re.compile(
+    r"^/cloud/jobs/[^/]+/artifacts/[^/]+/download$"
+)
+
+
+@dataclass
+class _Workspace(Generic[T]):
+    value: T
+    touched_at: float
+
+
+class HostedWorkspaceStore(Generic[T]):
+    """Bounded, process-local workspaces for the public Editor preview."""
+
+    def __init__(
+        self,
+        factory: Callable[[], T],
+        *,
+        max_workspaces: int = 256,
+        ttl_seconds: int = 86_400,
+    ) -> None:
+        self._factory = factory
+        self._max_workspaces = max_workspaces
+        self._ttl_seconds = ttl_seconds
+        self._items: dict[str, _Workspace[T]] = {}
+        self._lock = threading.Lock()
+
+    def get_or_create(self, token: str | None) -> tuple[str, T, bool]:
+        now = time.time()
+        with self._lock:
+            self._reap(now)
+            if token and token in self._items:
+                item = self._items[token]
+                item.touched_at = now
+                return token, item.value, False
+            while len(self._items) >= self._max_workspaces:
+                oldest = min(self._items, key=lambda key: self._items[key].touched_at)
+                self._items.pop(oldest, None)
+            workspace_token = secrets.token_urlsafe(32)
+            value = self._factory()
+            self._items[workspace_token] = _Workspace(value=value, touched_at=now)
+            return workspace_token, value, True
+
+    def _reap(self, now: float) -> None:
+        expired = [
+            token
+            for token, item in self._items.items()
+            if now - item.touched_at > self._ttl_seconds
+        ]
+        for token in expired:
+            self._items.pop(token, None)
+
+
+def route_allowed(method: str, path: str, *, query: str = "") -> bool:
+    method = method.upper()
+    if method == "GET" and path in {"/healthz", "/readyz", "/hosted/status"}:
+        return True
+    if method == "GET" and path in {"/node-types", "/node-defs", "/graph", "/validate"}:
+        return True
+    if path == "/graph" and method == "POST":
+        return True
+    if path in {"/graph/requirements", "/graph/refresh-node-schemas"} and method in {
+        "PATCH",
+        "POST",
+    }:
+        return True
+    if path.startswith("/nodes/"):
+        if path.endswith(("/control", "/depth-frame")):
+            return False
+        return method in {"GET", "PATCH", "DELETE"}
+    if path == "/nodes" and method == "POST":
+        return True
+    if path == "/edges" and method in {"POST", "DELETE"}:
+        return True
+    if path == "/subnets" and method == "POST":
+        return True
+    if path == "/cloud/status" and method == "GET":
+        return True
+    if path in {
+        "/cloud/auth/register",
+        "/cloud/auth/login",
+        "/cloud/auth/verify-email",
+        "/cloud/auth/logout",
+    } and method == "POST":
+        return True
+    if path == "/cloud/credits/history" and method == "GET":
+        return True
+    if path == "/cloud/jobs" and method == "POST":
+        return True
+    if _CLOUD_JOB_PATH.fullmatch(path):
+        return method in {"GET", "DELETE"}
+    if _CLOUD_JOB_LOGS_PATH.fullmatch(path):
+        return method == "GET"
+    if _CLOUD_JOB_ARTIFACTS_PATH.fullmatch(path):
+        return method == "GET"
+    if _CLOUD_ARTIFACT_DOWNLOAD_PATH.fullmatch(path):
+        return method == "GET"
+    if path == "/templates" and method == "GET":
+        return True
+    if path.startswith("/templates/"):
+        return method == "GET" or (method == "POST" and path.endswith("/load"))
+    if path == "/packages" and method == "GET":
+        return "git=true" not in query.lower()
+    if path == "/packages/index" and method == "GET":
+        return True
+    if path.startswith("/packages/") and method == "GET" and path.endswith("/dependencies"):
+        return True
+    return path == "/reset" and method == "POST"

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -4,6 +4,7 @@ import asyncio, uuid, os, sys, json, threading, re, queue, io, contextlib, time,
 from array import array
 import urllib.error, urllib.parse, urllib.request
 from concurrent.futures import ThreadPoolExecutor, wait
+from contextvars import ContextVar
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
@@ -86,6 +87,7 @@ from project_store import ProjectStore, ProjectStoreError
 from run_store import RunStore
 import cloud_client
 import cloud_sessions
+from hosted_mode import HostedWorkspaceStore, route_allowed as hosted_route_allowed
 
 
 def package_index_payload(*args, **kwargs):
@@ -112,8 +114,23 @@ def workflow_node_types(*args, **kwargs):
     return bn_package_index.workflow_node_types(*args, **kwargs)
 
 
+_HOSTED_MODE = os.environ.get("BLACKNODE_HOSTED_MODE", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+}
+_HOSTED_PUBLIC_ORIGIN = os.environ.get(
+    "BLACKNODE_HOSTED_PUBLIC_ORIGIN",
+    "https://app.blacknoderobotics.com",
+).strip().rstrip("/")
+
 app = FastAPI(title="Blacknode Editor Server")
-app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[] if _HOSTED_MODE else ["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 _CLOUD_SESSION_COOKIE = "blacknode_cloud_session"
 _cloud_sessions = cloud_sessions.CloudSessionStore()
@@ -221,6 +238,8 @@ def _save_now() -> None:
 
 def _save(debounce: float = 0.0) -> None:
     """Write graph to disk. Pass debounce > 0 to coalesce rapid calls (e.g. node drag)."""
+    if _HOSTED_MODE:
+        return
     global _save_timer
     if _save_timer:
         _save_timer.cancel()
@@ -284,7 +303,85 @@ class Session:
         self.metadata: dict[str, Any] = {}
         self.entrypoint: dict[str, str] | None = None
 
-_session = Session()
+
+_local_session = Session()
+_hosted_session_context: ContextVar[Session | None] = ContextVar(
+    "blacknode_hosted_session",
+    default=None,
+)
+_hosted_workspaces = HostedWorkspaceStore(Session)
+
+
+class _SessionProxy:
+    def _target(self) -> Session:
+        return _hosted_session_context.get() or _local_session
+
+    def __getattr__(self, name: str):
+        return getattr(self._target(), name)
+
+    def __setattr__(self, name: str, value) -> None:
+        setattr(self._target(), name, value)
+
+
+_session = _SessionProxy()
+
+
+def _hosted_error(code: str, message: str) -> Response:
+    response = Response(
+        content=json.dumps({"detail": {"code": code, "message": message}}),
+        status_code=403,
+        media_type="application/json",
+    )
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
+
+
+@app.middleware("http")
+async def hosted_preview_boundary(request: Request, call_next):
+    if not _HOSTED_MODE:
+        return await call_next(request)
+    path = request.url.path
+    method = request.method.upper()
+    if not hosted_route_allowed(method, path, query=request.url.query):
+        return _hosted_error(
+            "HOSTED_CAPABILITY_UNAVAILABLE",
+            "This capability is available in the installed Blacknode Editor.",
+        )
+    if method in {"POST", "PUT", "PATCH", "DELETE"}:
+        origin = request.headers.get("origin", "").rstrip("/")
+        if origin != _HOSTED_PUBLIC_ORIGIN:
+            return _hosted_error("INVALID_ORIGIN", "The request origin is not allowed.")
+    workspace_token = None
+    context_token = None
+    created = False
+    if path not in {"/healthz", "/readyz", "/hosted/status"}:
+        workspace_token, workspace, created = _hosted_workspaces.get_or_create(
+            request.cookies.get("__Host-blacknode_workspace")
+        )
+        context_token = _hosted_session_context.set(workspace)
+    try:
+        response = await call_next(request)
+    finally:
+        if context_token is not None:
+            _hosted_session_context.reset(context_token)
+    if created and workspace_token:
+        response.set_cookie(
+            "__Host-blacknode_workspace",
+            workspace_token,
+            max_age=86_400,
+            httponly=True,
+            secure=True,
+            samesite="strict",
+            path="/",
+        )
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
 
 
 # ── Schema models ─────────────────────────────────────────────────────────────
@@ -2035,7 +2132,27 @@ def _broadcast_learned_node_event(event_type: str, name: str) -> dict[str, Any]:
     return event
 
 
-_load()   # restore last session on startup
+if not _HOSTED_MODE:
+    _load()   # restore the trusted local session on startup
+
+
+@app.get("/healthz")
+def editor_health():
+    return {"status": "ok", "mode": "hosted" if _HOSTED_MODE else "local"}
+
+
+@app.get("/readyz")
+def editor_readiness():
+    return {"status": "ready", "mode": "hosted" if _HOSTED_MODE else "local"}
+
+
+@app.get("/hosted/status")
+def hosted_status():
+    return {
+        "hosted": _HOSTED_MODE,
+        "workspace_persistence": "session" if _HOSTED_MODE else "local",
+        "execution": "cloud-only" if _HOSTED_MODE else "local-and-cloud",
+    }
 
 
 # ── Routes ────────────────────────────────────────────────────────────────────

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -219,6 +219,7 @@ function WorkspaceApp() {
   const [runtimeStopPending, setRuntimeStopPending] = useState(false)
   const [activeRunMode, setActiveRunMode] = useState<'once' | 'live' | null>(null)
   const [executionTarget, setExecutionTarget] = useState<'local' | 'cloud'>('local')
+  const [hostedPreview, setHostedPreview] = useState(false)
   const [cloudPanelOpen, setCloudPanelOpen] = useState(false)
   const [cloudJobPending, setCloudJobPending] = useState(false)
   const [cloudJob, setCloudJob] = useState<CloudJob | null>(null)
@@ -239,6 +240,15 @@ function WorkspaceApp() {
   const [newtonWorkspace, setNewtonWorkspace] = useState<NewtonWorkspaceStatus | null>(null)
   const [newtonWorkspaceAvailable, setNewtonWorkspaceAvailable] = useState(false)
   const [newtonWorkspaceBusy, setNewtonWorkspaceBusy] = useState(false)
+
+  useEffect(() => {
+    void api.hostedStatus()
+      .then(status => {
+        setHostedPreview(status.hosted)
+        if (status.hosted) setExecutionTarget('cloud')
+      })
+      .catch(() => undefined)
+  }, [])
   const lastSimulationViewerUrl = useRef('')
   const simulationViewerMenuTriggerRef = useRef<HTMLButtonElement | null>(null)
   const simulationViewerMenuRef = useRef<HTMLDivElement | null>(null)
@@ -1849,14 +1859,15 @@ function WorkspaceApp() {
 
             <div className="bn-topbar-group bn-topbar-run-group" aria-label="Run controls">
               <span className="bn-topbar-group-label">Run</span>
+              {hostedPreview && <span className="bn-hosted-preview-badge">WEB PREVIEW</span>}
               <select
                 className="bn-top-select"
                 value={executionTarget}
-                disabled={onceRunActive || liveRunActive || cloudJobPending}
+                disabled={hostedPreview || onceRunActive || liveRunActive || cloudJobPending}
                 onChange={event => setExecutionTarget(event.target.value === 'cloud' ? 'cloud' : 'local')}
                 title="Choose where this graph executes"
               >
-                <option value="local">Local</option>
+                {!hostedPreview && <option value="local">Local</option>}
                 <option value="cloud">Blacknode Cloud · L40S</option>
               </select>
               {executionTarget === 'cloud' && cloudAccountStatus?.credits && (
@@ -1883,18 +1894,20 @@ function WorkspaceApp() {
                   : onceRunActive ? '■ Stop once' : '▶ Run once'}
               </button>
 
-              <button
-                className={`bn-top-button bn-top-run-button bn-top-live-button${liveRunActive ? ' is-stop-live' : ' is-start-live'}`}
-                onClick={() => (liveRunActive ? void handleStopRuntime() : void handleRunGraph('live'))}
-                disabled={executionTarget === 'cloud' || !serverOk || runtimeStopPending || onceRunActive || (!liveRunActive && nodes.length === 0)}
-                title={liveRunActive
-                  ? 'Stop the live graph and its managed runtime services.'
-                  : liveCapableCount > 0
-                  ? `Start ${liveCapableCount} live-capable node${liveCapableCount === 1 ? '' : 's'}; evaluate the other ${runOnceNodeCount} node${runOnceNodeCount === 1 ? '' : 's'} once.`
-                  : 'No live-capable nodes are present; this will run the graph once.'}
-              >
-                {runtimeStopPending ? 'Stopping live…' : liveRunActive ? '■ Stop live' : '● Go live'}
-              </button>
+              {!hostedPreview && (
+                <button
+                  className={`bn-top-button bn-top-run-button bn-top-live-button${liveRunActive ? ' is-stop-live' : ' is-start-live'}`}
+                  onClick={() => (liveRunActive ? void handleStopRuntime() : void handleRunGraph('live'))}
+                  disabled={executionTarget === 'cloud' || !serverOk || runtimeStopPending || onceRunActive || (!liveRunActive && nodes.length === 0)}
+                  title={liveRunActive
+                    ? 'Stop the live graph and its managed runtime services.'
+                    : liveCapableCount > 0
+                    ? `Start ${liveCapableCount} live-capable node${liveCapableCount === 1 ? '' : 's'}; evaluate the other ${runOnceNodeCount} node${runOnceNodeCount === 1 ? '' : 's'} once.`
+                    : 'No live-capable nodes are present; this will run the graph once.'}
+                >
+                  {runtimeStopPending ? 'Stopping live…' : liveRunActive ? '■ Stop live' : '● Go live'}
+                </button>
+              )}
 
               <button
                 className="bn-top-button bn-top-reset-button"

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1045,6 +1045,12 @@ export interface CloudStatus {
   credits: CloudCredits | null
 }
 
+export interface HostedEditorStatus {
+  hosted: boolean
+  workspace_persistence: 'session' | 'local'
+  execution: 'cloud-only' | 'local-and-cloud'
+}
+
 export interface CloudAccount {
   id: string
   organization_id: string
@@ -1664,6 +1670,7 @@ async function streamDeviceAction<T>(
 }
 
 export const api = {
+  hostedStatus: ()                           => req<HostedEditorStatus>('GET', '/hosted/status'),
   nodeTypes: ()                              => req<string[]>('GET', '/node-types'),
   nodeDefs:  ()                              => req<Record<string, BnNodeDef>>('GET', '/node-defs'),
   depthFrame: (nodeId: string, signal?: AbortSignal) =>

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -11822,6 +11822,17 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   white-space: nowrap;
 }
 
+.bn-hosted-preview-badge {
+  padding: 3px 6px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 32%, var(--line2));
+  border-radius: 4px;
+  font: 700 11px var(--font-mono);
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
 .bn-cloud-auth,
 .bn-cloud-account {
   margin-top: 24px;

--- a/tests/test_editor_hosted_mode.py
+++ b/tests/test_editor_hosted_mode.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITOR_SERVER = ROOT / "editor-server"
+if str(EDITOR_SERVER) not in sys.path:
+    sys.path.insert(0, str(EDITOR_SERVER))
+
+from hosted_mode import HostedWorkspaceStore, route_allowed
+
+
+class EditorHostedModeTests(unittest.TestCase):
+    def test_hosted_workspaces_are_isolated_and_reused(self) -> None:
+        store = HostedWorkspaceStore(dict, max_workspaces=2)
+
+        first_token, first, first_created = store.get_or_create(None)
+        first["nodes"] = ["a"]
+        repeated_token, repeated, repeated_created = store.get_or_create(first_token)
+        second_token, second, second_created = store.get_or_create(None)
+
+        self.assertTrue(first_created)
+        self.assertFalse(repeated_created)
+        self.assertTrue(second_created)
+        self.assertEqual(repeated_token, first_token)
+        self.assertEqual(repeated, {"nodes": ["a"]})
+        self.assertNotEqual(second_token, first_token)
+        self.assertEqual(second, {})
+
+    def test_hosted_route_allowlist_keeps_graph_and_cloud_surfaces(self) -> None:
+        self.assertTrue(route_allowed("GET", "/node-defs"))
+        self.assertTrue(route_allowed("POST", "/nodes"))
+        self.assertTrue(route_allowed("PATCH", "/nodes/node_1/params"))
+        self.assertTrue(route_allowed("POST", "/edges"))
+        self.assertTrue(route_allowed("POST", "/templates/hello/load"))
+        self.assertTrue(route_allowed("POST", "/cloud/auth/login"))
+        self.assertTrue(route_allowed("POST", "/cloud/jobs"))
+        self.assertTrue(route_allowed("GET", "/cloud/jobs/job_123/artifacts"))
+        self.assertTrue(
+            route_allowed(
+                "GET",
+                "/cloud/jobs/job_123/artifacts/artifact_456/download",
+            )
+        )
+
+    def test_hosted_route_allowlist_blocks_machine_and_execution_surfaces(self) -> None:
+        blocked = [
+            ("POST", "/cook"),
+            ("POST", "/cook-stream"),
+            ("POST", "/console/exec"),
+            ("POST", "/filesystem/browse"),
+            ("POST", "/device-hosts/inspect"),
+            ("POST", "/devices"),
+            ("POST", "/packages/install"),
+            ("DELETE", "/packages/blacknode-cuda"),
+            ("POST", "/custom-nodes"),
+            ("POST", "/exec-node"),
+            ("POST", "/api/workflows/current/run"),
+            ("POST", "/nodes/node_1/control"),
+            ("GET", "/nodes/node_1/depth-frame"),
+        ]
+        for method, path in blocked:
+            self.assertFalse(route_allowed(method, path), (method, path))
+
+        self.assertFalse(route_allowed("GET", "/packages", query="git=true"))
+        self.assertFalse(route_allowed("POST", "/cloud/admin/statistics"))
+        self.assertFalse(route_allowed("PATCH", "/cloud/jobs/job_123"))

--- a/tests/test_editor_point_cloud_viewer.py
+++ b/tests/test_editor_point_cloud_viewer.py
@@ -391,8 +391,11 @@ def test_go_live_button_becomes_stop_live_for_viewer_and_slam_sessions():
     assert "if (executionTarget === 'cloud') void handleCloudRun()" in source
     assert "else if (onceRunActive) stopCook()" in source
     assert "else void handleRunGraph('once')" in source
-    assert """className={`bn-top-button bn-top-run-button bn-top-live-button${liveRunActive ? ' is-stop-live' : ' is-start-live'}`}
-                onClick={() => (liveRunActive ? void handleStopRuntime() : void handleRunGraph('live'))}""" in source
+    assert "className={`bn-top-button bn-top-run-button bn-top-live-button" in source
+    assert (
+        "onClick={() => (liveRunActive ? void handleStopRuntime() : "
+        "void handleRunGraph('live'))}"
+    ) in source
     assert 'className="bn-top-button bn-top-reset-button"' in source
     assert ".bn-top-live-button.is-start-live" in styles
     assert "background: var(--ok)" in styles


### PR DESCRIPTION
## What changed
- add an opt-in hosted Editor mode with isolated, expiring browser workspaces
- enforce a strict server-side allowlist for graph editing, templates, and Blacknode Cloud account/job operations
- reject local execution, filesystem, console, package mutation, custom code, SSH, and device surfaces
- require the configured same-origin Origin header for mutations and issue HttpOnly Secure SameSite=Strict workspace cookies
- force Cloud execution in the hosted UI and preserve HTTPS forwarding for secure Cloud session cookies
- document the hosted preview contract and security boundary

## Why
This provides a safe browser-first Blacknode product preview at app.blacknoderobotics.com while keeping workflows behind the Blacknode Cloud execution boundary.

## Validation
- `python -m unittest discover -s tests` — 556 passed, 8 skipped
- `python -m ruff check editor-server/hosted_mode.py tests/test_editor_hosted_mode.py`
- `cd editor && npm run build`
- hosted TestClient integration: route denial, Origin enforcement, secure cookie, and two-client workspace isolation

## Release decision
No managed-device Runtime release is required. The change is limited to the Editor UI, Editor server hosted orchestration, container proxy configuration, tests, and documentation; it does not alter the managed-device bundle.