### PR TITLE
Pin runtime 0.4.15 device sources

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,14 +3,14 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "439730445746acdb5cd583888832f4dd73563825"
+    "commit": "15104da6f3cba24f502a0683772815860bd1e01b"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "4eae24078d4660ca83736e4dc29405fb7de65788"
+    "commit": "85a4bb87bf9d4658dd00e893cda93197d50ccf90"
   },
   "hardware": {
     "repository": "temiroff/blacknode-robot",
-    "commit": "7528d637fe661bc628d86765c65d82b2a0d5050a"
+    "commit": "027bdd6b1ee966823e5f8349e6527ead9862fc96"
   }
 }


### PR DESCRIPTION
Pins the merged Runtime 0.4.15 release (15104da6f3cba24f502a0683772815860bd1e01b), merged core robot-viewer release (85a4bb87bf9d4658dd00e893cda93197d50ccf90), and current merged hardware safety release (027bdd6b1ee966823e5f8349e6527ead9862fc96) for managed-device delivery. Tests: python -m pytest tests/test_editor_devices.py (143 passed); python -m pytest (834 passed, 8 skipped). Runtime release decision: Yes, completed by blacknode-runtime PR #29; this lock publishes the merged sources as Latest.