### PR TITLE
Add cloud provider settings and PPO viewer controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ need on-demand GPU compute. Cloud accounts use compute credits measured in
 GPU-seconds: a job reserves its runtime limit, charges measured GPU time, and
 returns progress, logs, metrics, and downloadable artifacts to the editor. The
 same workflow format runs locally, on paired devices, and in Blacknode Cloud.
+Signed-in users choose **Auto**, **NVIDIA**, or **Nebius** in the editor's Cloud
+account settings when those compute providers are configured. The workflow and
+job contract stay provider-neutral, and existing jobs keep their original
+provider if the account preference changes.
 Signup credits remain visible but locked until email verification succeeds;
 the editor and Cloud API both block job submission before verification.
 The hosted Editor preview and its cloud-only security boundary are documented

--- a/docs/hosted-preview.md
+++ b/docs/hosted-preview.md
@@ -4,7 +4,9 @@ The Blacknode hosted preview provides the visual workflow canvas and Blacknode
 Cloud execution at `https://app.blacknoderobotics.com`. Each browser receives
 an isolated, process-local graph workspace. The preview supports core node
 schemas, graph editing, templates, Cloud account access, GPU-second credits,
-job submission, progress, logs, and artifact downloads.
+compute-provider preference, job submission, progress, logs, and artifact
+downloads. Available accounts can choose Auto, NVIDIA, or Nebius in the Cloud
+account panel; Auto follows the Cloud service default.
 
 Set these values only on the hosted Editor server:
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -171,7 +171,7 @@ development:
 | `blacknode-cuda` | CUDA capability, image-processing, tensor-operation, and optional benchmark components backed by internal kernels. |
 | `blacknode-dataset` | Default recording, replay, and validation with optional evaluation, export, and repository publishing. |
 | `blacknode-drivers` | Selectively enabled concrete physical drivers; the `feetech` component provides inert bus configuration, read-only probing, and torque-safe bus primitives. |
-| `blacknode-isaac` | Direct closed-loop policy deployment using Isaac Sim articulation state, named RGB sensors, safety-gated targets, and runtime replay logs. |
+| `blacknode-isaac` | Direct closed-loop ACT and compatible PPO evaluation using Isaac Sim articulation state, semantic observations, safety-gated targets, and runtime replay logs. |
 | `blacknode-perception` | Camera, tracking, VLM, and spatial-perception components, organized as selectable components. |
 | `blacknode-robot` | Robot contracts, profiles, calibration, connected-device discovery and lifecycle, normalized telemetry, driver descriptors, and driver process launch. |
 | `blacknode-ros2` | Native DDS graph, topic, service, and diagnostic integration with optional rosbridge and managed processes. |

--- a/docs/robot-policy-training.md
+++ b/docs/robot-policy-training.md
@@ -61,12 +61,17 @@ validated before any physical policy test.
    managed PyTorch PPO job updates the policy. Start with the template defaults;
    lower `environment_count` to 64 for a lightweight functional check.
    Blacknode automatically opens the live simulation pane for one sampled arm.
-   The viewer shows the green reach target, orange end-effector trail, reward,
-   distance, episode step, and training update. Select another environment from
-   the viewer without restarting training.
-4. Use the node's **Stop** control for cooperative shutdown. Keep `resume=true`
+   Choose `viewer_provider=viser` for the target, trail, metrics, and environment
+   selector, or enable `blacknode-newton/viewer-ovrtx` in **Packages** and choose
+   `viewer_provider=ovrtx` for the RTX-rendered USD view.
+4. The final sampled arm remains visible after training completes while
+   Blacknode releases the replicated training batch. Press **Replay checkpoint**
+   to run the newest checkpoint deterministically in a one-arm Newton environment
+   at visible speed. Set `replay_episodes` to control the replay length, and use
+   **Close viewer** when inspection is complete.
+5. Use the node's **Stop** control for cooperative shutdown. Keep `resume=true`
    and the same output directory to continue from the newest atomic checkpoint.
-5. Run `PPOPolicyEvaluate` on the checkpoint, then export it with
+6. Run `PPOPolicyEvaluate` on the checkpoint, then export it with
    `PPOPolicyExport`. Evaluation and export retain a simulation-only safety
    contract.
 
@@ -179,11 +184,13 @@ command is published during preview.
 
 ### Closed-loop evaluation in Isaac Sim
 
-Open **Isaac Sim ACT Policy Deployment** to run the same artifact against live
-simulator observations before physical evaluation. Start `IsaacPolicyBridge`,
-then run `clients/isaac_policy_client.py` inside Isaac Sim with the articulation
-root and one USD camera prim for every policy camera name. The client sends
-measured joint positions, USD limits, and rendered RGB frames to Blacknode.
+Open **Isaac Sim ACT Policy Deployment** for an ACT artifact or **Isaac Sim PPO
+Evaluation** for a compatible SO-ARM101 reach artifact. Start
+`IsaacPolicyBridge`, then run `clients/isaac_policy_client.py` inside Isaac Sim.
+ACT maps the articulation root and one USD camera prim for every policy camera
+name. PPO maps the articulation root, task target, and end-effector prim; the
+client sends ordered joint positions and velocities, USD limits, and both xyz
+positions in metres.
 
 Set `IsaacPolicyRuntime.action=check`, then `start` for disarmed continuous
 inference. Use a separate `arm` action only after inspecting predictions. The
