### PR TITLE
Use provider-neutral Hardware configuration error

### DIFF
--- a/editor-server/device_installer.py
+++ b/editor-server/device_installer.py
@@ -2289,7 +2289,7 @@ printf '__BLACKNODE_HARDWARE_CONFIGURATION__={"configured":%d}\n' "$configured"
             ) from exc
         if configured < 1:
             raise DeviceInstallError(
-                "No connected serial robots were configured."
+                "No connected robot Hardware provider was configured."
             )
         return {"ok": True, "configured": configured}
     finally:


### PR DESCRIPTION
Uses the generic Hardware-provider wording after existing ROS 2 configuration. No managed Runtime release is required because this is editor-server-only error reporting. The surrounding configuration path is covered by the 142 passing editor device tests in PR #158.