### PR TITLE
Fix hosted editor toolbar layout

### DIFF
--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -245,6 +245,8 @@ function WorkspaceApp() {
   const [simulationViewerHeight, setSimulationViewerHeight] = useState(loadSimulationViewerHeight)
   const [simulationViewerMenuOpen, setSimulationViewerMenuOpen] = useState(false)
   const [simulationViewerMenuPosition, setSimulationViewerMenuPosition] = useState({ top: 0, left: 0 })
+  const [hostedViewMenuOpen, setHostedViewMenuOpen] = useState(false)
+  const [hostedViewMenuPosition, setHostedViewMenuPosition] = useState({ top: 0, left: 0 })
   const [newtonWorkspace, setNewtonWorkspace] = useState<NewtonWorkspaceStatus | null>(null)
   const [newtonWorkspaceAvailable, setNewtonWorkspaceAvailable] = useState(false)
   const [newtonWorkspaceBusy, setNewtonWorkspaceBusy] = useState(false)
@@ -271,6 +273,8 @@ function WorkspaceApp() {
   const lastSimulationViewerUrl = useRef('')
   const simulationViewerMenuTriggerRef = useRef<HTMLButtonElement | null>(null)
   const simulationViewerMenuRef = useRef<HTMLDivElement | null>(null)
+  const hostedViewMenuTriggerRef = useRef<HTMLButtonElement | null>(null)
+  const hostedViewMenuRef = useRef<HTMLDivElement | null>(null)
   const updatePendingCloseName = useCallback((draftName: string) => {
     setPendingClose(current => current ? { ...current, draftName } : current)
   }, [])
@@ -541,6 +545,36 @@ function WorkspaceApp() {
       window.removeEventListener('scroll', positionMenu, true)
     }
   }, [simulationViewerMenuOpen])
