### PR TITLE
Accept PC-assisted Hardware snapshots during robot discovery

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -1887,8 +1887,11 @@ target_private="$target/.blacknode-hardware"
 legacy_private="$legacy/.blacknode-hardware"
 marker="__BLACKNODE_HARDWARE_ADOPTION__="
 
-valid_target_checkout() {
-  [[ -d "$1/.git" && -f "$1/pyproject.toml" ]] \
+valid_target_package() {
+  [[ -f "$1/pyproject.toml" \
+    && -f "$1/blacknode_robot/__init__.py" \
+    && -f "$1/configure.sh" \
+    && -f "$1/install-service.sh" ]] \
     && grep -Eq '^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']blacknode-robot["'"'"'][[:space:]]*$' \
       "$1/pyproject.toml"
 }
@@ -1899,7 +1902,7 @@ valid_legacy_checkout() {
       "$1/pyproject.toml"
 }
 
-valid_target_checkout "$target" || {
+valid_target_package "$target" || {
   echo "The organized Hardware package is missing or invalid: $target" >&2
   exit 4
 }
@@ -2068,7 +2071,10 @@ if [[ "$instance" == "default" ]]; then
   service_instance=""
   legacy="$HOME/blacknode-hardware"
 fi
-[[ -d "$target/.git" && -f "$target/pyproject.toml" ]] \
+[[ -f "$target/pyproject.toml" \
+  && -f "$target/blacknode_robot/__init__.py" \
+  && -f "$target/configure.sh" \
+  && -f "$target/install-service.sh" ]] \
   && grep -Eq '^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']blacknode-(robot|hardware)["'"'"'][[:space:]]*$' \
     "$target/pyproject.toml" || {
   echo "The organized Hardware package is missing or invalid: $target" >&2

--- a/tests/test_editor_devices.py
+++ b/tests/test_editor_devices.py
@@ -1411,8 +1411,11 @@ class EditorDeviceApiTests(unittest.TestCase):
         self.assertNotIn("ssh-password", uploaded[0])
         self.assertIn('target="$HOME/Blacknode/devices/default/hardware"', uploaded[0])
         self.assertIn('legacy="$HOME/blacknode-hardware"', uploaded[0])
-        self.assertIn("valid_target_checkout", uploaded[0])
+        self.assertIn("valid_target_package", uploaded[0])
         self.assertIn("valid_legacy_checkout", uploaded[0])
+        self.assertIn('"$1/blacknode_robot/__init__.py"', uploaded[0])
+        target_validation = uploaded[0].split("valid_legacy_checkout()", 1)[0]
+        self.assertNotIn('"$1/.git"', target_validation)
         self.assertIn("blacknode-robot", uploaded[0])
         self.assertIn("blacknode-hardware", uploaded[0])
         self.assertIn('cp -a -- "$legacy_private" "$temporary_private"', uploaded[0])
@@ -1489,6 +1492,8 @@ class EditorDeviceApiTests(unittest.TestCase):
             'target="$HOME/Blacknode/devices/$instance/hardware"',
             uploaded[0],
         )
+        self.assertIn('"$target/blacknode_robot/__init__.py"', uploaded[0])
+        self.assertNotIn('[[ -d "$target/.git"', uploaded[0])
         self.assertIn(
             '[[ "$directory" == "$legacy" ]] || continue',
             uploaded[0],


### PR DESCRIPTION
## Outcome

Robot discovery and connected-robot configuration now validate PC-assisted Robot Hardware snapshots by their package module and operational scripts. They no longer require the organized Hardware directory to contain Git metadata. Legacy Hardware migration continues to require a recognized legacy Git checkout.

This fixes the post-install error on managed PC-assisted devices:

The organized Hardware package is missing or invalid

## Verification

- Live editor state confirms the Jetson has /home/ubuntu/Blacknode/devices/default/hardware, delivery_mode=pc_assisted, and stack_mode=isolated
- python -m pytest tests/test_editor_devices.py -q — 142 passed
- $env:PYTHONPATH=(Join-Path (Get-Location) 'python'); python -m unittest discover -s tests — 566 passed, 8 skipped
- git diff --check

## Managed Runtime release decision

No Runtime release is required. This is editor-server SSH discovery/configuration orchestration behind the existing **Find and attach robots** action and does not alter the managed Runtime bundle or service contract.