### PR TITLE
Enable trusted website account login

### DIFF
--- a/docs/hosted-preview.md
+++ b/docs/hosted-preview.md
@@ -33,3 +33,23 @@ not execute in the hosted Editor service.
 
 The installed Editor remains the operator surface for local files, packages,
 devices, ROS 2, cameras, local CUDA, and managed robot hardware.
+
+## Website account entry
+
+The Blacknode website can present its own account dialog while using the hosted
+Editor's existing Cloud account endpoints. Configure the exact HTTPS website
+origins in `BLACKNODE_HOSTED_ACCOUNT_ORIGINS`. The hosted server grants those
+origins credentialed browser access only to account status, login,
+registration, and logout. Graph, package, device, filesystem, and job routes do
+not receive cross-origin access.
+
+The website sends account requests directly to the hosted Editor origin with
+browser credentials enabled. The Editor continues to keep the Cloud bearer
+token in its server-side session behind an HttpOnly, Secure, SameSite cookie;
+the website JavaScript cannot read that token. Because the cookie remains
+host-only for `app.blacknoderobotics.com`, the same authenticated session is
+available when the user opens the Editor.
+
+`https://app.blacknoderobotics.com/?cloud=account` remains available as a
+direct account-panel entry and fallback when a trusted website origin is not
+configured.

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -123,6 +123,17 @@ _HOSTED_PUBLIC_ORIGIN = os.environ.get(
     "BLACKNODE_HOSTED_PUBLIC_ORIGIN",
     "https://app.blacknoderobotics.com",
 ).strip().rstrip("/")
+_HOSTED_ACCOUNT_ORIGINS = frozenset(
+    origin.strip().rstrip("/")
+    for origin in os.environ.get("BLACKNODE_HOSTED_ACCOUNT_ORIGINS", "").split(",")
+    if origin.strip().startswith(("http://", "https://"))
+)
+_HOSTED_ACCOUNT_CORS_METHODS = {
+    "/cloud/status": frozenset({"GET"}),
+    "/cloud/auth/register": frozenset({"POST"}),
+    "/cloud/auth/login": frozenset({"POST"}),
+    "/cloud/auth/logout": frozenset({"POST"}),
+}
 
 app = FastAPI(title="Blacknode Editor Server")
 app.add_middleware(
@@ -339,20 +350,48 @@ def _hosted_error(code: str, message: str) -> Response:
     return response
 
 
+def _hosted_account_cors_allowed(origin: str, method: str, path: str) -> bool:
+    return (
+        origin in _HOSTED_ACCOUNT_ORIGINS
+        and method.upper() in _HOSTED_ACCOUNT_CORS_METHODS.get(path, frozenset())
+    )
+
+
+def _set_hosted_account_cors(response: Response, origin: str) -> None:
+    response.headers["Access-Control-Allow-Origin"] = origin
+    response.headers["Access-Control-Allow-Credentials"] = "true"
+    vary = response.headers.get("Vary", "")
+    if "origin" not in {item.strip().lower() for item in vary.split(",") if item.strip()}:
+        response.headers["Vary"] = f"{vary}, Origin".strip(", ")
+
+
 @app.middleware("http")
 async def hosted_preview_boundary(request: Request, call_next):
     if not _HOSTED_MODE:
         return await call_next(request)
     path = request.url.path
     method = request.method.upper()
+    origin = request.headers.get("origin", "").rstrip("/")
+    requested_method = request.headers.get("access-control-request-method", "").upper()
+    if method == "OPTIONS":
+        if not _hosted_account_cors_allowed(origin, requested_method, path):
+            return _hosted_error("INVALID_ORIGIN", "The request origin is not allowed.")
+        response = Response(status_code=204)
+        _set_hosted_account_cors(response, origin)
+        response.headers["Access-Control-Allow-Methods"] = requested_method
+        response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        response.headers["Access-Control-Max-Age"] = "600"
+        return response
+    cross_origin_account_request = bool(origin and origin != _HOSTED_PUBLIC_ORIGIN)
+    if cross_origin_account_request and not _hosted_account_cors_allowed(origin, method, path):
+        return _hosted_error("INVALID_ORIGIN", "The request origin is not allowed.")
     if not hosted_route_allowed(method, path, query=request.url.query):
         return _hosted_error(
             "HOSTED_CAPABILITY_UNAVAILABLE",
             "This capability is available in the installed Blacknode Editor.",
         )
     if method in {"POST", "PUT", "PATCH", "DELETE"}:
-        origin = request.headers.get("origin", "").rstrip("/")
-        if origin != _HOSTED_PUBLIC_ORIGIN:
+        if origin != _HOSTED_PUBLIC_ORIGIN and not cross_origin_account_request:
             return _hosted_error("INVALID_ORIGIN", "The request origin is not allowed.")
     workspace_token = None
     context_token = None
@@ -381,6 +420,8 @@ async def hosted_preview_boundary(request: Request, call_next):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "no-referrer"
+    if cross_origin_account_request:
+        _set_hosted_account_cors(response, origin)
     return response
 
 

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -67,6 +67,14 @@ function loadDarkThemePreference() {
   }
 }
 