@@ -192,6 +199,14 @@ through USD limits, maximum velocity, maximum per-cycle step, workspace, and
 freshness checks. The Isaac client clamps against USD limits again before
 applying a target. `disarm`, `estop`, `takeover`, `stop`, **Stop All**, stale
 observations, and faults suppress future articulation commands.
+
+PPO artifacts exported by Blacknode carry a
+`blacknode.ppo-compatibility-contract` and can run in Newton or Isaac Sim. For
+the reverse direction, export an Isaac-trained deterministic actor as
+TorchScript with shape `[batch,21] -> [batch,6]`, then open **SO-ARM101 Isaac
+PPO Import**. `PPOPolicyImport` validates and packages it, and
+`PPOPolicyEvaluate` evaluates it in Newton. Joint order, observation fields,
+action scale, and the simulation-only safety contract must match exactly.
 
 ### 6. Arm, interrupt, and take over
 

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -514,7 +514,11 @@ class CloudRegisterReq(CloudLoginReq):
 
 
 class CloudUpdateAccountReq(BaseModel):
-    display_name: str = Field(min_length=1, max_length=100)
+    display_name: str | None = Field(default=None, min_length=1, max_length=100)
+    compute_provider_preference: str | None = Field(
+        default=None,
+        pattern=r"^(auto|nvcf|nebius)$",
+    )
 
 
 class CloudNewsletterReq(BaseModel):
@@ -2865,8 +2869,12 @@ def control_node(node_id: str, req: NodeControlReq):
         _session.graph._dirty.discard(node_id)
         return {"ok": True, "node_id": node_id, "outputs": outputs}
     if meta.get("type") == "PPOTraining":
-        if req.action not in {"status", "stop"}:
-            raise HTTPException(400, "PPOTraining direct controls support status or stop; use Run to start")
+        if req.action not in {"status", "stop", "close-viewer"}:
+            raise HTTPException(
+                400,
+                "PPOTraining direct controls support status, stop, or close-viewer; "
+                "use Run to start training or replay",
+            )
         control_fn = _runtime_callable("training", _RUNTIME_MODULES["training"], "control_ppo_training_job")
         if control_fn is None:
             raise HTTPException(503, "blacknode-training PPO runtime is not loaded")
@@ -4287,6 +4295,7 @@ def _cloud_status_payload(request: Request, response: Response) -> dict[str, Any
         "authenticated": False,
         "account": None,
         "credits": None,
+        "compute_providers": None,
     }
     session_id = request.cookies.get(_CLOUD_SESSION_COOKIE)
     session = _cloud_sessions.get(session_id)
@@ -4307,6 +4316,12 @@ def _cloud_status_payload(request: Request, response: Response) -> dict[str, Any
             authorization=session.token,
             allow_admin=False,
         )
+        compute_providers = _cloud_call(
+            "GET",
+            "/v1/compute/providers",
+            authorization=session.token,
+            allow_admin=False,
+        )
     except HTTPException as exc:
         if exc.status_code == 401:
             _cloud_sessions.pop(session_id)
@@ -4317,6 +4332,7 @@ def _cloud_status_payload(request: Request, response: Response) -> dict[str, Any
         authenticated=True,
         account=account,
         credits=credits,
+        compute_providers=compute_providers,
     )
     response.headers["Cache-Control"] = "no-store"
     return status_payload
@@ -4339,13 +4355,24 @@ def update_cloud_account(
     request: Request,
     response: Response,
 ):
+    payload = {
+        key: value
+        for key, value in {
+            "display_name": req.display_name,
+            "compute_provider_preference": req.compute_provider_preference,
+        }.items()
+        if value is not None
+    }
+    if not payload:
+        raise HTTPException(422, "Provide at least one Cloud account setting.")
     account = _cloud_user_call(
         request,
         "PATCH",
         "/v1/account",
-        {"display_name": req.display_name},
+        payload,
     )
     credits = _cloud_user_call(request, "GET", "/v1/credits")
