### PR TITLE
Add hosted account and newsletter surfaces

### DIFF
--- a/editor-server/hosted_mode.py
+++ b/editor-server/hosted_mode.py
@@ -91,6 +91,10 @@ def route_allowed(method: str, path: str, *, query: str = "") -> bool:
         return True
     if path == "/cloud/status" and method == "GET":
         return True
+    if path == "/cloud/account" and method == "PATCH":
+        return True
+    if path == "/cloud/newsletter/subscribe" and method == "POST":
+        return True
     if path in {
         "/cloud/auth/register",
         "/cloud/auth/login",

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -130,9 +130,11 @@ _HOSTED_ACCOUNT_ORIGINS = frozenset(
 )
 _HOSTED_ACCOUNT_CORS_METHODS = {
     "/cloud/status": frozenset({"GET"}),
+    "/cloud/account": frozenset({"PATCH"}),
     "/cloud/auth/register": frozenset({"POST"}),
     "/cloud/auth/login": frozenset({"POST"}),
     "/cloud/auth/logout": frozenset({"POST"}),
+    "/cloud/newsletter/subscribe": frozenset({"POST"}),
 }
 
 app = FastAPI(title="Blacknode Editor Server")
@@ -509,6 +511,21 @@ class CloudLoginReq(BaseModel):
 class CloudRegisterReq(CloudLoginReq):
     password: str = Field(min_length=10, max_length=200)
     display_name: str = Field(default="", max_length=100)
+
+
+class CloudUpdateAccountReq(BaseModel):
+    display_name: str = Field(min_length=1, max_length=100)
+
+
+class CloudNewsletterReq(BaseModel):
+    email: str = Field(min_length=3, max_length=254)
+    consent: bool
+    source: str = Field(
+        default="website",
+        min_length=1,
+        max_length=50,
+        pattern=r"^[a-z0-9_-]+$",
+    )
 
 
 class CloudEmailVerificationReq(BaseModel):
@@ -4316,6 +4333,31 @@ def cloud_status(request: Request, response: Response):
     return _cloud_status_payload(request, response)
 
 
+@app.patch("/cloud/account")
+def update_cloud_account(
+    req: CloudUpdateAccountReq,
+    request: Request,
+    response: Response,
+):
+    account = _cloud_user_call(
+        request,
+        "PATCH",
+        "/v1/account",
+        {"display_name": req.display_name},
+    )
+    credits = _cloud_user_call(request, "GET", "/v1/credits")
+    config = cloud_client.configuration()
+    response.headers["Cache-Control"] = "no-store"
+    return {
+        "configured": config.available,
+        "gpu": "NVIDIA L40S",
+        "url": config.base_url if config.available else "",
+        "authenticated": True,
+        "account": account,
+        "credits": credits,
+    }
+
+
 def _cloud_authenticate(
     request: Request,
     response: Response,
@@ -4372,6 +4414,16 @@ def login_cloud_account(req: CloudLoginReq, request: Request, response: Response
         response,
         "/v1/auth/login",
         {"email": req.email, "password": req.password},
+    )
+
+
+@app.post("/cloud/newsletter/subscribe")
+def subscribe_cloud_newsletter(req: CloudNewsletterReq):
+    return _cloud_call(
+        "POST",
+        "/v1/newsletter/subscriptions",
+        {"email": req.email, "consent": req.consent, "source": req.source},
+        allow_admin=False,
     )
 
 

--- a/tests/test_editor_cloud.py
+++ b/tests/test_editor_cloud.py
@@ -123,6 +123,39 @@ class EditorCloudTests(unittest.TestCase):
         self.assertIsNotNone(response.json()["account"]["email_verified_at"])
         self.assertEqual(response.json()["credits"]["locked"], 0)
 
+    def test_account_display_name_update_uses_registered_session(self):
+        client = self.authenticated_client()
+
+        def cloud_user_call(request, method, path, payload=None):
+            self.assertIsNotNone(request.cookies.get(server._CLOUD_SESSION_COOKIE))
+            if path == "/v1/account":
+                self.assertEqual((method, payload), ("PATCH", {"display_name": "Robotics Team"}))
+                return {
+                    "id": "user_123",
+                    "organization_id": "org_123",
+                    "email": "robot@example.com",
+                    "display_name": "Robotics Team",
+                    "created_at": datetime.now(UTC).isoformat(),
+                }
+            if path == "/v1/credits":
+                self.assertEqual(method, "GET")
+                return {"unit": "gpu-second", "balance": 7200, "reserved": 0, "available": 7200}
+            raise AssertionError(path)
+
+        with (
+            patch.dict(os.environ, {"BLACKNODE_CLOUD_URL": "https://cloud.blacknode.example"}),
+            patch.object(server, "_cloud_user_call", side_effect=cloud_user_call),
+        ):
+            response = client.patch(
+                "/cloud/account",
+                json={"display_name": "Robotics Team"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["account"]["display_name"], "Robotics Team")
+        self.assertEqual(response.json()["credits"]["available"], 7200)
+        self.assertEqual(response.headers["cache-control"], "no-store")
+
     def test_login_keeps_cloud_token_in_http_only_server_session(self):
         auth = {
             "token": "registered-user-cloud-token-0123456789",
@@ -262,6 +295,30 @@ class EditorCloudTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["verified"])
 
+    def test_newsletter_proxy_never_uses_admin_or_user_credentials(self):
+        def cloud_call(method, path, payload=None, **kwargs):
+            self.assertEqual((method, path), ("POST", "/v1/newsletter/subscriptions"))
+            self.assertEqual(
+                payload,
+                {"email": "reader@example.com", "consent": True, "source": "website"},
+            )
+            self.assertFalse(kwargs["allow_admin"])
+            self.assertNotIn("authorization", kwargs)
+            return {"subscribed": True}
+
+        with patch.object(server, "_cloud_call", side_effect=cloud_call):
+            response = TestClient(server.app).post(
+                "/cloud/newsletter/subscribe",
+                json={
+                    "email": "reader@example.com",
+                    "consent": True,
+                    "source": "website",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"subscribed": True})
+
     def test_trusted_website_origin_can_use_only_account_routes(self):
         website_origin = "https://blacknoderobotics.com"
         client = TestClient(server.app)
@@ -282,6 +339,22 @@ class EditorCloudTests(unittest.TestCase):
                 "/cloud/status",
                 headers={"Origin": website_origin},
             )
+            account_preflight = client.options(
+                "/cloud/account",
+                headers={
+                    "Origin": website_origin,
+                    "Access-Control-Request-Method": "PATCH",
+                    "Access-Control-Request-Headers": "content-type",
+                },
+            )
+            newsletter_preflight = client.options(
+                "/cloud/newsletter/subscribe",
+                headers={
+                    "Origin": website_origin,
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "content-type",
+                },
+            )
             graph_response = client.get(
                 "/graph",
                 headers={"Origin": website_origin},
@@ -299,6 +372,10 @@ class EditorCloudTests(unittest.TestCase):
         self.assertEqual(preflight.headers["access-control-allow-credentials"], "true")
         self.assertEqual(status_response.status_code, 200)
         self.assertEqual(status_response.headers["access-control-allow-origin"], website_origin)
+        self.assertEqual(account_preflight.status_code, 204)
+        self.assertEqual(account_preflight.headers["access-control-allow-methods"], "PATCH")
+        self.assertEqual(newsletter_preflight.status_code, 204)
+        self.assertEqual(newsletter_preflight.headers["access-control-allow-methods"], "POST")
         self.assertEqual(graph_response.status_code, 403)
         self.assertEqual(graph_response.json()["detail"]["code"], "INVALID_ORIGIN")
         self.assertEqual(rejected.status_code, 403)

--- a/tests/test_editor_hosted_mode.py
+++ b/tests/test_editor_hosted_mode.py
@@ -36,6 +36,8 @@ class EditorHostedModeTests(unittest.TestCase):
         self.assertTrue(route_allowed("POST", "/edges"))
         self.assertTrue(route_allowed("POST", "/templates/hello/load"))
         self.assertTrue(route_allowed("POST", "/cloud/auth/login"))
+        self.assertTrue(route_allowed("PATCH", "/cloud/account"))
+        self.assertTrue(route_allowed("POST", "/cloud/newsletter/subscribe"))
         self.assertTrue(route_allowed("POST", "/cloud/jobs"))
         self.assertTrue(route_allowed("GET", "/cloud/jobs/job_123/artifacts"))
         self.assertTrue(


### PR DESCRIPTION
## What changed
- add the hosted account display-name update surface
- proxy public newsletter consent submissions to Blacknode Cloud
- allow only configured website origins and methods in hosted mode

## Impact
The static Blacknode website can use Cloud account settings and newsletter signup without exposing admin or user bearer tokens.

## Checks
- focused hosted Cloud tests: 11 passed
- hosted allowlist tests: 3 passed
- full core suite: 559 passed, 8 skipped

## Managed Runtime release
No. This is editor-server orchestration and does not alter the managed-device bundle.