+function loadCloudAccountEntryRequest(): boolean {
+  try {
+    return new URLSearchParams(window.location.search).get('cloud') === 'account'
+  } catch {
+    return false
+  }
+}
+
 function loadUiTestPreference() {
   return true
 }
@@ -220,7 +228,7 @@ function WorkspaceApp() {
   const [activeRunMode, setActiveRunMode] = useState<'once' | 'live' | null>(null)
   const [executionTarget, setExecutionTarget] = useState<'local' | 'cloud'>('local')
   const [hostedPreview, setHostedPreview] = useState(false)
-  const [cloudPanelOpen, setCloudPanelOpen] = useState(false)
+  const [cloudPanelOpen, setCloudPanelOpen] = useState(loadCloudAccountEntryRequest)
   const [cloudJobPending, setCloudJobPending] = useState(false)
   const [cloudJob, setCloudJob] = useState<CloudJob | null>(null)
   const [cloudJobError, setCloudJobError] = useState('')
@@ -248,6 +256,17 @@ function WorkspaceApp() {
         if (status.hosted) setExecutionTarget('cloud')
       })
       .catch(() => undefined)
+  }, [])
+
+  useEffect(() => {
+    if (!loadCloudAccountEntryRequest()) return
+    const url = new URL(window.location.href)
+    url.searchParams.delete('cloud')
+    window.history.replaceState(
+      window.history.state,
+      '',
+      `${url.pathname}${url.search}${url.hash}`,
+    )
   }, [])
   const lastSimulationViewerUrl = useRef('')
   const simulationViewerMenuTriggerRef = useRef<HTMLButtonElement | null>(null)

--- a/tests/test_editor_cloud.py
+++ b/tests/test_editor_cloud.py
@@ -262,6 +262,47 @@ class EditorCloudTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["verified"])
 
+    def test_trusted_website_origin_can_use_only_account_routes(self):
+        website_origin = "https://blacknoderobotics.com"
+        client = TestClient(server.app)
+        with (
+            patch.object(server, "_HOSTED_MODE", True),
+            patch.object(server, "_HOSTED_ACCOUNT_ORIGINS", frozenset({website_origin})),
+            patch.dict(os.environ, {"BLACKNODE_CLOUD_URL": "https://cloud.blacknode.example"}),
+        ):
+            preflight = client.options(
+                "/cloud/auth/login",
+                headers={
+                    "Origin": website_origin,
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "content-type",
+                },
+            )
+            status_response = client.get(
+                "/cloud/status",
+                headers={"Origin": website_origin},
+            )
+            graph_response = client.get(
+                "/graph",
+                headers={"Origin": website_origin},
+            )
+            rejected = client.options(
+                "/cloud/auth/login",
+                headers={
+                    "Origin": "https://untrusted.example",
+                    "Access-Control-Request-Method": "POST",
+                },
+            )
+
+        self.assertEqual(preflight.status_code, 204)
+        self.assertEqual(preflight.headers["access-control-allow-origin"], website_origin)
+        self.assertEqual(preflight.headers["access-control-allow-credentials"], "true")
+        self.assertEqual(status_response.status_code, 200)
+        self.assertEqual(status_response.headers["access-control-allow-origin"], website_origin)
+        self.assertEqual(graph_response.status_code, 403)
+        self.assertEqual(graph_response.json()["detail"]["code"], "INVALID_ORIGIN")
+        self.assertEqual(rejected.status_code, 403)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed
- allow exact configured website origins to call hosted account status, registration, login, and logout
- keep graph, device, package, filesystem, and job APIs outside the cross-origin boundary
- retain Cloud credentials in the hosted Editor's HttpOnly server-side session
- support the direct `?cloud=account` account-panel entry as a fallback

## Why
The Blacknode Robotics website now presents an account dialog while reusing the hosted Editor login session. The previous hosted image supported only same-origin Editor login, so browser preflight requests from the website were rejected.

## Validation
- `python -m unittest discover -s tests -p "test_editor_cloud.py"`
- `python -m unittest discover -s tests -p "test_editor_hosted_mode.py"`
- `PYTHONPATH=python python -m unittest discover -s tests` (557 passed, 8 skipped)
- `npm run build` in `editor/`

## Release decision
Managed-device Runtime release: **No**. This changes only the hosted Editor UI/server boundary.