### PR TITLE
Recognize snapshot Runtime during Hardware install

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -2095,7 +2095,10 @@ fi
 runtime_dir="$organized_runtime_dir"
 hardware_dir="$organized_hardware_dir"
 layout="organized"
-if [[ ! -d "$runtime_dir/.git" || ! -f "$runtime_dir/pyproject.toml" ]]; then
+valid_runtime() {
+  [[ -f "$1/pyproject.toml" && -f "$1/blacknode_runtime/__init__.py" ]]
+}
+if ! valid_runtime "$runtime_dir"; then
   runtime_dir="$legacy_runtime_dir"
   hardware_dir="$legacy_hardware_dir"
   layout="legacy"
@@ -2106,7 +2109,7 @@ case "$hardware_dir" in
   "$HOME/blacknode-hardware-instances/"*) ;;
   *) echo "Unsafe Hardware directory."; exit 2 ;;
 esac
-[[ -d "$runtime_dir/.git" && -f "$runtime_dir/pyproject.toml" ]] || {
+valid_runtime "$runtime_dir" || {
   echo "No valid Runtime installation was found. Checked:"
   echo "  $organized_runtime_dir"
   echo "  $legacy_runtime_dir"

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -1168,6 +1168,14 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertIn('legacy_hardware_dir="$HOME/blacknode-hardware"', uploaded[0])
         self.assertIn('layout="legacy"', uploaded[0])
         self.assertIn(
+            '[[ -f "$1/pyproject.toml" && -f "$1/blacknode_runtime/__init__.py" ]]',
+            uploaded[0],
+        )
+        self.assertNotIn(
+            '[[ -d "$runtime_dir/.git" && -f "$runtime_dir/pyproject.toml" ]]',
+            uploaded[0],
+        )
+        self.assertIn(
             "git clone https://github.com/temiroff/blacknode-robot.git",
             uploaded[0],
         )


### PR DESCRIPTION
Fixes Install Hardware for PC-assisted managed Runtime snapshots, which intentionally have no .git directory. Runtime validity now uses the required pyproject.toml and blacknode_runtime package files, preserving the existing installation in place.\n\nVerification: all 141 device/editor tests passed.\n\nManaged Runtime release: not required; this is an editor-server SSH installer correction.