+    compute_providers = _cloud_user_call(request, "GET", "/v1/compute/providers")
     config = cloud_client.configuration()
     response.headers["Cache-Control"] = "no-store"
     return {
@@ -4355,6 +4382,7 @@ def update_cloud_account(
         "authenticated": True,
         "account": account,
         "credits": credits,
+        "compute_providers": compute_providers,
     }
 
 
@@ -4379,6 +4407,12 @@ def _cloud_authenticate(
         authorization=session.token,
         allow_admin=False,
     )
+    compute_providers = _cloud_call(
+        "GET",
+        "/v1/compute/providers",
+        authorization=session.token,
+        allow_admin=False,
+    )
     return {
         "configured": config.available,
         "gpu": "NVIDIA L40S",
@@ -4386,6 +4420,7 @@ def _cloud_authenticate(
         "authenticated": True,
         "account": session.account,
         "credits": credits,
+        "compute_providers": compute_providers,
     }
 
 

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -307,7 +307,10 @@ function WorkspaceApp() {
           ? results.viewer as Record<string, unknown>
           : {}
         const url = String(results.viewer_url ?? status.viewer_url ?? viewer.viewer_url ?? '').trim()
-        if (!url || results.running !== true) continue
+        const viewerRunning = results.viewer_running === true
+          || status.viewer_running === true
+          || viewer.running === true
+        if (!url || (results.running !== true && !viewerRunning)) continue
         return {
           url,
           label: String(node.data.params?.run_id ?? 'SO-ARM101 PPO training'),
@@ -1848,6 +1851,12 @@ function WorkspaceApp() {
         .join(' '),
     }))
   }, [edges, hoveredEdgeId, hoveredPort, nodes])
