### PR TITLE
Index ROSOrin mapping and navigation nodes

### DIFF
--- a/python/blacknode/package_index.py
+++ b/python/blacknode/package_index.py
@@ -198,6 +198,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                             "default": False,
                             "node_types": [
                                 "BaseSafetyGate",
+                                "NavigateTo",
+                                "NavigationSession",
                                 "ROS2BaseMove",
                                 "ROS2BaseStop",
                                 "ROS2LaserScanCheck",
@@ -205,6 +207,11 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                             ],
                             "dependencies": {
                                 "requires": [
+                                    {
+                                        "package": "blacknode-ros2",
+                                        "component": "core",
+                                        "version": ">=0.6.2,<1.0.0"
+                                    },
                                     {
                                         "package": "blacknode-ros2",
                                         "component": "rosbridge",
@@ -270,6 +277,8 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
             "node_types": [
                 "BaseSafetyGate",
                 "JointMotionProfile",
+                "NavigateTo",
+                "NavigationSession",
                 "PolicyRuntime",
                 "PolicySafetyGate",
                 "ROS2BaseMove",
@@ -780,7 +789,23 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "slam": {
                     "name": "slam",
                     "default": False,
-                    "node_types": []
+                    "node_types": [],
+                    "adapters": {
+                        "ros2": {
+                            "name": "ros2",
+                            "default": False,
+                            "node_types": ["MapEnvironment"],
+                            "dependencies": {
+                                "requires": [
+                                    {
+                                        "package": "blacknode-ros2",
+                                        "component": "core",
+                                        "version": ">=0.6.2,<1.0.0"
+                                    }
+                                ]
+                            }
+                        }
+                    }
                 },
                 "localization": {
                     "name": "localization",
@@ -815,6 +840,7 @@ _CORE_PACKAGES: dict[str, dict[str, Any]] = {
                 "FramePrompt",
                 "LaserScanProcessor",
                 "LiDAR",
+                "MapEnvironment",
                 "IMUProcessor",
                 "IMU",
                 "IMUViewer",


### PR DESCRIPTION
## What changed

- Index MapEnvironment under the perception SLAM ROS 2 adapter.
- Index NavigationSession and NavigateTo under the motion ROS 2 adapter.
- Declare the blacknode-ros2 0.6.2 dependency.

## Why

The editor package resolver needs the new ROSOrin mapping and navigation node ownership metadata.

## Impact

The editor can resolve and install the extension packages required by the two ROSOrin workflows.

## Validation

560 core tests passed, 10 skipped. The change was prepared in a clean worktree so unrelated local VLA work was not included.