+
+  useLayoutEffect(() => {
+    if (!hostedViewMenuOpen) return
+    const positionMenu = () => {
+      const trigger = hostedViewMenuTriggerRef.current
+      if (!trigger) return
+      const bounds = trigger.getBoundingClientRect()
+      const width = 210
+      setHostedViewMenuPosition({
+        top: bounds.bottom + 7,
+        left: Math.max(8, Math.min(window.innerWidth - width - 8, bounds.right - width)),
+      })
+    }
+    const closeOnOutsidePointer = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (hostedViewMenuTriggerRef.current?.contains(target)) return
+      if (hostedViewMenuRef.current?.contains(target)) return
+      setHostedViewMenuOpen(false)
+    }
+    positionMenu()
+    document.addEventListener('pointerdown', closeOnOutsidePointer)
+    window.addEventListener('resize', positionMenu)
+    window.addEventListener('scroll', positionMenu, true)
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsidePointer)
+      window.removeEventListener('resize', positionMenu)
+      window.removeEventListener('scroll', positionMenu, true)
+    }
+  }, [hostedViewMenuOpen])
 
   useEffect(() => {
     if (!activeSimulationViewer) {
@@ -1821,7 +1855,7 @@ function WorkspaceApp() {
       <div className="bn-editor-main" style={{ flex: 1, position: 'relative' }} onDrop={onDrop} onDragOver={onDragOver} onMouseMove={trackMouseFlowPos}>
 
         {/* ── top bar ── */}
-        <div className="bn-topbar" style={{
+        <div className={`bn-topbar${hostedPreview ? ' is-hosted-preview' : ''}`} style={{
           position: 'fixed', top: 0, left: leftRailW, right: 0, zIndex: 50,
           background: 'var(--panel)',
           borderBottom: '1px solid var(--line)',
@@ -1879,16 +1913,22 @@ function WorkspaceApp() {
             <div className="bn-topbar-group bn-topbar-run-group" aria-label="Run controls">
               <span className="bn-topbar-group-label">Run</span>
               {hostedPreview && <span className="bn-hosted-preview-badge">WEB PREVIEW</span>}
-              <select
-                className="bn-top-select"
-                value={executionTarget}
-                disabled={hostedPreview || onceRunActive || liveRunActive || cloudJobPending}
-                onChange={event => setExecutionTarget(event.target.value === 'cloud' ? 'cloud' : 'local')}
-                title="Choose where this graph executes"
-              >
-                {!hostedPreview && <option value="local">Local</option>}
-                <option value="cloud">Blacknode Cloud · L40S</option>
-              </select>
+              {hostedPreview ? (
+                <span className="bn-hosted-target-badge" title="Runs on Blacknode Cloud using one NVIDIA L40S">
+                  Cloud · L40S
+                </span>
+              ) : (
+                <select
+                  className="bn-top-select"
+                  value={executionTarget}
+                  disabled={onceRunActive || liveRunActive || cloudJobPending}
+                  onChange={event => setExecutionTarget(event.target.value === 'cloud' ? 'cloud' : 'local')}
+                  title="Choose where this graph executes"
+                >
+                  <option value="local">Local</option>
+                  <option value="cloud">Blacknode Cloud · L40S</option>
+                </select>
+              )}
               {executionTarget === 'cloud' && cloudAccountStatus?.credits && (
                 <span className="bn-cloud-credit-badge" title="Available Blacknode Cloud GPU-second credits">
                   {cloudAccountStatus.credits.available.toLocaleString()} credits
@@ -1939,6 +1979,98 @@ function WorkspaceApp() {
 
             <div className="bn-topbar-group bn-topbar-view-group" aria-label="View controls">
               <span className="bn-topbar-group-label">View</span>
+              {hostedPreview ? (
+                <>
+                  <button
+                    ref={hostedViewMenuTriggerRef}
+                    type="button"
+                    className="bn-top-button bn-hosted-view-menu-trigger"
+                    title="Canvas and appearance options"
+                    aria-haspopup="menu"
+                    aria-expanded={hostedViewMenuOpen}
+                    onClick={() => setHostedViewMenuOpen(open => !open)}
+                  >
+                    View <span aria-hidden="true">▾</span>
+                  </button>
+                  {hostedViewMenuOpen && createPortal(
+                    <div
+                      ref={hostedViewMenuRef}
+                      className="bn-simulation-viewer-menu-items bn-hosted-view-menu-items is-portal"
+                      role="menu"
+                      style={hostedViewMenuPosition}
+                    >
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={() => {
+                          void handleOrganize()
+                          setHostedViewMenuOpen(false)
+                        }}
+                      >
+                        Organize graph
+                      </button>
+                      <button
+                        type="button"
+                        role="menuitem"
+                        disabled={!serverOk || cookActive || refreshingCanvas}
+                        onClick={() => {
+                          void handleRefreshCanvas()
+                          setHostedViewMenuOpen(false)
+                        }}
+                      >
+                        {refreshingCanvas ? 'Refreshing…' : 'Refresh canvas'}
+                      </button>
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={() => {
+                          setIsDark(dark => !dark)
+                          setHostedViewMenuOpen(false)
+                        }}
+                      >
+                        {isDark ? 'Use light theme' : 'Use dark theme'}
+                      </button>
+                      <div className="bn-hosted-view-menu-divider" role="separator" />
+                      <button
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={nodeDensity === 'compact'}
+                        onClick={() => {
+                          setNodeDensity('compact')
+                          setHostedViewMenuOpen(false)
+                        }}
+                      >
+                        Compact nodes{nodeDensity === 'compact' ? ' ✓' : ''}
+                      </button>
+                      <button
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={nodeDensity === 'detailed'}
+                        onClick={() => {
+                          setNodeDensity('detailed')
+                          setHostedViewMenuOpen(false)
+                        }}
+                      >
+                        Detailed nodes{nodeDensity === 'detailed' ? ' ✓' : ''}
+                      </button>
+                      <div className="bn-hosted-view-menu-divider" role="separator" />
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className="is-danger"
+                        onClick={() => {
+                          void reset()
+                          setHostedViewMenuOpen(false)
+                        }}
+                      >
+                        Clear workflow
+                      </button>
+                    </div>,
+                    document.body,
+                  )}
+                </>
+              ) : (
+                <>
               <button
                 className={`bn-top-button bn-simulation-viewer-toggle${activeSimulationViewer && (simulationViewerVisible || simulationViewerDetached) ? ' is-visible' : ''}`}
                 type="button"
@@ -2129,6 +2261,8 @@ function WorkspaceApp() {
               >
                 Clear
               </button>
+                </>
+              )}
             </div>
 
             <button

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -11833,6 +11833,105 @@ html[data-ui-test="refined"] .bn-package-action-menu summary {
   white-space: nowrap;
 }
 
+.bn-hosted-target-badge {
+  color: var(--tx2);
+  font: 700 11px var(--font-mono);
+  white-space: nowrap;
+}
+
+/* Hosted editor: keep the account action in layout and move secondary view
+   actions into a menu so the 52px toolbar never collides or shows a scrollbar. */
+.bn-topbar.is-hosted-preview {
+  overflow: hidden;
+}
+
+.bn-topbar.is-hosted-preview .bn-brand {
+  width: 154px !important;
+  padding-inline: 12px !important;
+}
+
+.bn-topbar.is-hosted-preview .bn-topbar-controls {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-right: 0;
+  scrollbar-width: none;
+}
+
+.bn-topbar.is-hosted-preview .bn-topbar-controls::-webkit-scrollbar {
+  display: none;
+}
+
+html[data-ui-test="refined"] .bn-topbar.is-hosted-preview .bn-topbar-controls {
+  margin-right: 0;
+  padding: 5px 0 5px 8px !important;
+}
+
+html[data-ui-test="refined"] .bn-topbar.is-hosted-preview .bn-topbar-group {
+  box-sizing: border-box;
+  min-height: 42px;
+  padding: 0 10px;
+}
+
+html[data-ui-test="refined"] .bn-topbar.is-hosted-preview .bn-topbar-group-label {
+  display: none;
+}
+
+.bn-topbar.is-hosted-preview > .bn-cloud-account-trigger {
+  position: static;
+  z-index: auto;
+  flex: 0 0 auto;
+  margin: 0 10px 0 8px;
+}
+
+.bn-topbar.is-hosted-preview .bn-backend-label {
+  display: none;
+}
+
+.bn-hosted-view-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bn-hosted-view-menu-divider {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--line2);
+}
+
+.bn-hosted-view-menu-items button.is-danger {
+  color: var(--err);
+}
+
+.bn-hosted-view-menu-items button.is-danger:hover {
+  background: var(--err-soft);
+  color: var(--err);
+}
+
+@media (max-width: 1180px) {
+  .bn-topbar.is-hosted-preview .bn-brand {
+    width: 52px !important;
+    padding-inline: 10px !important;
+  }
+
+  .bn-topbar.is-hosted-preview .bn-brand span,
+  .bn-topbar.is-hosted-preview .bn-hosted-target-badge {
+    display: none;
+  }
+
+  html[data-ui-test="refined"] .bn-topbar.is-hosted-preview .bn-topbar-group {
+    padding-inline: 6px;
+  }
+}
+
+@media (max-width: 1050px) {
+  .bn-topbar.is-hosted-preview .bn-hosted-preview-badge {
+    display: none;
+  }
+}
+
 .bn-cloud-auth,
 .bn-cloud-account {
   margin-top: 24px;


### PR DESCRIPTION
## What changed
- keep the hosted Cloud account control inside the toolbar layout instead of overlaying it
- collapse hosted canvas and appearance actions into a compact View menu
- compact hosted-only labels and branding at narrower viewport widths
- preserve the existing 52px toolbar and local editor behavior

## Root cause
The account control used fixed positioning over a horizontally scrolling toolbar. The toolbar also reserved a hard-coded right padding, so controls could overlap the account action and the scrollbar consumed the already-tight vertical space.

## Impact
Hosted editor actions and account access remain visible without overlap at common desktop widths, including 1024px and 1440px.

## Validation
- `cd editor && npm run build`
- `git diff --check`
- hosted-mode visual checks at 1024x768 and 1440x900

## Managed Runtime release
Not required. This is an editor-only UI change and does not alter the managed-device bundle.