+  const cloudProviderLabel = cloudAccountStatus?.compute_providers?.options.find(
+    option => option.id === (
+      cloudAccountStatus.account?.compute_provider_preference
+        ?? cloudAccountStatus.compute_providers?.preference
+    ),
+  )?.label ?? 'Auto'
   return (
     <div className="bn-editor-shell" style={{ display: 'flex', height: '100vh', background: 'var(--bg)' }}>
       <NodePalette />
@@ -1914,8 +1923,8 @@ function WorkspaceApp() {
               <span className="bn-topbar-group-label">Run</span>
               {hostedPreview && <span className="bn-hosted-preview-badge">WEB PREVIEW</span>}
               {hostedPreview ? (
-                <span className="bn-hosted-target-badge" title="Runs on Blacknode Cloud using one NVIDIA L40S">
-                  Cloud · L40S
+                <span className="bn-hosted-target-badge" title={`Runs on Blacknode Cloud via ${cloudProviderLabel} using one NVIDIA L40S`}>
+                  Cloud · {cloudProviderLabel} · L40S
                 </span>
               ) : (
                 <select
@@ -1926,7 +1935,7 @@ function WorkspaceApp() {
                   title="Choose where this graph executes"
                 >
                   <option value="local">Local</option>
-                  <option value="cloud">Blacknode Cloud · L40S</option>
+                  <option value="cloud">Blacknode Cloud · {cloudProviderLabel} · L40S</option>
                 </select>
               )}
               {executionTarget === 'cloud' && cloudAccountStatus?.credits && (
@@ -1943,7 +1952,7 @@ function WorkspaceApp() {
                 }}
                 disabled={!serverOk || liveRunActive || (!onceRunActive && nodes.length === 0)}
                 title={executionTarget === 'cloud'
-                  ? 'Submit this graph to Blacknode Cloud on one NVIDIA L40S.'
+                  ? `Submit this graph to Blacknode Cloud via ${cloudProviderLabel} on one NVIDIA L40S.`
                   : onceRunActive
                     ? 'Stop the current one-time evaluation'
                     : 'Evaluate the graph once. Live-capable nodes return one snapshot and do not keep streaming.'}

--- a/editor/src/api.ts
+++ b/editor/src/api.ts
@@ -1043,6 +1043,21 @@ export interface CloudStatus {
   authenticated: boolean
   account: CloudAccount | null
   credits: CloudCredits | null
+  compute_providers: CloudProviderCatalog | null
+}
+
+export type CloudProviderPreference = 'auto' | 'nvcf' | 'nebius'
+
+export interface CloudProviderOption {
+  id: CloudProviderPreference
+  label: string
+  gpu: string
+  available: boolean
+}
+
+export interface CloudProviderCatalog {
+  preference: CloudProviderPreference
+  options: CloudProviderOption[]
 }
 
 export interface HostedEditorStatus {
@@ -1058,6 +1073,7 @@ export interface CloudAccount {
   display_name: string
   created_at: string
   email_verified_at?: string | null
+  compute_provider_preference: CloudProviderPreference
 }
 
 export interface CloudCredits {
@@ -1720,6 +1736,10 @@ export const api = {
     }),
   loginCloudAccount: (email: string, password: string) =>
     req<CloudStatus>('POST', '/cloud/auth/login', { email, password }),
+  updateCloudAccount: (settings: {
+    display_name?: string
+    compute_provider_preference?: CloudProviderPreference
+  }) => req<CloudStatus>('PATCH', '/cloud/account', settings),
   verifyCloudEmail: (token: string) =>
     req<{ verified: boolean; account: CloudAccount }>('POST', '/cloud/auth/verify-email', { token }),
   logoutCloudAccount: () =>

--- a/editor/src/components/BlackNode.tsx
+++ b/editor/src/components/BlackNode.tsx
@@ -560,7 +560,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   const [manualMovePending, setManualMovePending] = useState<null | 'release' | 'monitor' | 'hold'>(null)
   const [calibrationPending, setCalibrationPending] = useState<null | 'start' | 'pause' | 'capture_home' | 'finish' | 'cancel'>(null)
   const [episodePending, setEpisodePending] = useState<null | 'start' | 'pause' | 'resume' | 'save' | 'stop' | 'discard'>(null)
-  const [trainingPending, setTrainingPending] = useState<null | 'start' | 'stop'>(null)
+  const [trainingPending, setTrainingPending] = useState<null | 'start' | 'stop' | 'replay' | 'close-viewer'>(null)
   const [datasetFolderPending, setDatasetFolderPending] = useState(false)
   const dashboardAutoFitDone = useRef(false)
   const streamFitDone = useRef(false)
@@ -980,6 +980,14 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     && edges.some(edge => edge.target === id && (edge.targetHandle === 'camera_stream' || edge.targetHandle === 'camera_streams'))
   const trainingRunning = isPolicyTraining && data.portResults?.running === true
   const trainingPhase = isPolicyTraining ? String(data.portResults?.phase ?? 'not started') : ''
+  const trainingViewer = isPolicyTraining && data.portResults?.viewer && typeof data.portResults.viewer === 'object'
+    ? data.portResults.viewer as Record<string, unknown>
+    : {}
+  const trainingViewerRunning = isPPOTraining && (
+    data.portResults?.viewer_running === true || trainingViewer.running === true
+  )
+  const trainingReplaying = isPPOTraining && trainingPhase === 'replaying'
+  const trainingCheckpoint = isPPOTraining ? String(data.portResults?.checkpoint ?? '').trim() : ''
   const trainingStopping = trainingRunning && trainingPhase === 'stopping'
   const trainingStep = isPolicyTraining
     ? Number(data.portResults?.[isPPOTraining ? 'update' : 'step'] ?? 0)
@@ -1506,12 +1514,21 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
     }
   }
 
-  const runTrainingAction = async (action: 'start' | 'stop') => {
+  const runTrainingAction = async (action: 'start' | 'stop' | 'replay' | 'close-viewer') => {
     if (trainingPending) return
     setTrainingPending(action)
     try {
       if (action === 'stop') {
         await controlNode(id, 'stop')
+      } else if (action === 'close-viewer') {
+        await controlNode(id, 'close-viewer')
+      } else if (action === 'replay') {
+        await updateParam(id, 'action', 'replay')
+        try {
+          await cookNode(id, 'dashboard')
+        } finally {
+          await updateParam(id, 'action', 'start')
+        }
       } else {
         await updateParam(id, 'action', 'start')
         await cookNode(id, 'dashboard')
@@ -1672,7 +1689,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
   }, [id, isViewer, updateNodeInternals])
 
   useEffect(() => {
-    if (!isPolicyTraining || !trainingRunning) return
+    if (!isPolicyTraining || (!trainingRunning && !trainingViewerRunning)) return
     let cancelled = false
     const refresh = async () => {
       try {
@@ -1688,7 +1705,7 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
       cancelled = true
       window.clearInterval(timer)
     }
-  }, [controlNode, id, isPolicyTraining, trainingRunning])
+  }, [controlNode, id, isPolicyTraining, trainingRunning, trainingViewerRunning])
 
   return (
     <NodeFrame
@@ -1743,14 +1760,14 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
           onMouseDown={e => e.stopPropagation()}
           style={{ padding: '7px 10px', borderBottom: '1px solid var(--line)', fontFamily: 'var(--font-ui)' }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}>
             <span style={{
               width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
               background: trainingRunning ? 'var(--ok)' : trainingPhase === 'failed' ? 'var(--err)' : 'var(--tx3)',
               boxShadow: trainingRunning ? '0 0 8px var(--ok)' : 'none',
             }} />
             <strong style={{ color: trainingRunning ? 'var(--ok)' : trainingPhase === 'failed' ? 'var(--err)' : 'var(--tx2)', fontSize: 12 }}>
-              {trainingStopping ? 'STOPPING' : trainingRunning ? 'TRAINING' : trainingPhase.toUpperCase()}
+              {trainingStopping ? 'STOPPING' : trainingReplaying ? 'REPLAYING' : trainingRunning ? 'TRAINING' : trainingPhase.toUpperCase()}
             </strong>
             <span style={{ marginLeft: 'auto', color: 'var(--tx2)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
               {trainingStep}/{trainingSteps || '—'} · {Math.round(trainingProgress * 100)}%
@@ -1765,6 +1782,30 @@ function BlackNode({ id, data, selected }: NodeProps<NodeData>) {
             >
               {trainingPending === 'stop' || trainingStopping ? 'Stopping…' : trainingPending === 'start' ? 'Starting…' : trainingRunning ? '■ Stop' : '▶ Start / resume'}
             </button>
+            {isPPOTraining && !trainingRunning && trainingCheckpoint && (
+              <button
+                disabled={Boolean(trainingPending)}
+                onClick={e => { e.stopPropagation(); void runTrainingAction('replay') }}
+                style={{
+                  ...driverBtn('var(--accent)', Boolean(trainingPending)),
+                  padding: '3px 8px', fontSize: 11,
+                }}
+              >
+                {trainingPending === 'replay' ? 'Opening replay…' : '↻ Replay checkpoint'}
+              </button>
+            )}
+            {isPPOTraining && !trainingRunning && trainingViewerRunning && (
+              <button
+                disabled={Boolean(trainingPending)}
+                onClick={e => { e.stopPropagation(); void runTrainingAction('close-viewer') }}
+                style={{
+                  ...driverBtn('var(--tx3)', Boolean(trainingPending)),
+                  padding: '3px 8px', fontSize: 11,
+                }}
+              >
+                {trainingPending === 'close-viewer' ? 'Closing…' : 'Close viewer'}
+              </button>
+            )}
           </div>
           <div style={{ height: 5, marginTop: 6, borderRadius: 3, overflow: 'hidden', background: 'var(--line2)' }}>
             <div style={{ width: `${trainingProgress * 100}%`, height: '100%', background: trainingPhase === 'failed' ? 'var(--err)' : 'var(--ok)', transition: 'width .25s ease' }} />

--- a/editor/src/components/CloudRunPanel.tsx
+++ b/editor/src/components/CloudRunPanel.tsx
@@ -6,6 +6,7 @@ import {
   type CloudCreditEntry,
   type CloudJob,
   type CloudJobEvent,
+  type CloudProviderPreference,
   type CloudStatus,
 } from '../api'
 
@@ -42,7 +43,7 @@ function bytes(value: number): string {
 
 function creditReason(entry: CloudCreditEntry): string {
   if (entry.reason === 'signup-credit') return 'Signup credits'
-  if (entry.reason === 'gpu-job') return 'NVIDIA GPU job'
+  if (entry.reason === 'gpu-job') return 'Cloud GPU job'
   return entry.reason.split('-').join(' ')
 }
 
@@ -69,6 +70,9 @@ export default function CloudRunPanel({
   const [confirmPassword, setConfirmPassword] = useState('')
   const [authPending, setAuthPending] = useState(false)
   const [authError, setAuthError] = useState('')
+  const [providerPending, setProviderPending] = useState(false)
+  const [providerError, setProviderError] = useState('')
+  const [providerPreference, setProviderPreference] = useState<CloudProviderPreference>('auto')
   const nextSeq = useRef(0)
 
   const refreshAccount = useCallback(async () => {
@@ -96,6 +100,14 @@ export default function CloudRunPanel({
       .then(page => setHistory(page.entries))
       .catch(cause => setAuthError(cause instanceof Error ? cause.message : String(cause)))
   }, [accountStatus?.authenticated, accountStatus?.account?.id, open])
+
+  useEffect(() => {
+    setProviderPreference(
+      accountStatus?.account?.compute_provider_preference
+        ?? accountStatus?.compute_providers?.preference
+        ?? 'auto',
+    )
+  }, [accountStatus?.account?.compute_provider_preference, accountStatus?.compute_providers?.preference])
 
   useEffect(() => {
     if (job && TERMINAL.has(job.status)) void refreshAccount()
@@ -208,6 +220,21 @@ export default function CloudRunPanel({
     }
   }
 
+  const updateProviderPreference = async (preference: CloudProviderPreference) => {
+    const previous = providerPreference
+    setProviderPreference(preference)
+    setProviderPending(true)
+    setProviderError('')
+    try {
+      onAccountStatus(await api.updateCloudAccount({ compute_provider_preference: preference }))
+    } catch (cause) {
+      setProviderPreference(previous)
+      setProviderError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setProviderPending(false)
+    }
+  }
+
   if (!open) return null
   const credits = accountStatus?.credits
   const account = accountStatus?.account
@@ -218,6 +245,9 @@ export default function CloudRunPanel({
     : Math.max(credits?.locked ?? 0, credits?.available ?? 0)
   const activeJob = job && !TERMINAL.has(job.status)
   const visibleJob = view === 'job' ? job : null
+  const providerOptions = accountStatus?.compute_providers?.options ?? []
+  const selectedProvider = providerOptions.find(option => option.id === providerPreference)
+  const providerLabel = selectedProvider?.label ?? 'Auto'
 
   return (
     <div className="bn-cloud-run-backdrop" role="presentation">
@@ -231,7 +261,7 @@ export default function CloudRunPanel({
         </header>
 
         {(pending || (!accountStatus && !error)) && <div className="bn-cloud-run-message">Connecting to Blacknode Cloud…</div>}
-        {(error || pollError || authError) && <div className="bn-cloud-run-error">{error || pollError || authError}</div>}
+        {(error || pollError || authError || providerError) && <div className="bn-cloud-run-error">{error || pollError || authError || providerError}</div>}
         {!pending && accountStatus && !accountStatus.configured && !error && (
           <div className="bn-cloud-run-error">Blacknode Cloud is not configured on this editor server.</div>
         )}
@@ -304,6 +334,27 @@ export default function CloudRunPanel({
                 <div><span>Reserved</span><strong>{credits.reserved.toLocaleString()}</strong></div>
                 <div><span>Balance</span><strong>{credits.balance.toLocaleString()}</strong></div>
               </div>
+              <label className="bn-cloud-provider-setting">
+                <span>Cloud compute provider</span>
+                <select
+                  value={providerPreference}
+                  disabled={providerPending}
+                  onChange={event => void updateProviderPreference(event.target.value as CloudProviderPreference)}
+                >
+                  {providerOptions.map(option => (
+                    <option key={option.id} value={option.id} disabled={!option.available}>
+                      {option.label}{option.available ? '' : ' (unavailable)'}
+                    </option>
+                  ))}
+                </select>
+                <small>
+                  {providerPending
+                    ? 'Saving provider preference…'
+                    : providerPreference === 'auto'
+                      ? 'Auto uses the Cloud service default provider.'
+                      : `New jobs will use ${providerLabel}. Existing jobs stay with their original provider.`}
+                </small>
+              </label>
               <small>Credits are GPU-seconds. This job reserves its runtime limit and charges measured GPU time.</small>
               {!emailVerified && (
                 <div className="bn-cloud-verification-lock" role="status">
@@ -315,7 +366,7 @@ export default function CloudRunPanel({
                 </div>
               )}
               <button type="button" className="is-primary bn-cloud-submit" onClick={onRun} disabled={pending || !emailVerified}>
-                {emailVerified ? 'Run workflow on NVIDIA L40S' : 'Email verification required'}
+                {emailVerified ? `Run workflow via ${providerLabel} · NVIDIA L40S` : 'Email verification required'}
               </button>
             </div>
 

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -12054,6 +12054,36 @@ html[data-ui-test="refined"] .bn-topbar.is-hosted-preview .bn-topbar-group-label
   line-height: 1.45;
 }
 
+.bn-cloud-provider-setting {
+  display: grid;
+  gap: 6px;
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px solid var(--line2);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 88%, var(--accent) 12%);
+}
+
+.bn-cloud-provider-setting > span {
+  color: var(--tx1);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.bn-cloud-provider-setting select {
+  width: 100%;
+  padding: 8px 10px;
+  color: var(--tx1);
+  border: 1px solid var(--line2);
+  border-radius: 6px;
+  background: var(--panel);
+}
+
+.bn-cloud-provider-setting small {
+  color: var(--tx3);
+  line-height: 1.45;
+}
+
 .bn-cloud-account > header strong,
 .bn-cloud-account > header span {
   display: block;

--- a/editor/src/store.ts
+++ b/editor/src/store.ts
@@ -718,6 +718,28 @@ function clearRuntimeNodeData(data: NodeData): NodeData {
       },
     }
   }
+  if (data.type === 'PPOTraining') {
+    const previousStatus = data.portResults?.status
+    const status = previousStatus && typeof previousStatus === 'object' && !Array.isArray(previousStatus)
+      ? previousStatus as Record<string, unknown>
+      : {}
+    return {
+      ...base,
+      portResults: {
+        ...stoppedResults,
+        viewer_running: false,
+        viewer_url: '',
+        viewer: { running: false, viewer_url: '', error: '' },
+        status: {
+          ...status,
+          service_running: false,
+          viewer_running: false,
+          viewer_url: '',
+          viewer: { running: false, viewer_url: '', error: '' },
+        },
+      },
+    }
+  }
   if (VIEWER_NODE_TYPES.has(data.type)) {
     const previousStatus = data.portResults?.status
     const status = previousStatus && typeof previousStatus === 'object' && !Array.isArray(previousStatus)
@@ -1774,14 +1796,27 @@ export const useStore = create<Store>((set, get) => ({
             armed: managedRun.armed === true,
             phase: String(managedRun.phase ?? ''),
             viewer_url: String(managedRun.viewer_url ?? ''),
+            viewer_running: managedRun.viewer_running === true,
+            viewer: managedRun.viewer && typeof managedRun.viewer === 'object'
+              ? managedRun.viewer
+              : {},
             session: managedRun,
             positions: managedRun.positions ?? managedRun.positions_radians ?? {},
             positions_radians: managedRun.positions_radians ?? {},
             rigid_bodies: managedRun.rigid_body_positions_m ?? {},
+            ...(node.data.type === 'PPOTraining' ? {
+              status: managedRun,
+              update: Number(managedRun.update ?? 0),
+              checkpoint: String(managedRun.checkpoint ?? ''),
+              mode: String(managedRun.mode ?? 'training'),
+              replay_episode: Number(managedRun.replay_episode ?? 0),
+              replay_episodes: Number(managedRun.replay_episodes ?? 0),
+            } : {}),
           } : {}
           if (Object.keys(liveOutputs).length === 0 && Object.keys(managedOutputs).length === 0) {
             const runtimeWasActive = Boolean(
               node.data.portResults?.running === true
+              || node.data.portResults?.viewer_running === true
               || node.data.portResults?.live === true
               || node.data.portResults?.streaming === true
               || node.data.portResults?.launched === true

--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -948,14 +948,15 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                         "PPOTraining",
                         "PPOCheckpointInspect",
                         "PPOPolicyEvaluate",
-                        "PPOPolicyExport"
+                        "PPOPolicyExport",
+                        "PPOPolicyImport"
                     ],
                     "dependencies": {
                         "requires": [
                             {
                                 "package": "blacknode-newton",
                                 "component": "runtime",
-                                "version": ">=0.1,<1"
+                                "version": ">=0.1.3,<1"
                             }
                         ]
                     }
@@ -972,6 +973,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "PPOCheckpointInspect",
                 "PPOPolicyEvaluate",
                 "PPOPolicyExport",
+                "PPOPolicyImport",
                 "PPOTraining",
                 "PolicyArtifactLoad",
                 "TrainingDatasetCheck"
@@ -990,7 +992,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                             {
                                 "package": "blacknode-motion",
                                 "component": "policy",
-                                "version": ">=0.1.0,<1.0.0"
+                                "version": ">=0.6.1,<1.0.0"
                             }
                         ]
                     }
@@ -1037,7 +1039,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 }
             },
             "git_url": "https://github.com/temiroff/blacknode-isaac.git",
-            "description": "Closed-loop policy deployment for Isaac Sim articulations and named RGB sensors.",
+            "description": "Closed-loop ACT and compatible PPO policy evaluation for Isaac Sim articulations and semantic observations.",
             "node_types": [
                 "IsaacPolicyBridge",
                 "IsaacPolicyRuntime",

--- a/tests/test_editor_cloud.py
+++ b/tests/test_editor_cloud.py
@@ -47,6 +47,17 @@ class EditorCloudTests(unittest.TestCase):
         client.cookies.set(server._CLOUD_SESSION_COOKIE, session_id)
         return client
 
+    @staticmethod
+    def provider_catalog(preference="auto"):
+        return {
+            "preference": preference,
+            "options": [
+                {"id": "auto", "label": "Auto", "gpu": "NVIDIA L40S", "available": True},
+                {"id": "nvcf", "label": "NVIDIA", "gpu": "NVIDIA L40S", "available": True},
+                {"id": "nebius", "label": "Nebius", "gpu": "NVIDIA L40S", "available": True},
+            ],
+        }
+
     def test_cloud_status_reports_configuration_without_exposing_key(self):
         with patch.dict(
             os.environ,
@@ -114,6 +125,8 @@ class EditorCloudTests(unittest.TestCase):
                     "available": 7200,
                     "locked": 0,
                 }
+            if path == "/v1/compute/providers":
+                return self.provider_catalog()
             raise AssertionError(path)
 
         with patch.object(server, "_cloud_call", side_effect=cloud_call):
@@ -140,6 +153,9 @@ class EditorCloudTests(unittest.TestCase):
             if path == "/v1/credits":
                 self.assertEqual(method, "GET")
                 return {"unit": "gpu-second", "balance": 7200, "reserved": 0, "available": 7200}
+            if path == "/v1/compute/providers":
+                self.assertEqual(method, "GET")
+                return self.provider_catalog()
             raise AssertionError(path)
 
         with (
@@ -154,7 +170,47 @@ class EditorCloudTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["account"]["display_name"], "Robotics Team")
         self.assertEqual(response.json()["credits"]["available"], 7200)
+        self.assertEqual(response.json()["compute_providers"]["preference"], "auto")
         self.assertEqual(response.headers["cache-control"], "no-store")
+
+    def test_account_compute_provider_update_forwards_nebius_preference(self):
+        client = self.authenticated_client()
+
+        def cloud_user_call(_request, method, path, payload=None):
+            if path == "/v1/account":
+                self.assertEqual(
+                    (method, payload),
+                    ("PATCH", {"compute_provider_preference": "nebius"}),
+                )
+                return {
+                    "id": "user_123",
+                    "organization_id": "org_123",
+                    "email": "robot@example.com",
+                    "display_name": "Robot Builder",
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "compute_provider_preference": "nebius",
+                }
+            if path == "/v1/credits":
+                return {"unit": "gpu-second", "balance": 7200, "reserved": 0, "available": 7200}
+            if path == "/v1/compute/providers":
+                return self.provider_catalog("nebius")
+            raise AssertionError(path)
+
+        with (
+            patch.dict(os.environ, {"BLACKNODE_CLOUD_URL": "https://cloud.blacknode.example"}),
+            patch.object(server, "_cloud_user_call", side_effect=cloud_user_call),
+        ):
+            response = client.patch(
+                "/cloud/account",
+                json={"compute_provider_preference": "nebius"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["account"]["compute_provider_preference"],
+            "nebius",
+        )
+        self.assertEqual(response.json()["compute_providers"]["preference"], "nebius")
 
     def test_login_keeps_cloud_token_in_http_only_server_session(self):
         auth = {
@@ -176,6 +232,9 @@ class EditorCloudTests(unittest.TestCase):
             if path == "/v1/credits":
                 self.assertEqual(kwargs["authorization"], auth["token"])
                 return {"unit": "gpu-second", "balance": 7200, "reserved": 0, "available": 7200}
+            if path == "/v1/compute/providers":
+                self.assertEqual(kwargs["authorization"], auth["token"])
+                return self.provider_catalog()
             raise AssertionError(path)
 
         with (

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -849,12 +849,18 @@ class EditorRuntimeTests(unittest.TestCase):
                 client = TestClient(server.app)
                 status = client.post(f"/nodes/{node_id}/control", json={"action": "status"})
                 stopped = client.post(f"/nodes/{node_id}/control", json={"action": "stop"})
+                closed = client.post(f"/nodes/{node_id}/control", json={"action": "close-viewer"})
             self.assertEqual(status.status_code, 200)
             self.assertEqual(status.json()["outputs"]["update"], 7)
             self.assertEqual(status.json()["outputs"]["viewer_url"], "http://127.0.0.1:8091")
             self.assertEqual(stopped.status_code, 200)
             self.assertEqual(stopped.json()["outputs"]["phase"], "stopped")
-            self.assertEqual(calls, [("so101-test", "status"), ("so101-test", "stop")])
+            self.assertEqual(closed.status_code, 200)
+            self.assertEqual(
+                calls,
+                [("so101-test", "status"), ("so101-test", "stop"),
+                 ("so101-test", "close-viewer")],
+            )
             self.assertNotIn(node_id, server._session.graph._dirty)
             prepare_cook.assert_not_called()
         finally:

--- a/tests/test_editor_simulation_viewer.py
+++ b/tests/test_editor_simulation_viewer.py
@@ -45,11 +45,21 @@ def test_newton_viewer_floats_inside_editor_without_recreating_its_iframe():
 
 def test_newton_managed_runtime_state_supplies_and_clears_the_viewer_url():
     store = (ROOT / "editor" / "src" / "store.ts").read_text(encoding="utf-8")
+    app = (ROOT / "editor" / "src" / "App.tsx").read_text(encoding="utf-8")
+    node = (
+        ROOT / "editor" / "src" / "components" / "BlackNode.tsx"
+    ).read_text(encoding="utf-8")
 
     assert "record.runtime === 'newton'" in store
     assert "viewer_url: String(managedRun.viewer_url ?? '')" in store
+    assert "viewer_running: managedRun.viewer_running === true" in store
+    assert "data.type === 'PPOTraining'" in store
     assert "node.data.type !== 'NewtonSimulation'" in store
     assert "viewer_url: ''" in store
+    assert "status.viewer_running === true" in app
+    assert "↻ Replay checkpoint" in node
+    assert "Close viewer" in node
+    assert "controlNode(id, 'close-viewer')" in node
 
 
 def test_open_newton_scene_uses_the_in_editor_file_browser():

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -291,12 +291,13 @@ def test_core_index_maps_official_node_types_to_git_packages():
     assert payload["nodes"]["ACTPolicyExport"]["package"] == "blacknode-training"
     assert payload["nodes"]["ACTPolicyReplay"]["package"] == "blacknode-training"
     assert payload["nodes"]["PPOTraining"]["package"] == "blacknode-training"
+    assert payload["nodes"]["PPOPolicyImport"]["package"] == "blacknode-training"
     assert payload["packages"]["blacknode-training"]["components"]["reinforcement-learning"]["dependencies"] == {
         "requires": [
             {
                 "package": "blacknode-newton",
                 "component": "runtime",
-                "version": ">=0.1,<1",
+                "version": ">=0.1.3,<1",
             }
         ]
     }
@@ -310,6 +311,12 @@ def test_core_index_maps_official_node_types_to_git_packages():
         "git_url": "https://github.com/temiroff/blacknode-isaac.git",
     }
     assert payload["nodes"]["IsaacPolicyRuntime"]["package"] == "blacknode-isaac"
+    assert payload["packages"]["blacknode-isaac"]["components"]["core"]["dependencies"] == {
+        "requires": [{
+            "package": "blacknode-motion", "component": "policy",
+            "version": ">=0.6.1,<1.0.0",
+        }]
+    }
 
 
 def test_installed_package_manifest_maps_new_node_types_without_core_edit():


### PR DESCRIPTION
## What changed

- add the Cloud account setting for Auto, NVIDIA, and Nebius compute selection
- proxy provider catalog and account preference through editor-server
- keep Cloud workflow submissions provider-neutral
- improve PPO training viewer lifecycle, checkpoint replay, and close-viewer controls
- update package catalog mappings and policy-training documentation

## Why

The editor needs a user-facing compute preference backed by the merged Cloud API, while the PPO workflow needs durable viewer and replay controls for training inspection.

## Dependency

- Cloud API support merged first in temiroff/blacknode-cloud#30

## Validation

- public Python suite — 560 passed, 8 skipped
- `python tests/test_editor_cloud.py` — 12 passed
- `npm run build` in `editor/`
- `git diff --check`

## Release impact

Editor/editor-server/catalog release only. No managed-device Runtime release is required because the device bundle and runtime service contract are unchanged. Deploy the merged Cloud API image before the hosted editor-server/editor images.