### PR TITLE
feat: harden operator apps and release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Run tests
         run: python -m pytest
 
+      - name: Validate managed-device source pins
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/update_device_source_lock.py --verify-merged
+
   editor:
     name: Editor build
     runs-on: ubuntu-latest
@@ -53,6 +58,18 @@ jobs:
       - name: Install editor dependencies
         working-directory: editor
         run: npm ci
+
+      - name: Test editor
+        working-directory: editor
+        run: npm test
+
+      - name: Install Chromium
+        working-directory: editor
+        run: npx playwright install --with-deps chromium
+
+      - name: Test packaged App flow
+        working-directory: editor
+        run: npm run test:e2e
 
       - name: Build editor
         working-directory: editor
@@ -92,7 +109,7 @@ jobs:
         run: .\.venv\Scripts\blacknode.exe demo
 
   rust:
-    name: Rust check
+    name: Rust tests
     runs-on: ubuntu-latest
     env:
       PYO3_PYTHON: python
@@ -109,5 +126,5 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Check Rust workspace
-        run: cargo check
+      - name: Test Rust workspace
+        run: cargo test --workspace --all-targets

--- a/.github/workflows/update-device-source-lock.yml
+++ b/.github/workflows/update-device-source-lock.yml
@@ -1,0 +1,64 @@
+name: Update device source lock
+
+on:
+  workflow_dispatch:
+    inputs:
+      runtime_commit:
+        description: Full merged blacknode-runtime commit SHA
+        required: true
+        type: string
+      core_commit:
+        description: Full merged Blacknode core commit SHA
+        required: true
+        type: string
+      hardware_commit:
+        description: Full merged blacknode-robot commit SHA
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  source-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Update and verify merged source pins
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNTIME_COMMIT: ${{ inputs.runtime_commit }}
+          CORE_COMMIT: ${{ inputs.core_commit }}
+          HARDWARE_COMMIT: ${{ inputs.hardware_commit }}
+        run: >-
+          python scripts/update_device_source_lock.py
+          --runtime-commit "$RUNTIME_COMMIT"
+          --core-commit "$CORE_COMMIT"
+          --hardware-commit "$HARDWARE_COMMIT"
+          --verify-merged
+          --write
+
+      - name: Run source-lock tests
+        run: python -m unittest tests.test_device_source_lock_script
+
+      - name: Open source-lock pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNTIME_COMMIT: ${{ inputs.runtime_commit }}
+        run: |
+          branch="release/device-source-lock-${RUNTIME_COMMIT:0:12}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add editor-server/device-runtime-sources.lock.json
+          git commit -m "release: update managed-device source lock"
+          git push origin "$branch"
+          gh pr create --base master --head "$branch" --title "release: update managed-device source lock" --body "Pins merged Runtime, core, and hardware commits after validating default-branch ancestry."

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ venv/
 .idea/
 *.swp
 node_modules/
+editor/test-results/
+editor/playwright-report/
 
 # Claude Code — local only, not for repo
 CLAUDE.md

--- a/crates/blacknode-core/src/graph.rs
+++ b/crates/blacknode-core/src/graph.rs
@@ -57,7 +57,7 @@ impl Graph {
             .get(&to)
             .ok_or_else(|| BlacknodeError::NodeNotFound(to.to_string()))?;
 
-        self.dag.add_edge(
+        let edge_index = self.dag.add_edge(
             fi,
             ti,
             Edge {
@@ -67,10 +67,7 @@ impl Graph {
         );
 
         if is_cyclic_directed(&self.dag) {
-            // roll back the edge we just added
-            if let Some(ei) = self.dag.find_edge(fi, ti) {
-                self.dag.remove_edge(ei);
-            }
+            self.dag.remove_edge(edge_index);
             return Err(BlacknodeError::CycleDetected);
         }
 
@@ -177,5 +174,83 @@ impl Graph {
 impl Default for Graph {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NodeMeta, Port};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    struct AddNode {
+        meta: NodeMeta,
+        cooks: Arc<AtomicUsize>,
+    }
+
+    impl AddNode {
+        fn new(value: i64, cooks: Arc<AtomicUsize>) -> Self {
+            Self {
+                meta: NodeMeta::new("Add")
+                    .with_port(Port::input("value", "Int"))
+                    .with_port(Port::output("result", "Int"))
+                    .with_param("value", value),
+                cooks,
+            }
+        }
+    }
+
+    impl Node for AddNode {
+        fn meta(&self) -> &NodeMeta {
+            &self.meta
+        }
+
+        fn meta_mut(&mut self) -> &mut NodeMeta {
+            &mut self.meta
+        }
+
+        fn cook(&self, inputs: HashMap<String, Value>) -> anyhow::Result<HashMap<String, Value>> {
+            self.cooks.fetch_add(1, Ordering::SeqCst);
+            let value = inputs.get("value").and_then(Value::as_f64).unwrap_or_default() as i64;
+            Ok(HashMap::from([("result".to_string(), Value::Int(value + 1))]))
+        }
+    }
+
+    #[test]
+    fn caches_results_and_invalidates_downstream_after_parameter_update() {
+        let first_cooks = Arc::new(AtomicUsize::new(0));
+        let second_cooks = Arc::new(AtomicUsize::new(0));
+        let mut graph = Graph::new();
+        let first = graph.add_node(Box::new(AddNode::new(1, first_cooks.clone())));
+        let second = graph.add_node(Box::new(AddNode::new(0, second_cooks.clone())));
+        graph.connect(first, "result", second, "value").unwrap();
+
+        assert_eq!(graph.cook(second, "result").unwrap(), Value::Int(3));
+        assert_eq!(graph.cook(second, "result").unwrap(), Value::Int(3));
+        assert_eq!(first_cooks.load(Ordering::SeqCst), 1);
+        assert_eq!(second_cooks.load(Ordering::SeqCst), 1);
+
+        graph.set_param(first, "value", Value::Int(5)).unwrap();
+        assert_eq!(graph.cook(second, "result").unwrap(), Value::Int(7));
+        assert_eq!(first_cooks.load(Ordering::SeqCst), 2);
+        assert_eq!(second_cooks.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn rejects_cycles_without_removing_an_existing_parallel_edge() {
+        let mut graph = Graph::new();
+        let cooks = Arc::new(AtomicUsize::new(0));
+        let first = graph.add_node(Box::new(AddNode::new(1, cooks.clone())));
+        let second = graph.add_node(Box::new(AddNode::new(2, cooks)));
+        graph.connect(first, "result", second, "value").unwrap();
+
+        assert!(matches!(
+            graph.connect(second, "result", first, "value"),
+            Err(BlacknodeError::CycleDetected)
+        ));
+        assert_eq!(graph.cook(second, "result").unwrap(), Value::Int(3));
     }
 }

--- a/crates/blacknode-runtime/src/lib.rs
+++ b/crates/blacknode-runtime/src/lib.rs
@@ -1,6 +1,7 @@
 use blacknode_core::{BlacknodeError, Graph, NodeId};
 use blacknode_types::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Async executor that cooks multiple terminal nodes in parallel
 /// using tokio tasks. Each branch is independent once inputs are resolved.
@@ -9,7 +10,7 @@ pub struct AsyncExecutor;
 impl AsyncExecutor {
     /// Cook a set of (node_id, port) targets concurrently.
     pub async fn cook_many(
-        graph: &Graph,
+        graph: Arc<Graph>,
         targets: Vec<(NodeId, String)>,
     ) -> HashMap<(NodeId, String), Result<Value, BlacknodeError>> {
         let mut results = HashMap::new();
@@ -18,12 +19,10 @@ impl AsyncExecutor {
         let handles: Vec<_> = targets
             .into_iter()
             .map(|(id, port)| {
-                // SAFETY: Graph is Sync — shared reference across tasks.
-                let g = graph as *const Graph as usize;
+                let graph = Arc::clone(&graph);
                 let port_clone = port.clone();
                 let handle = tokio::task::spawn_blocking(move || {
-                    let g = unsafe { &*(g as *const Graph) };
-                    ((id, port_clone.clone()), g.cook(id, &port_clone))
+                    ((id, port_clone.clone()), graph.cook(id, &port_clone))
                 });
                 handle
             })
@@ -35,5 +34,55 @@ impl AsyncExecutor {
             }
         }
         results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blacknode_core::{Node, NodeMeta, Port};
+
+    struct ConstantNode {
+        meta: NodeMeta,
+        value: i64,
+    }
+
+    impl ConstantNode {
+        fn new(value: i64) -> Self {
+            Self {
+                meta: NodeMeta::new("Constant").with_port(Port::output("value", "Int")),
+                value,
+            }
+        }
+    }
+
+    impl Node for ConstantNode {
+        fn meta(&self) -> &NodeMeta {
+            &self.meta
+        }
+
+        fn meta_mut(&mut self) -> &mut NodeMeta {
+            &mut self.meta
+        }
+
+        fn cook(&self, _inputs: HashMap<String, Value>) -> anyhow::Result<HashMap<String, Value>> {
+            Ok(HashMap::from([("value".to_string(), Value::Int(self.value))]))
+        }
+    }
+
+    #[tokio::test]
+    async fn cooks_multiple_targets_without_borrowing_graph_memory_into_tasks() {
+        let mut graph = Graph::new();
+        let first = graph.add_node(Box::new(ConstantNode::new(2)));
+        let second = graph.add_node(Box::new(ConstantNode::new(5)));
+
+        let results = AsyncExecutor::cook_many(
+            Arc::new(graph),
+            vec![(first, "value".to_string()), (second, "value".to_string())],
+        )
+        .await;
+
+        assert_eq!(results[&(first, "value".to_string())].as_ref().unwrap(), &Value::Int(2));
+        assert_eq!(results[&(second, "value".to_string())].as_ref().unwrap(), &Value::Int(5));
     }
 }

--- a/crates/blacknode-types/src/lib.rs
+++ b/crates/blacknode-types/src/lib.rs
@@ -86,3 +86,22 @@ impl From<HashMap<String, Value>> for Value {
         Value::Map(m)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn values_round_trip_through_the_tagged_json_contract() {
+        let value = Value::Map(HashMap::from([
+            ("enabled".to_string(), Value::Bool(true)),
+            ("samples".to_string(), Value::List(vec![Value::Int(3), Value::Float(4.5)])),
+        ]));
+
+        let encoded = serde_json::to_string(&value).unwrap();
+        let decoded: Value = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded, value);
+        assert_eq!(decoded.type_name(), "Map");
+    }
+}

--- a/docs/app-deployments.md
+++ b/docs/app-deployments.md
@@ -140,6 +140,23 @@ For a customer domain, also set `BLACKNODE_APP_PUBLIC_ORIGINS` to the exact
 comma-separated HTTPS origins allowed to send operator commands. Local startup
 accepts `http://localhost:3000` and `http://127.0.0.1:3000` by default.
 
+App file fields can browse only the extensions declared by their operator-view
+field. The browser is rooted at the deployment user's home directory by
+default. Set `BLACKNODE_APP_FILE_ROOTS` to an OS-path-separator-delimited list
+of existing directories to expose narrower or additional artifact roots:
+
+```powershell
+$env:BLACKNODE_APP_FILE_ROOTS = "D:\RobotModels;D:\Datasets"
+```
+
+```bash
+export BLACKNODE_APP_FILE_ROOTS="/srv/robot-models:/srv/datasets"
+```
+
+Paths outside those roots and file types absent from the active App contract
+are rejected by the server. Keep credentials and other sensitive host data
+outside the configured roots.
+
 Opening Blacknode now enters the customer App shell automatically. A direct App
 link uses `/app/<app-id>`, such as `/app/collect-episodes`.
 

--- a/docs/operator-apps.md
+++ b/docs/operator-apps.md
@@ -84,15 +84,21 @@ An operator view is declared inside workflow metadata:
 
 Supported widgets are `image`, `viewer`, `status`, `metrics`, `fields`, and
 `actions`. Image, viewer, status, and metric widgets read live node output
-ports. A `viewer` embeds an HTTP(S) URL produced by a trusted workflow node and
-is intended for managed simulation, robot-scene, and other interactive browser
-surfaces. Field widgets update declared node parameters. Actions can update
+ports. A `viewer` embeds a sandboxed HTTP(S) URL produced by a trusted workflow
+node and is intended for managed simulation, robot-scene, and other interactive
+browser surfaces. Relative URLs, loopback hosts, private-network addresses, and
+`.local` hosts are accepted automatically. Declare `trusted_origins` on the
+viewer widget when it must load a public origin, using exact origins such as
+`["https://viewer.example.com"]`. Viewer frames use a least-privilege capability
+set with scripting, forms, pointer-lock, and fullscreen. Field widgets update
+declared node parameters. Actions can update
 parameters, cook a declared node output, or call a node's existing
 direct-control endpoint.
 
 Use `input: "file_path"` for a path that must exist on the App host. It keeps
 the path editable and adds a **Browse…** button backed by Blacknode's filesystem
-browser. Declare `extensions` to filter selectable files, and optionally set
+browser. Declare a non-empty `extensions` allowlist to grant selectable file
+types, and optionally set
 `picker_title` and `button_label`. This is appropriate for robot descriptions,
 scenes, datasets, checkpoints, and other host-side artifacts.
 

--- a/editor-server/app_mode.py
+++ b/editor-server/app_mode.py
@@ -33,6 +33,7 @@ def route_allowed(method: str, path: str) -> bool:
         "/cook",
         "/cook-stream",
         "/cook/stop",
+        "/filesystem/browse",
         "/runtime/stop",
     }:
         return True

--- a/editor-server/filesystem_access.py
+++ b/editor-server/filesystem_access.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+
+_EXTENSION_RE = re.compile(r"\.[a-z0-9][a-z0-9._+-]{0,31}", re.I)
+
+
+def normalize_extensions(values: Iterable[object]) -> frozenset[str]:
+    extensions: set[str] = set()
+    for value in values:
+        clean = str(value or "").strip().lower()
+        if not clean:
+            continue
+        normalized = clean if clean.startswith(".") else f".{clean}"
+        if not _EXTENSION_RE.fullmatch(normalized):
+            raise ValueError(f"Invalid file extension '{clean}'.")
+        extensions.add(normalized)
+    return frozenset(extensions)
+
+
+def configured_app_roots(raw_value: str | None) -> tuple[Path, ...]:
+    values = [item.strip() for item in (raw_value or "").split(os.pathsep) if item.strip()]
+    roots = tuple(Path(item).expanduser().resolve() for item in values) or (Path.home().resolve(),)
+    missing = [str(root) for root in roots if not root.is_dir()]
+    if missing:
+        raise ValueError(f"App file roots must be existing directories: {', '.join(missing)}")
+    return roots
+
+
+def path_within_roots(path: Path, roots: Iterable[Path]) -> bool:
+    resolved = path.resolve()
+    return any(resolved == root or root in resolved.parents for root in roots)
+
+
+def _system_roots() -> tuple[Path, ...]:
+    if os.name == "nt":
+        return tuple(
+            Path(f"{letter}:\\").resolve()
+            for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            if Path(f"{letter}:\\").is_dir()
+        )
+    return (Path("/").resolve(),)
+
+
+def browse_listing(
+    raw_path: str,
+    extensions: Iterable[object],
+    *,
+    roots: tuple[Path, ...] | None = None,
+) -> dict[str, object]:
+    """Return a directory listing, optionally constrained to explicit roots."""
+    restricted = roots is not None
+    browse_roots = roots if roots is not None else _system_roots()
+    fallback = browse_roots[0] if restricted else Path.home().resolve()
+    clean_path = str(raw_path or "").strip()
+    requested = Path(clean_path).expanduser() if clean_path and not clean_path.startswith("package://") else fallback
+    try:
+        requested = requested.resolve()
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"Could not resolve {requested}: {exc}") from exc
+    if restricted and not path_within_roots(requested, browse_roots):
+        raise PermissionError("The requested path is outside the App's configured file roots.")
+
+    selected = ""
+    if requested.is_file():
+        selected = str(requested)
+        requested = requested.parent
+    if not requested.is_dir():
+        if restricted:
+            raise ValueError(f"Directory does not exist: {requested}")
+        requested = fallback
+
+    allowed = normalize_extensions(extensions)
+    try:
+        entries: list[dict[str, object]] = []
+        for child in requested.iterdir():
+            try:
+                resolved = child.resolve()
+                if restricted and not path_within_roots(resolved, browse_roots):
+                    continue
+                is_directory = child.is_dir()
+                if not is_directory and allowed and child.suffix.lower() not in allowed:
+                    continue
+                entries.append({
+                    "name": child.name,
+                    "path": str(resolved),
+                    "is_directory": is_directory,
+                    "size": None if is_directory else child.stat().st_size,
+                })
+            except (OSError, RuntimeError):
+                continue
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"Could not browse {requested}: {exc}") from exc
+
+    entries.sort(key=lambda item: (not bool(item["is_directory"]), str(item["name"]).casefold()))
+    parent = requested.parent
+    parent_path = str(parent) if parent != requested and (not restricted or path_within_roots(parent, browse_roots)) else ""
+    return {
+        "path": str(requested),
+        "parent": parent_path,
+        "roots": [str(root) for root in browse_roots],
+        "selected": selected,
+        "entries": entries[:5000],
+    }

--- a/editor-server/server.py
+++ b/editor-server/server.py
@@ -99,6 +99,7 @@ import cloud_client
 import cloud_sessions
 from hosted_mode import HostedWorkspaceStore, route_allowed as hosted_route_allowed
 from app_mode import route_allowed as app_mode_route_allowed
+from filesystem_access import browse_listing, configured_app_roots, normalize_extensions
 
 
 def package_index_payload(*args, **kwargs):
@@ -175,7 +176,12 @@ _active_deployment_permissions: dict[str, set[tuple[str, ...]]] = {
     "updates": set(),
     "controls": set(),
     "cooks": set(),
+    "files": set(),
 }
+try:
+    _APP_FILE_ROOTS = configured_app_roots(os.environ.get("BLACKNODE_APP_FILE_ROOTS"))
+except ValueError as exc:
+    raise RuntimeError(f"Invalid BLACKNODE_APP_FILE_ROOTS: {exc}") from exc
 
 app = FastAPI(title="Blacknode Editor Server")
 app.add_middleware(
@@ -3362,54 +3368,27 @@ def pick_file(req: PickFileReq):
     return {"selected": selected, "cancelled": not bool(selected)}
 
 
-def _filesystem_roots() -> list[str]:
-    if os.name == "nt":
-        return [f"{letter}:\\" for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" if Path(f"{letter}:\\").is_dir()]
-    return ["/"]
-
-
 @app.post("/filesystem/browse")
 def browse_files(req: BrowseFilesReq):
-    raw_path = str(req.path or "").strip()
-    requested = Path(raw_path).expanduser() if raw_path and not raw_path.startswith("package://") else Path.home()
-    selected = ""
-    if requested.is_file():
-        selected = str(requested.resolve())
-        requested = requested.parent
-    if not requested.is_dir():
-        requested = Path.home()
     try:
-        current = requested.resolve()
-        allowed = {
-            (extension if str(extension).startswith(".") else f".{extension}").lower()
-            for extension in req.extensions
-            if str(extension or "").strip()
-        }
-        entries = []
-        for child in current.iterdir():
-            try:
-                is_directory = child.is_dir()
-                if not is_directory and allowed and child.suffix.lower() not in allowed:
-                    continue
-                entries.append({
-                    "name": child.name,
-                    "path": str(child.resolve()),
-                    "is_directory": is_directory,
-                    "size": None if is_directory else child.stat().st_size,
-                })
-            except (OSError, RuntimeError):
-                continue
-    except (OSError, RuntimeError) as exc:
-        raise HTTPException(400, f"Could not browse {current}: {exc}") from exc
-    entries.sort(key=lambda item: (not item["is_directory"], item["name"].casefold()))
-    parent = current.parent
-    return {
-        "path": str(current),
-        "parent": str(parent) if parent != current else "",
-        "roots": _filesystem_roots(),
-        "selected": selected,
-        "entries": entries[:5000],
-    }
+        roots = None
+        if _APP_DEPLOYMENT is not None:
+            if _active_deployment_app_id is None:
+                raise HTTPException(409, "Activate a deployed App before browsing files.")
+            requested_extensions = normalize_extensions(req.extensions)
+            granted_extensions = {
+                item[0]
+                for item in _active_deployment_permissions.get("files", set())
+                if item
+            }
+            if not requested_extensions or not requested_extensions.issubset(granted_extensions):
+                raise HTTPException(403, "The active App does not grant access to these file types.")
+            roots = _APP_FILE_ROOTS
+        return browse_listing(req.path, req.extensions, roots=roots)
+    except PermissionError as exc:
+        raise HTTPException(403, str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
 
 
 @app.patch("/nodes/{node_id}/ports")

--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -17,14 +17,238 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.3",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^6.0.2",
+        "jsdom": "^27.0.1",
         "typescript": "^5.4.5",
-        "vite": "^8.1.4"
+        "vite": "^8.1.4",
+        "vitest": "^3.2.7"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -61,6 +285,472 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -88,6 +778,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@reactflow/background": {
@@ -456,6 +1162,441 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -465,6 +1606,25 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3": {
@@ -720,6 +1880,20 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -780,11 +1954,238 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/classcat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -898,6 +2299,75 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -906,6 +2376,96 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -941,11 +2501,122 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1220,10 +2891,72 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1237,6 +2970,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -1257,6 +3020,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -1288,6 +3098,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1313,6 +3149,14 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/reactflow": {
       "version": "11.11.4",
       "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
@@ -1329,6 +3173,30 @@
       "peerDependencies": {
         "react": ">=17",
         "react-dom": ">=17"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -1365,6 +3233,79 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1373,6 +3314,13 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1383,6 +3331,74 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -1399,6 +3415,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -1509,6 +3601,396 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zustand": {
       "version": "4.5.7",

--- a/editor/package.json
+++ b/editor/package.json
@@ -9,6 +9,8 @@
   },
   "scripts": {
     "dev": "vite",
+    "test": "vitest run",
+    "test:e2e": "playwright test",
     "build": "tsc && vite build",
     "build:slam-viewer": "tsc && vite build --config vite.standalone-slam.config.ts",
     "preview": "vite preview"
@@ -22,10 +24,15 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.3",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^6.0.2",
+    "jsdom": "^27.0.1",
     "typescript": "^5.4.5",
-    "vite": "^8.1.4"
+    "vite": "^8.1.4",
+    "vitest": "^3.2.7"
   }
 }

--- a/editor/playwright.config.ts
+++ b/editor/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+})

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import ReactFlow, {
   Background, Controls, MiniMap,
@@ -15,10 +15,6 @@ import ModelNode from './components/ModelNode'
 import OutputNode from './components/OutputNode'
 import ComputeDeviceNode from './components/ComputeDeviceNode'
 import ROS2GraphExplorerNode from './components/ROS2GraphExplorerNode'
-import SimulationViewerPane from './components/SimulationViewerPane'
-import CloudRunPanel from './components/CloudRunPanel'
-import EmailVerificationPage from './components/EmailVerificationPage'
-import LocalFilePicker from './components/LocalFilePicker'
 import RobotMonitorNode from './components/RobotMonitorNode'
 import RobotServoNode from './components/RobotServoNode'
 import SubnetNode from './components/SubnetNode'
@@ -29,9 +25,6 @@ import NodePalette from './components/NodePalette'
 import BlacknodeLogo from './components/BlacknodeLogo'
 import Inspector from './components/Inspector'
 import WorkflowShortcuts from './components/WorkflowShortcuts'
-import WorkflowOperatorView from './components/WorkflowOperatorView'
-import CustomerAppShell from './components/CustomerAppShell'
-import AppPackageDialog from './components/AppPackageDialog'
 import NodeSearch from './components/NodeSearch'
 import { portColor, portVisualColor, portsCompatible } from './portColors'
 import { PYTHON_TOOL_TYPES, resolvePythonToolPreset } from './pythonToolPresets'
@@ -40,6 +33,14 @@ import { api, type AppDeploymentSummary, type CloudJob, type CloudStatus, type F
 import { inferGraphRunTargets } from './graphRun'
 import { copyTextToClipboard } from './clipboard'
 import { isWorkflowOperatorView } from './operatorView'
+
+const SimulationViewerPane = lazy(() => import('./components/SimulationViewerPane'))
+const CloudRunPanel = lazy(() => import('./components/CloudRunPanel'))
+const EmailVerificationPage = lazy(() => import('./components/EmailVerificationPage'))
+const LocalFilePicker = lazy(() => import('./components/LocalFilePicker'))
+const WorkflowOperatorView = lazy(() => import('./components/WorkflowOperatorView'))
+const CustomerAppShell = lazy(() => import('./components/CustomerAppShell'))
+const AppPackageDialog = lazy(() => import('./components/AppPackageDialog'))
 
 const NODE_TYPES = {
   blacknode: BlackNode,
@@ -234,9 +235,17 @@ function nodeIdAtScreenPoint(point: { x: number; y: number }): string | null {
 
 export default function App() {
   if (window.location.pathname.replace(/\/+$/, '') === '/verify-email') {
-    return <EmailVerificationPage />
+    return <Suspense fallback={<AppLoading />}><EmailVerificationPage /></Suspense>
   }
-  return <AppDeploymentGate />
+  return <Suspense fallback={<AppLoading />}><AppDeploymentGate /></Suspense>
+}
+
+function AppLoading() {
+  return (
+    <main className="bn-app-mode-loading" aria-label="Loading Blacknode">
+      <BlacknodeLogo className="bn-app-mode-loading-logo" />
+    </main>
+  )
 }
 
 function AppDeploymentGate() {
@@ -249,11 +258,7 @@ function AppDeploymentGate() {
   }, [])
 
   if (deployment === undefined) {
-    return (
-      <main className="bn-app-mode-loading" aria-label="Loading Blacknode">
-        <BlacknodeLogo className="bn-app-mode-loading-logo" />
-      </main>
-    )
+    return <AppLoading />
   }
   return deployment ? <CustomerAppShell deployment={deployment} /> : <WorkspaceApp />
 }

--- a/editor/src/components/LocalFilePicker.test.tsx
+++ b/editor/src/components/LocalFilePicker.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import LocalFilePicker from './LocalFilePicker'
+
+const { browseFiles } = vi.hoisted(() => ({ browseFiles: vi.fn() }))
+
+vi.mock('../api', () => ({
+  api: { browseFiles },
+}))
+
+describe('LocalFilePicker', () => {
+  beforeEach(() => {
+    browseFiles.mockReset()
+    browseFiles.mockResolvedValue({
+      path: '/models',
+      parent: '',
+      roots: ['/models'],
+      selected: '',
+      entries: [{ name: 'robot.usd', path: '/models/robot.usd', is_directory: false, size: 2048 }],
+    })
+  })
+
+  it('browses with the declared extensions and returns the chosen file', async () => {
+    const onSelect = vi.fn()
+    render(
+      <LocalFilePicker
+        title="Choose a robot model"
+        initialPath="/models"
+        extensions={['.usd']}
+        onSelect={onSelect}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByRole('option', { name: /robot\.usd/i })).toBeInTheDocument()
+    expect(browseFiles).toHaveBeenCalledWith('/models', ['.usd'])
+    fireEvent.doubleClick(screen.getByRole('option', { name: /robot\.usd/i }))
+    expect(onSelect).toHaveBeenCalledWith('/models/robot.usd')
+  })
+
+  it('renders API errors for the operator', async () => {
+    browseFiles.mockRejectedValue(new Error('File type is not granted'))
+    render(
+      <LocalFilePicker
+        title="Choose a robot model"
+        initialPath="/models"
+        extensions={['.usd']}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText('File type is not granted')).toBeInTheDocument())
+  })
+})

--- a/editor/src/components/NodePalette.tsx
+++ b/editor/src/components/NodePalette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useRef } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useState, useRef } from 'react'
 import { api } from '../api'
 import { useStore } from '../store'
 import BlacknodeLogo from './BlacknodeLogo'
@@ -6,19 +6,20 @@ import { CATEGORIES, familyColor } from '../categories'
 import { CORE_GROUP, componentDisplayName, groupForPackage, packageGroupIndex } from '../packageGroups'
 import { freeCanvasSpot } from '../placement'
 import { PYTHON_TOOL_TYPES, resolvePythonToolPreset } from '../pythonToolPresets'
-import McpPanel from './McpPanel'
-import LearnedNodesPanel from './LearnedNodesPanel'
-import PackagesPanel from './PackagesPanel'
-import RunsPanel from './RunsPanel'
-import DeploymentsPanel from './DeploymentsPanel'
-import DevicesPanel from './DevicesPanel'
-import RuntimePanel from './RuntimePanel'
-import ConsolePanel from './ConsolePanel'
-import ScriptEditor from './ScriptEditor'
-import TemplateGallery from './TemplateGallery'
-import WorkflowManager from './WorkflowManager'
-import ProjectPanel from './ProjectPanel'
 import NodeGlyph from './NodeGlyph'
+
+const McpPanel = lazy(() => import('./McpPanel'))
+const LearnedNodesPanel = lazy(() => import('./LearnedNodesPanel'))
+const PackagesPanel = lazy(() => import('./PackagesPanel'))
+const RunsPanel = lazy(() => import('./RunsPanel'))
+const DeploymentsPanel = lazy(() => import('./DeploymentsPanel'))
+const DevicesPanel = lazy(() => import('./DevicesPanel'))
+const RuntimePanel = lazy(() => import('./RuntimePanel'))
+const ConsolePanel = lazy(() => import('./ConsolePanel'))
+const ScriptEditor = lazy(() => import('./ScriptEditor'))
+const TemplateGallery = lazy(() => import('./TemplateGallery'))
+const WorkflowManager = lazy(() => import('./WorkflowManager'))
+const ProjectPanel = lazy(() => import('./ProjectPanel'))
 
 // Curated ordering for the built-in categories; anything else sorts by name.
 const CATEGORY_ORDER = Object.keys(CATEGORIES)
@@ -748,6 +749,7 @@ export default function NodePalette() {
           </div>
 
           <div className="bn-palette-panel-content" style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+            <Suspense fallback={<div className="bn-palette-loading" role="status">Opening panel…</div>}>
 
             {/* ── NODES ── */}
             {activeTab === 'nodes' && (
@@ -835,6 +837,8 @@ export default function NodePalette() {
 
             {/* ── MCP ── */}
             {activeTab === 'mcp' && <McpPanel />}
+
+            </Suspense>
 
           </div>
         </div>

--- a/editor/src/components/WorkflowOperatorView.tsx
+++ b/editor/src/components/WorkflowOperatorView.tsx
@@ -11,7 +11,7 @@ import {
 
 import { useStore } from '../store'
 import LocalFilePicker from './LocalFilePicker'
-import { normalizeViewerUrl } from '../operatorView'
+import { normalizeViewerUrl, viewerSandbox } from '../operatorView'
 import type {
   OperatorActionItem,
   OperatorFieldItem,
@@ -150,7 +150,7 @@ function OperatorViewer({ widget, nodes }: {
               src={url}
               title={widget.title}
               allow="fullscreen"
-              sandbox="allow-forms allow-pointer-lock allow-same-origin allow-scripts"
+              sandbox={viewerSandbox(url)}
               referrerPolicy="no-referrer"
               loading="lazy"
             />

--- a/editor/src/components/WorkflowOperatorView.tsx
+++ b/editor/src/components/WorkflowOperatorView.tsx
@@ -11,6 +11,7 @@ import {
 
 import { useStore } from '../store'
 import LocalFilePicker from './LocalFilePicker'
+import { normalizeViewerUrl } from '../operatorView'
 import type {
   OperatorActionItem,
   OperatorFieldItem,
@@ -135,31 +136,24 @@ function OperatorImage({ widget, nodes }: {
   )
 }
 
-function viewerUrl(value: unknown): string {
-  const candidates: unknown[] = [value]
-  if (value && typeof value === 'object') {
-    const record = value as Record<string, unknown>
-    candidates.push(record.viewer_url, record.url)
-  }
-  for (const candidate of candidates) {
-    if (typeof candidate !== 'string') continue
-    const trimmed = candidate.trim()
-    if (/^(https?:\/\/|\/(?!\/))/i.test(trimmed)) return trimmed
-  }
-  return ''
-}
-
 function OperatorViewer({ widget, nodes }: {
   widget: Extract<OperatorWidget, { type: 'viewer' }>
   nodes: ReturnType<typeof useStore.getState>['nodes']
 }) {
-  const url = viewerUrl(valueFor(widget.source, nodes))
+  const url = normalizeViewerUrl(valueFor(widget.source, nodes), widget.trusted_origins)
   return (
     <article className="bn-operator-card bn-operator-viewer-card">
       <header><strong>{widget.title}</strong><span className={url ? 'is-live' : ''}>{url ? 'LIVE' : 'WAITING'}</span></header>
       <div className="bn-operator-viewer-frame">
         {url
-          ? <iframe src={url} title={widget.title} allow="clipboard-read; clipboard-write; fullscreen" referrerPolicy="no-referrer" />
+          ? <iframe
+              src={url}
+              title={widget.title}
+              allow="fullscreen"
+              sandbox="allow-forms allow-pointer-lock allow-same-origin allow-scripts"
+              referrerPolicy="no-referrer"
+              loading="lazy"
+            />
           : <div className="bn-operator-image-empty"><i aria-hidden="true" />{widget.empty ?? 'Start the workflow to open this viewer.'}</div>}
       </div>
     </article>

--- a/editor/src/operatorView.test.ts
+++ b/editor/src/operatorView.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import { isWorkflowOperatorView, normalizeViewerUrl } from './operatorView'
+
+function operatorView(): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    id: 'robot-viewer',
+    title: 'Robot viewer',
+    run_target: { node_id: 'viewer', port: 'viewer_url' },
+    settings: {
+      groups: [{
+        id: 'scene',
+        title: 'Scene',
+        items: [{
+          node_id: 'viewer',
+          param: 'model_path',
+          label: 'Model',
+          input: 'file_path',
+          extensions: ['.usd', '.usda'],
+        }],
+      }],
+    },
+    sections: [{
+      id: 'main',
+      widgets: [
+        { type: 'viewer', id: 'viewer', title: 'Scene', source: { node_id: 'viewer', port: 'viewer_url' } },
+        { type: 'status', id: 'status', items: [{ label: 'Ready', node_id: 'viewer', port: 'ready', tone: 'success' }] },
+        { type: 'metrics', id: 'metrics', items: [{ label: 'Bodies', node_id: 'viewer', port: 'body_count', format: 'number' }] },
+        { type: 'actions', id: 'actions', items: [{ id: 'start', label: 'Start', cook_target: { node_id: 'viewer', port: 'viewer_url' } }] },
+      ],
+    }],
+  }
+}
+
+describe('isWorkflowOperatorView', () => {
+  it('accepts a complete operator contract', () => {
+    expect(isWorkflowOperatorView(operatorView())).toBe(true)
+  })
+
+  it('rejects malformed widget payloads and duplicate widget ids', () => {
+    const malformed = operatorView()
+    const sections = malformed.sections as Array<Record<string, unknown>>
+    const widgets = sections[0].widgets as Array<Record<string, unknown>>
+    delete (widgets[1].items as Array<Record<string, unknown>>)[0].port
+    expect(isWorkflowOperatorView(malformed)).toBe(false)
+
+    const duplicate = operatorView()
+    const duplicateWidgets = (duplicate.sections as Array<Record<string, unknown>>)[0].widgets as Array<Record<string, unknown>>
+    duplicateWidgets[1].id = 'viewer'
+    expect(isWorkflowOperatorView(duplicate)).toBe(false)
+  })
+
+  it('requires an extension allowlist for generic file fields', () => {
+    const malformed = operatorView()
+    const settings = malformed.settings as Record<string, unknown>
+    const groups = settings.groups as Array<Record<string, unknown>>
+    const field = (groups[0].items as Array<Record<string, unknown>>)[0]
+    delete field.extensions
+    expect(isWorkflowOperatorView(malformed)).toBe(false)
+  })
+
+  it('accepts exact viewer origins and rejects origins containing paths', () => {
+    const valid = operatorView()
+    const widgets = ((valid.sections as Array<Record<string, unknown>>)[0].widgets as Array<Record<string, unknown>>)
+    widgets[0].trusted_origins = ['https://viewer.example.com']
+    expect(isWorkflowOperatorView(valid)).toBe(true)
+
+    widgets[0].trusted_origins = ['https://viewer.example.com/path']
+    expect(isWorkflowOperatorView(valid)).toBe(false)
+  })
+})
+
+describe('normalizeViewerUrl', () => {
+  it('allows relative and local viewer URLs', () => {
+    expect(normalizeViewerUrl('/viewer/session')).toBe('/viewer/session')
+    expect(normalizeViewerUrl({ viewer_url: 'http://127.0.0.1:8090/' })).toBe('http://127.0.0.1:8090/')
+    expect(normalizeViewerUrl('https://robot.local/view')).toBe('https://robot.local/view')
+  })
+
+  it('rejects active schemes, embedded credentials, and undeclared public origins', () => {
+    expect(normalizeViewerUrl('javascript:alert(1)')).toBe('')
+    expect(normalizeViewerUrl('https://user:secret@example.com/view')).toBe('')
+    expect(normalizeViewerUrl('https://viewer.example.com/view')).toBe('')
+  })
+
+  it('allows an explicitly trusted public origin', () => {
+    expect(normalizeViewerUrl('https://viewer.example.com/view', ['https://viewer.example.com']))
+      .toBe('https://viewer.example.com/view')
+  })
+})

--- a/editor/src/operatorView.test.ts
+++ b/editor/src/operatorView.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isWorkflowOperatorView, normalizeViewerUrl } from './operatorView'
+import { isWorkflowOperatorView, normalizeViewerUrl, viewerSandbox } from './operatorView'
 
 function operatorView(): Record<string, unknown> {
   return {
@@ -87,5 +87,17 @@ describe('normalizeViewerUrl', () => {
   it('allows an explicitly trusted public origin', () => {
     expect(normalizeViewerUrl('https://viewer.example.com/view', ['https://viewer.example.com']))
       .toBe('https://viewer.example.com/view')
+  })
+})
+
+describe('viewerSandbox', () => {
+  it('keeps same-origin viewers in an opaque sandbox', () => {
+    expect(viewerSandbox('/viewer/session', 'https://app.example.com'))
+      .toBe('allow-forms allow-pointer-lock allow-scripts')
+  })
+
+  it('preserves a cross-origin viewer identity for its own assets and sockets', () => {
+    expect(viewerSandbox('http://127.0.0.1:8090', 'http://127.0.0.1:7777'))
+      .toBe('allow-forms allow-pointer-lock allow-scripts allow-same-origin')
   })
 })

--- a/editor/src/operatorView.ts
+++ b/editor/src/operatorView.ts
@@ -293,3 +293,15 @@ export function normalizeViewerUrl(value: unknown, trustedOrigins: string[] = []
   }
   return ''
 }
+
+export function viewerSandbox(url: string, baseOrigin: string = window.location.origin): string {
+  const capabilities = ['allow-forms', 'allow-pointer-lock', 'allow-scripts']
+  try {
+    if (new URL(url, baseOrigin).origin !== new URL(baseOrigin).origin) {
+      capabilities.push('allow-same-origin')
+    }
+  } catch {
+    // Invalid URLs never reach the iframe; retain the strict same-origin set.
+  }
+  return capabilities.join(' ')
+}

--- a/editor/src/operatorView.ts
+++ b/editor/src/operatorView.ts
@@ -89,6 +89,7 @@ export type OperatorWidget =
       title: string
       source: OperatorValueSource
       empty?: string
+      trusted_origins?: string[]
     }
   | { type: 'status'; id: string; title?: string; items: OperatorStatusItem[] }
   | { type: 'metrics'; id: string; title?: string; items: OperatorMetricItem[] }
@@ -120,49 +121,175 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
+function hasText(record: Record<string, unknown>, key: string): boolean {
+  return typeof record[key] === 'string' && String(record[key]).trim().length > 0
+}
+
+function optionalText(record: Record<string, unknown>, key: string): boolean {
+  return record[key] === undefined || typeof record[key] === 'string'
+}
+
+function optionalEnum(record: Record<string, unknown>, key: string, values: readonly string[]): boolean {
+  return record[key] === undefined || values.includes(String(record[key]))
+}
+
+function isSource(value: unknown): value is OperatorValueSource {
+  return isRecord(value) && hasText(value, 'node_id') && hasText(value, 'port')
+}
+
+function isRunTarget(value: unknown): value is OperatorRunTarget {
+  return isRecord(value)
+    && hasText(value, 'node_id')
+    && hasText(value, 'port')
+    && optionalEnum(value, 'mode', ['once', 'live'])
+    && optionalText(value, 'label')
+    && optionalText(value, 'confirm')
+    && (value.live_source === undefined || isSource(value.live_source))
+}
+
+function isField(value: unknown): value is OperatorFieldItem {
+  if (!isRecord(value) || !hasText(value, 'node_id') || !hasText(value, 'param') || !hasText(value, 'label')) return false
+  if (!optionalEnum(value, 'input', ['text', 'number', 'textarea', 'file_path', 'calibration_file', 'swap'])) return false
+  if (!['placeholder', 'button_label', 'picker_title', 'confirm'].every(key => optionalText(value, key))) return false
+  if (!['min', 'max', 'step'].every(key => value[key] === undefined || typeof value[key] === 'number')) return false
+  if (value.extensions !== undefined && (!Array.isArray(value.extensions) || value.extensions.length === 0 || !value.extensions.every(item => typeof item === 'string' && item.trim()))) return false
+  if (value.input === 'file_path' && !Array.isArray(value.extensions)) return false
+  const isParamTarget = (target: unknown) => isRecord(target) && hasText(target, 'node_id') && hasText(target, 'param')
+  if (value.apply_to !== undefined && (!Array.isArray(value.apply_to) || !value.apply_to.every(isParamTarget))) return false
+  if (value.swap_pairs !== undefined && (
+    !Array.isArray(value.swap_pairs)
+    || value.swap_pairs.length === 0
+    || !value.swap_pairs.every(pair => isRecord(pair) && isParamTarget(pair.left) && isParamTarget(pair.right))
+  )) return false
+  return value.disabled_when === undefined || isSource(value.disabled_when)
+}
+
+function isControl(value: unknown): boolean {
+  return isRecord(value)
+    && hasText(value, 'node_id')
+    && hasText(value, 'action')
+    && (value.payload === undefined || isRecord(value.payload))
+}
+
+function isAction(value: unknown): value is OperatorActionItem {
+  if (!isRecord(value) || !hasText(value, 'id') || !hasText(value, 'label')) return false
+  if (!optionalEnum(value, 'tone', ['neutral', 'primary', 'success', 'warning', 'danger'])) return false
+  if (!optionalEnum(value, 'active_tone', ['neutral', 'primary', 'success', 'warning', 'danger'])) return false
+  if (!['confirm', 'active_label', 'active_confirm'].every(key => optionalText(value, key))) return false
+  if (value.updates !== undefined && (
+    !Array.isArray(value.updates)
+    || value.updates.length === 0
+    || !value.updates.every(update => isRecord(update) && hasText(update, 'node_id') && hasText(update, 'param') && Object.prototype.hasOwnProperty.call(update, 'value'))
+  )) return false
+  if (value.control !== undefined && !isControl(value.control)) return false
+  if (value.deactivate_control !== undefined && !isControl(value.deactivate_control)) return false
+  if (value.cook_target !== undefined && !isRunTarget(value.cook_target)) return false
+  if (value.state !== undefined && !isSource(value.state)) return false
+  return value.updates !== undefined || value.control !== undefined || value.cook_target !== undefined
+}
+
+function isWidget(value: unknown): value is OperatorWidget {
+  if (!isRecord(value) || !hasText(value, 'id') || !hasText(value, 'type') || !optionalText(value, 'title')) return false
+  if (value.type === 'image' || value.type === 'viewer') {
+    if (!hasText(value, 'title') || !isSource(value.source) || !optionalText(value, 'empty')) return false
+    if (value.type === 'image') return optionalEnum(value, 'aspect', ['video', 'dashboard'])
+    return value.trusted_origins === undefined || (
+      Array.isArray(value.trusted_origins)
+      && value.trusted_origins.every(origin => {
+        if (typeof origin !== 'string') return false
+        try {
+          const url = new URL(origin)
+          return ['http:', 'https:'].includes(url.protocol)
+            && !url.username && !url.password
+            && (url.pathname === '/' || url.pathname === '')
+            && !url.search && !url.hash
+            && origin.replace(/\/$/, '') === url.origin
+        } catch {
+          return false
+        }
+      })
+    )
+  }
+  if (!['status', 'metrics', 'fields', 'actions'].includes(String(value.type))) return false
+  if (!Array.isArray(value.items) || value.items.length === 0) return false
+  if (value.type === 'fields') return value.items.every(isField)
+  if (value.type === 'actions') return value.items.every(isAction)
+  return value.items.every(item => {
+    if (!isRecord(item) || !isSource(item) || !hasText(item, 'label')) return false
+    if (value.type === 'status') {
+      return optionalEnum(item, 'tone', ['neutral', 'success', 'warning', 'danger'])
+        && optionalText(item, 'true_label') && optionalText(item, 'false_label')
+    }
+    return optionalText(item, 'suffix') && optionalEnum(item, 'format', ['number', 'duration', 'text'])
+  })
+}
+
 export function isWorkflowOperatorView(value: unknown): value is WorkflowOperatorView {
-  if (!isRecord(value) || value.schema_version !== 1 || typeof value.title !== 'string') return false
+  if (!isRecord(value) || value.schema_version !== 1 || !hasText(value, 'title')) return false
+  if (!['id', 'description', 'accent'].every(key => optionalText(value, key))) return false
+  if (!optionalEnum(value, 'icon', ['record', 'camera', 'robot', 'workflow', 'play'])) return false
+  if (value.run_target !== undefined && !isRunTarget(value.run_target)) return false
   if (!Array.isArray(value.sections) || value.sections.length === 0) return false
-  const sectionsValid = value.sections.every(section => (
-    isRecord(section)
-    && typeof section.id === 'string'
-    && (section.region === undefined || section.region === 'main' || section.region === 'parameters')
-    && Array.isArray(section.widgets)
-    && section.widgets.every(widget => isRecord(widget) && typeof widget.type === 'string' && typeof widget.id === 'string')
-  ))
+  const sectionIds = new Set<string>()
+  const widgetIds = new Set<string>()
+  const sectionsValid = value.sections.every(section => {
+    if (!isRecord(section) || !hasText(section, 'id') || !optionalText(section, 'title') || !optionalText(section, 'description')) return false
+    if (!optionalEnum(section, 'region', ['main', 'parameters']) || !optionalEnum(section, 'layout', ['grid', 'stack'])) return false
+    if (!Array.isArray(section.widgets) || section.widgets.length === 0 || !section.widgets.every(isWidget)) return false
+    const sectionId = String(section.id)
+    if (sectionIds.has(sectionId)) return false
+    sectionIds.add(sectionId)
+    for (const widget of section.widgets) {
+      if (widgetIds.has(widget.id)) return false
+      widgetIds.add(widget.id)
+    }
+    return true
+  })
   if (!sectionsValid || value.settings === undefined) return sectionsValid
   if (!isRecord(value.settings) || !Array.isArray(value.settings.groups)) return false
-  return value.settings.groups.every(group => (
-    isRecord(group)
-    && typeof group.id === 'string'
-    && typeof group.title === 'string'
-    && Array.isArray(group.items)
-    && group.items.every(item => (
-      isRecord(item)
-      && typeof item.node_id === 'string'
-      && typeof item.param === 'string'
-      && typeof item.label === 'string'
-      && (item.input === undefined || ['text', 'number', 'textarea', 'file_path', 'calibration_file', 'swap'].includes(String(item.input)))
-      && (item.extensions === undefined || (
-        Array.isArray(item.extensions)
-        && item.extensions.every(extension => typeof extension === 'string')
-      ))
-      && (item.apply_to === undefined || (
-        Array.isArray(item.apply_to)
-        && item.apply_to.every(target => isRecord(target) && typeof target.node_id === 'string' && typeof target.param === 'string')
-      ))
-      && (item.swap_pairs === undefined || (
-        Array.isArray(item.swap_pairs)
-        && item.swap_pairs.every(pair => (
-          isRecord(pair)
-          && isRecord(pair.left)
-          && typeof pair.left.node_id === 'string'
-          && typeof pair.left.param === 'string'
-          && isRecord(pair.right)
-          && typeof pair.right.node_id === 'string'
-          && typeof pair.right.param === 'string'
-        ))
-      ))
-    ))
-  ))
+  if (!optionalText(value.settings, 'title') || !optionalText(value.settings, 'description') || value.settings.groups.length === 0) return false
+  const groupIds = new Set<string>()
+  return value.settings.groups.every(group => {
+    if (!isRecord(group) || !hasText(group, 'id') || !hasText(group, 'title') || !optionalText(group, 'description')) return false
+    if (!Array.isArray(group.items) || group.items.length === 0 || !group.items.every(isField)) return false
+    const groupId = String(group.id)
+    if (groupIds.has(groupId)) return false
+    groupIds.add(groupId)
+    return true
+  })
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const octets = hostname.split('.').map(Number)
+  if (octets.length !== 4 || octets.some(value => !Number.isInteger(value) || value < 0 || value > 255)) return false
+  return octets[0] === 10
+    || octets[0] === 127
+    || (octets[0] === 192 && octets[1] === 168)
+    || (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31)
+    || (octets[0] === 169 && octets[1] === 254)
+}
+
+export function normalizeViewerUrl(value: unknown, trustedOrigins: string[] = []): string {
+  const candidates: unknown[] = [value]
+  if (isRecord(value)) candidates.push(value.viewer_url, value.url)
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue
+    const trimmed = candidate.trim()
+    if (!trimmed || trimmed.length > 2048 || /^\/\//.test(trimmed)) continue
+    if (/^\/(?!\/)/.test(trimmed)) return trimmed
+    try {
+      const url = new URL(trimmed)
+      if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) continue
+      const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '')
+      const trusted = trustedOrigins.some(origin => {
+        try { return new URL(origin).origin === url.origin } catch { return false }
+      })
+      if (hostname === 'localhost' || hostname === '::1' || hostname.endsWith('.local') || isPrivateIpv4(hostname) || trusted) {
+        return url.toString()
+      }
+    } catch {
+      continue
+    }
+  }
+  return ''
 }

--- a/editor/src/test/setup.ts
+++ b/editor/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/editor/tests/e2e/app-mode.spec.ts
+++ b/editor/tests/e2e/app-mode.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test'
+
+const operatorView = {
+  schema_version: 1,
+  id: 'robot-viewer',
+  title: 'Robot viewer',
+  settings: {
+    groups: [{
+      id: 'scene',
+      title: 'Scene',
+      items: [{
+        node_id: 'viewer',
+        param: 'model_path',
+        label: 'Robot model',
+        input: 'file_path',
+        extensions: ['.usd'],
+      }],
+    }],
+  },
+  sections: [{
+    id: 'main',
+    widgets: [{
+      type: 'status',
+      id: 'status',
+      items: [{ label: 'Viewer', node_id: 'viewer', port: 'ready' }],
+    }],
+  }],
+}
+
+const graph = {
+  nodes: [{
+    id: 'viewer',
+    type: 'NewtonScene',
+    params: { model_path: '' },
+    pos: [0, 0],
+    inputs: ['model_path'],
+    outputs: ['ready'],
+    input_types: { model_path: 'Text' },
+    output_types: { ready: 'Bool' },
+    input_defaults: { model_path: '' },
+  }],
+  edges: [],
+  metadata: { operator_view: operatorView },
+  entrypoint: { node_id: 'viewer', port: 'ready' },
+}
+
+test('packaged App opens its granted file picker', async ({ page }) => {
+  await page.route('**/api/**', async route => {
+    const pathname = new URL(route.request().url()).pathname
+    if (pathname === '/api/app-deployment') {
+      await route.fulfill({ json: {
+        kind: 'blacknode.app-deployment',
+        schema_version: 1,
+        id: 'demo',
+        name: 'Demo',
+        start_app: 'robot-viewer',
+        access: { role: 'operator', graph_editing: false },
+        required_packages: [],
+        required_components: [],
+        required_adapters: [],
+        apps: [{
+          id: 'robot-viewer', name: 'Robot viewer', description: '', accent: '#76b900', icon: 'robot',
+          required_packages: [], required_components: [], required_adapters: [],
+        }],
+      } })
+    } else if (pathname.endsWith('/activate')) {
+      await route.fulfill({ json: { app: { id: 'robot-viewer' }, graph } })
+    } else if (pathname === '/api/graph') {
+      await route.fulfill({ json: graph })
+    } else if (pathname === '/api/filesystem/browse') {
+      expect(route.request().postDataJSON()).toEqual({ path: '', extensions: ['.usd'] })
+      await route.fulfill({ json: {
+        path: '/models', parent: '', roots: ['/models'], selected: '',
+        entries: [{ name: 'robot.usd', path: '/models/robot.usd', is_directory: false, size: 4096 }],
+      } })
+    } else {
+      await route.fulfill({ json: { modules: {} } })
+    }
+  })
+
+  await page.goto('/app/robot-viewer')
+  await expect(page.getByRole('heading', { name: 'Robot viewer' })).toBeVisible()
+  await page.getByRole('button', { name: 'App settings' }).click()
+  await page.getByRole('button', { name: 'Browse…' }).click()
+  await expect(page.getByRole('dialog', { name: 'Choose Robot model' })).toBeVisible()
+  await expect(page.getByRole('option', { name: /robot\.usd/i })).toBeVisible()
+})

--- a/editor/vite.config.ts
+++ b/editor/vite.config.ts
@@ -3,6 +3,26 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name: 'react-flow',
+              test: /node_modules[\\/](?:@reactflow|reactflow)[\\/]/,
+              priority: 20,
+            },
+            {
+              name: 'react-runtime',
+              test: /node_modules[\\/](?:react|react-dom|scheduler|zustand)[\\/]/,
+              priority: 10,
+            },
+          ],
+        },
+      },
+    },
+  },
   server: {
     port: 3000,
     proxy: {

--- a/editor/vitest.config.ts
+++ b/editor/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
+    setupFiles: ['./src/test/setup.ts'],
+  },
+})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "anyio>=4.10,<4.15",
     "fastapi>=0.110",
     "httpx>=0.27",
     "httpx2>=2.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 dev = [
     "fastapi>=0.110",
     "httpx>=0.27",
+    "httpx2>=2.12",
     "mcp>=1.0,<2.0",
     "pytest",
 ]

--- a/python/blacknode/app_deployments.py
+++ b/python/blacknode/app_deployments.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from .workflow import load_workflow, validate_workflow
+from .operator_views import OperatorViewValidationError, validate_operator_view
 
 
 APP_DEPLOYMENT_KIND = "blacknode.app-deployment"
@@ -33,13 +34,10 @@ def _operator_view(workflow: Mapping[str, Any], *, source: str) -> Mapping[str, 
     view = metadata.get("operator_view") if isinstance(metadata, Mapping) else None
     if not isinstance(view, Mapping):
         raise AppDeploymentError(f"{source} does not declare metadata.operator_view.")
-    if view.get("schema_version") != 1:
-        raise AppDeploymentError(f"{source} operator_view.schema_version must be 1.")
-    if not str(view.get("title") or "").strip():
-        raise AppDeploymentError(f"{source} operator_view.title is required.")
-    if not isinstance(view.get("sections"), list) or not view["sections"]:
-        raise AppDeploymentError(f"{source} operator_view.sections must contain at least one section.")
-    return view
+    try:
+        return validate_operator_view(view)
+    except OperatorViewValidationError as exc:
+        raise AppDeploymentError(f"{source} has an invalid operator view: {exc}") from exc
 
 
 def _secret_paths(value: object, path: str = "$") -> list[str]:
@@ -241,6 +239,7 @@ def operator_permissions(app: Mapping[str, Any]) -> dict[str, set[tuple[str, ...
     updates: set[tuple[str, str, str]] = set()
     controls: set[tuple[str, str, str]] = set()
     cooks: set[tuple[str, str, str]] = set()
+    files: set[tuple[str]] = set()
 
     def add_field_permissions(item: Mapping[str, Any]) -> None:
         params.add((str(item.get("node_id") or ""), str(item.get("param") or "")))
@@ -253,6 +252,12 @@ def operator_permissions(app: Mapping[str, Any]) -> dict[str, set[tuple[str, ...
             for target in (pair.get("left"), pair.get("right")):
                 if isinstance(target, Mapping):
                     params.add((str(target.get("node_id") or ""), str(target.get("param") or "")))
+        if item.get("input") in {"file_path", "calibration_file"}:
+            extensions = item.get("extensions") or ([".json"] if item.get("input") == "calibration_file" else [])
+            for extension in extensions:
+                clean = str(extension or "").strip().lower()
+                if clean:
+                    files.add((clean if clean.startswith(".") else f".{clean}",))
 
     run_target = view.get("run_target")
     if isinstance(run_target, Mapping):
@@ -310,4 +315,5 @@ def operator_permissions(app: Mapping[str, Any]) -> dict[str, set[tuple[str, ...
         "updates": {item for item in updates if all(item)},
         "controls": {item for item in controls if all(item)},
         "cooks": {item for item in cooks if all(item)},
+        "files": files,
     }

--- a/python/blacknode/operator_views.py
+++ b/python/blacknode/operator_views.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import re
+from typing import Any
+from urllib.parse import urlsplit
+
+
+_WIDGET_TYPES = frozenset({"image", "viewer", "status", "metrics", "fields", "actions"})
+_INPUT_TYPES = frozenset({"text", "number", "textarea", "file_path", "calibration_file", "swap"})
+_TONES = frozenset({"neutral", "primary", "success", "warning", "danger"})
+_EXTENSION_RE = re.compile(r"\.[a-z0-9][a-z0-9._+-]{0,31}", re.I)
+
+
+class OperatorViewValidationError(ValueError):
+    """Raised when a workflow's operator surface does not match schema version 1."""
+
+
+def _record(value: object, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise OperatorViewValidationError(f"{path} must be an object.")
+    return value
+
+
+def _list(value: object, path: str, *, nonempty: bool = False) -> Sequence[Any]:
+    if not isinstance(value, list) or (nonempty and not value):
+        suffix = " contain at least one item" if nonempty else " be an array"
+        raise OperatorViewValidationError(f"{path} must{suffix}.")
+    return value
+
+
+def _text(record: Mapping[str, Any], key: str, path: str, *, optional: bool = False) -> str:
+    value = record.get(key)
+    if optional and value is None:
+        return ""
+    if not isinstance(value, str) or not value.strip():
+        raise OperatorViewValidationError(f"{path}.{key} must be a non-empty string.")
+    return value
+
+
+def _optional_text(record: Mapping[str, Any], key: str, path: str) -> None:
+    if key in record and record[key] is not None and not isinstance(record[key], str):
+        raise OperatorViewValidationError(f"{path}.{key} must be a string.")
+
+
+def _enum(record: Mapping[str, Any], key: str, choices: frozenset[str], path: str) -> None:
+    value = record.get(key)
+    if value is not None and value not in choices:
+        raise OperatorViewValidationError(f"{path}.{key} must be one of: {', '.join(sorted(choices))}.")
+
+
+def _source(value: object, path: str) -> None:
+    source = _record(value, path)
+    _text(source, "node_id", path)
+    _text(source, "port", path)
+
+
+def _target(value: object, path: str) -> None:
+    target = _record(value, path)
+    _text(target, "node_id", path)
+    _text(target, "port", path)
+    _enum(target, "mode", frozenset({"once", "live"}), path)
+    _optional_text(target, "label", path)
+    _optional_text(target, "confirm", path)
+    if target.get("live_source") is not None:
+        _source(target["live_source"], f"{path}.live_source")
+
+
+def _field(value: object, path: str) -> None:
+    field = _record(value, path)
+    _text(field, "node_id", path)
+    _text(field, "param", path)
+    _text(field, "label", path)
+    _enum(field, "input", _INPUT_TYPES, path)
+    for key in ("placeholder", "button_label", "picker_title", "confirm"):
+        _optional_text(field, key, path)
+    for key in ("min", "max", "step"):
+        if key in field and field[key] is not None and not isinstance(field[key], (int, float)):
+            raise OperatorViewValidationError(f"{path}.{key} must be a number.")
+    if field.get("extensions") is not None:
+        extensions = _list(field["extensions"], f"{path}.extensions", nonempty=True)
+        for extension in extensions:
+            clean = str(extension or "").strip()
+            normalized = clean if clean.startswith(".") else f".{clean}"
+            if not isinstance(extension, str) or not _EXTENSION_RE.fullmatch(normalized):
+                raise OperatorViewValidationError(f"{path}.extensions contains an invalid file extension.")
+    if field.get("input") == "file_path" and not field.get("extensions"):
+        raise OperatorViewValidationError(f"{path}.extensions is required for a file_path field.")
+    if field.get("apply_to") is not None:
+        for index, raw_target in enumerate(_list(field["apply_to"], f"{path}.apply_to")):
+            target = _record(raw_target, f"{path}.apply_to[{index}]")
+            _text(target, "node_id", f"{path}.apply_to[{index}]")
+            _text(target, "param", f"{path}.apply_to[{index}]")
+    if field.get("swap_pairs") is not None:
+        for index, raw_pair in enumerate(_list(field["swap_pairs"], f"{path}.swap_pairs", nonempty=True)):
+            pair_path = f"{path}.swap_pairs[{index}]"
+            pair = _record(raw_pair, pair_path)
+            for side in ("left", "right"):
+                target = _record(pair.get(side), f"{pair_path}.{side}")
+                _text(target, "node_id", f"{pair_path}.{side}")
+                _text(target, "param", f"{pair_path}.{side}")
+    if field.get("disabled_when") is not None:
+        _source(field["disabled_when"], f"{path}.disabled_when")
+
+
+def _control(value: object, path: str) -> None:
+    control = _record(value, path)
+    _text(control, "node_id", path)
+    _text(control, "action", path)
+    if control.get("payload") is not None:
+        _record(control["payload"], f"{path}.payload")
+
+
+def _action(value: object, path: str) -> None:
+    action = _record(value, path)
+    _text(action, "id", path)
+    _text(action, "label", path)
+    _enum(action, "tone", _TONES, path)
+    _enum(action, "active_tone", _TONES, path)
+    for key in ("confirm", "active_label", "active_confirm"):
+        _optional_text(action, key, path)
+    if action.get("updates") is not None:
+        for index, raw_update in enumerate(_list(action["updates"], f"{path}.updates", nonempty=True)):
+            update_path = f"{path}.updates[{index}]"
+            update = _record(raw_update, update_path)
+            _text(update, "node_id", update_path)
+            _text(update, "param", update_path)
+            if "value" not in update:
+                raise OperatorViewValidationError(f"{update_path}.value is required.")
+    for key in ("control", "deactivate_control"):
+        if action.get(key) is not None:
+            _control(action[key], f"{path}.{key}")
+    if action.get("cook_target") is not None:
+        _target(action["cook_target"], f"{path}.cook_target")
+    if action.get("state") is not None:
+        _source(action["state"], f"{path}.state")
+    if not any(action.get(key) is not None for key in ("updates", "control", "cook_target")):
+        raise OperatorViewValidationError(f"{path} must declare updates, control, or cook_target.")
+
+
+def _widget(value: object, path: str) -> None:
+    widget = _record(value, path)
+    widget_type = _text(widget, "type", path)
+    if widget_type not in _WIDGET_TYPES:
+        raise OperatorViewValidationError(f"{path}.type must be one of: {', '.join(sorted(_WIDGET_TYPES))}.")
+    _text(widget, "id", path)
+    _optional_text(widget, "title", path)
+    if widget_type in {"image", "viewer"}:
+        _text(widget, "title", path)
+        _source(widget.get("source"), f"{path}.source")
+        _optional_text(widget, "empty", path)
+        if widget_type == "image":
+            _enum(widget, "aspect", frozenset({"video", "dashboard"}), path)
+        elif widget.get("trusted_origins") is not None:
+            origins = _list(widget["trusted_origins"], f"{path}.trusted_origins")
+            for origin in origins:
+                parsed = urlsplit(str(origin or ""))
+                if (
+                    not isinstance(origin, str)
+                    or parsed.scheme not in {"http", "https"}
+                    or not parsed.netloc
+                    or parsed.username
+                    or parsed.password
+                    or parsed.path not in {"", "/"}
+                    or parsed.query
+                    or parsed.fragment
+                ):
+                    raise OperatorViewValidationError(
+                        f"{path}.trusted_origins must contain exact HTTP(S) origins."
+                    )
+        return
+    items = _list(widget.get("items"), f"{path}.items", nonempty=True)
+    for index, item in enumerate(items):
+        item_path = f"{path}.items[{index}]"
+        if widget_type == "fields":
+            _field(item, item_path)
+        elif widget_type == "actions":
+            _action(item, item_path)
+        else:
+            record = _record(item, item_path)
+            _source(record, item_path)
+            _text(record, "label", item_path)
+            if widget_type == "status":
+                _enum(record, "tone", frozenset({"neutral", "success", "warning", "danger"}), item_path)
+                _optional_text(record, "true_label", item_path)
+                _optional_text(record, "false_label", item_path)
+            else:
+                _optional_text(record, "suffix", item_path)
+                _enum(record, "format", frozenset({"number", "duration", "text"}), item_path)
+
+
+def validate_operator_view(value: object) -> Mapping[str, Any]:
+    """Validate and return an operator-view mapping using the complete v1 contract."""
+    view = _record(value, "operator_view")
+    if view.get("schema_version") != 1:
+        raise OperatorViewValidationError("operator_view.schema_version must be 1.")
+    _text(view, "title", "operator_view")
+    for key in ("id", "description", "accent"):
+        _optional_text(view, key, "operator_view")
+    _enum(view, "icon", frozenset({"record", "camera", "robot", "workflow", "play"}), "operator_view")
+    if view.get("run_target") is not None:
+        _target(view["run_target"], "operator_view.run_target")
+    section_ids: set[str] = set()
+    widget_ids: set[str] = set()
+    for index, raw_section in enumerate(_list(view.get("sections"), "operator_view.sections", nonempty=True)):
+        path = f"operator_view.sections[{index}]"
+        section = _record(raw_section, path)
+        section_id = _text(section, "id", path)
+        if section_id in section_ids:
+            raise OperatorViewValidationError(f"{path}.id duplicates section id '{section_id}'.")
+        section_ids.add(section_id)
+        _optional_text(section, "title", path)
+        _optional_text(section, "description", path)
+        _enum(section, "region", frozenset({"main", "parameters"}), path)
+        _enum(section, "layout", frozenset({"grid", "stack"}), path)
+        for widget_index, widget in enumerate(_list(section.get("widgets"), f"{path}.widgets", nonempty=True)):
+            widget_path = f"{path}.widgets[{widget_index}]"
+            _widget(widget, widget_path)
+            widget_id = str(widget["id"])
+            if widget_id in widget_ids:
+                raise OperatorViewValidationError(f"{widget_path}.id duplicates widget id '{widget_id}'.")
+            widget_ids.add(widget_id)
+    settings = view.get("settings")
+    if settings is not None:
+        settings = _record(settings, "operator_view.settings")
+        _optional_text(settings, "title", "operator_view.settings")
+        _optional_text(settings, "description", "operator_view.settings")
+        group_ids: set[str] = set()
+        for index, raw_group in enumerate(_list(settings.get("groups"), "operator_view.settings.groups", nonempty=True)):
+            path = f"operator_view.settings.groups[{index}]"
+            group = _record(raw_group, path)
+            group_id = _text(group, "id", path)
+            if group_id in group_ids:
+                raise OperatorViewValidationError(f"{path}.id duplicates settings group id '{group_id}'.")
+            group_ids.add(group_id)
+            _text(group, "title", path)
+            _optional_text(group, "description", path)
+            for item_index, item in enumerate(_list(group.get("items"), f"{path}.items", nonempty=True)):
+                _field(item, f"{path}.items[{item_index}]")
+    return view

--- a/scripts/update_device_source_lock.py
+++ b/scripts/update_device_source_lock.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_SOURCE_KEYS = ("runtime", "core", "hardware")
+
+
+def load_and_validate(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != 1:
+        raise ValueError("source lock schema_version must be 1")
+    for key in _SOURCE_KEYS:
+        source = payload.get(key)
+        if not isinstance(source, dict) or not str(source.get("repository") or "").strip():
+            raise ValueError(f"source lock is missing {key}.repository")
+        sha = str(source.get("commit") or "").lower()
+        if not _SHA_RE.fullmatch(sha):
+            raise ValueError(f"source lock {key}.commit must be a full lowercase commit SHA")
+        source["commit"] = sha
+    return payload
+
+
+def update_commits(payload: dict[str, Any], commits: dict[str, str | None]) -> None:
+    for key, raw_sha in commits.items():
+        if raw_sha is None:
+            continue
+        sha = raw_sha.strip().lower()
+        if not _SHA_RE.fullmatch(sha):
+            raise ValueError(f"{key} commit must be a full lowercase commit SHA")
+        payload[key]["commit"] = sha
+
+
+def _github_json(url: str) -> dict[str, Any]:
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "blacknode-release-lock"}
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        raise ValueError(f"GitHub rejected source verification ({exc.code}) for {url}") from exc
+    except urllib.error.URLError as exc:
+        raise ValueError(f"Could not reach GitHub for source verification: {exc.reason}") from exc
+
+
+def verify_merged_sources(payload: dict[str, Any]) -> None:
+    for key in _SOURCE_KEYS:
+        repository = payload[key]["repository"]
+        sha = payload[key]["commit"]
+        repo = _github_json(f"https://api.github.com/repos/{repository}")
+        default_branch = str(repo.get("default_branch") or "").strip()
+        if not default_branch:
+            raise ValueError(f"GitHub did not report a default branch for {repository}")
+        encoded_branch = urllib.parse.quote(default_branch, safe="")
+        comparison = _github_json(
+            f"https://api.github.com/repos/{repository}/compare/{sha}...{encoded_branch}"
+        )
+        if comparison.get("status") not in {"ahead", "identical"}:
+            raise ValueError(
+                f"{key} commit {sha} is not merged into {repository}:{default_branch}"
+            )
+
+
+def write_lock(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate or update managed-device source pins.")
+    parser.add_argument(
+        "--lock",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "editor-server" / "device-runtime-sources.lock.json",
+    )
+    parser.add_argument("--runtime-commit")
+    parser.add_argument("--core-commit")
+    parser.add_argument("--hardware-commit")
+    parser.add_argument("--verify-merged", action="store_true")
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        payload = load_and_validate(args.lock)
+        update_commits(payload, {
+            "runtime": args.runtime_commit,
+            "core": args.core_commit,
+            "hardware": args.hardware_commit,
+        })
+        if args.verify_merged:
+            verify_merged_sources(payload)
+        if args.write:
+            write_lock(args.lock, payload)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"source-lock error: {exc}", file=sys.stderr)
+        return 1
+    print("Managed-device source lock is valid and uses merged full-SHA pins.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_app_deployments.py
+++ b/tests/test_app_deployments.py
@@ -143,6 +143,55 @@ class AppDeploymentTests(unittest.TestCase):
         self.assertEqual(permissions["updates"], {("text", "value", '"ready"')})
         self.assertEqual(permissions["controls"], {("out", "refresh", "{}")})
         self.assertEqual(permissions["cooks"], {("out", "value", "once")})
+        self.assertEqual(permissions["files"], set())
+
+    def test_operator_permissions_grant_only_declared_file_extensions(self):
+        workflow = _workflow()
+        fields = workflow["metadata"]["operator_view"]["sections"][0]["widgets"][0]["items"]
+        fields.append({
+            "node_id": "text",
+            "param": "value",
+            "label": "Scene",
+            "input": "file_path",
+            "extensions": ["usd", ".USDA"],
+        })
+
+        permissions = operator_permissions({"id": "customer-task", "workflow": workflow})
+
+        self.assertEqual(permissions["files"], {(".usd",), (".usda",)})
+
+    def test_bundle_rejects_malformed_operator_widget(self):
+        workflow = _workflow()
+        workflow["metadata"]["operator_view"]["sections"][0]["widgets"][0]["items"][0].pop("param")
+
+        with self.assertRaisesRegex(AppDeploymentError, r"items\[0\]\.param"):
+            build_app_deployment([("customer.json", workflow)], deployment_id="customer-demo")
+
+    def test_bundle_requires_extensions_for_generic_file_picker(self):
+        workflow = _workflow()
+        field = workflow["metadata"]["operator_view"]["sections"][0]["widgets"][0]["items"][0]
+        field["input"] = "file_path"
+
+        with self.assertRaisesRegex(AppDeploymentError, r"extensions is required"):
+            build_app_deployment([("customer.json", workflow)], deployment_id="customer-demo")
+
+    def test_bundle_rejects_unsafe_extensions_and_non_origin_viewer_hosts(self):
+        workflow = _workflow()
+        field = workflow["metadata"]["operator_view"]["sections"][0]["widgets"][0]["items"][0]
+        field.update({"input": "file_path", "extensions": ["../json"]})
+        with self.assertRaisesRegex(AppDeploymentError, "invalid file extension"):
+            build_app_deployment([("customer.json", workflow)], deployment_id="customer-demo")
+
+        workflow = _workflow()
+        workflow["metadata"]["operator_view"]["sections"][0]["widgets"].append({
+            "type": "viewer",
+            "id": "viewer",
+            "title": "Viewer",
+            "source": {"node_id": "out", "port": "value"},
+            "trusted_origins": ["https://viewer.example.com/path"],
+        })
+        with self.assertRaisesRegex(AppDeploymentError, r"trusted_origins"):
+            build_app_deployment([("customer.json", workflow)], deployment_id="customer-demo")
 
     def test_operator_permissions_include_role_swaps_and_toggle_off_controls(self):
         workflow = _workflow()

--- a/tests/test_device_source_lock_script.py
+++ b/tests/test_device_source_lock_script.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "update_device_source_lock.py"
+SPEC = importlib.util.spec_from_file_location("update_device_source_lock", SCRIPT)
+assert SPEC and SPEC.loader
+source_lock = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(source_lock)
+
+
+def _payload() -> dict:
+    return {
+        "schema_version": 1,
+        "python_minor": "3.11",
+        "runtime": {"repository": "temiroff/blacknode-runtime", "commit": "a" * 40},
+        "core": {"repository": "temiroff/Blacknode", "commit": "b" * 40},
+        "hardware": {"repository": "temiroff/blacknode-robot", "commit": "c" * 40},
+    }
+
+
+class DeviceSourceLockScriptTests(unittest.TestCase):
+    def test_updates_and_writes_full_sha_pins(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "lock.json"
+            path.write_text(json.dumps(_payload()), encoding="utf-8")
+
+            result = source_lock.main(["--lock", str(path), "--runtime-commit", "d" * 40, "--write"])
+
+            self.assertEqual(result, 0)
+            self.assertEqual(json.loads(path.read_text(encoding="utf-8"))["runtime"]["commit"], "d" * 40)
+
+    def test_rejects_short_or_non_hex_pins(self):
+        payload = _payload()
+        with self.assertRaisesRegex(ValueError, "full lowercase commit SHA"):
+            source_lock.update_commits(payload, {"runtime": "deadbeef"})
+
+    def test_verification_requires_each_pin_on_its_default_branch(self):
+        responses = iter([
+            {"default_branch": "main"}, {"status": "ahead"},
+            {"default_branch": "master"}, {"status": "identical"},
+            {"default_branch": "main"}, {"status": "diverged"},
+        ])
+        with patch.object(source_lock, "_github_json", side_effect=lambda _url: next(responses)):
+            with self.assertRaisesRegex(ValueError, "hardware commit"):
+                source_lock.verify_merged_sources(_payload())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_editor_app_mode.py
+++ b/tests/test_editor_app_mode.py
@@ -85,6 +85,7 @@ class EditorAppModeTests(unittest.TestCase):
         self.assertTrue(route_allowed("PATCH", "/nodes/text/params"))
         self.assertTrue(route_allowed("POST", "/nodes/recorder/control"))
         self.assertTrue(route_allowed("POST", "/cook-stream"))
+        self.assertTrue(route_allowed("POST", "/filesystem/browse"))
         self.assertFalse(route_allowed("POST", "/nodes"))
         self.assertFalse(route_allowed("POST", "/graph"))
         self.assertFalse(route_allowed("GET", "/workflows"))
@@ -99,7 +100,7 @@ class EditorAppModeTests(unittest.TestCase):
         with (
             patch.object(server, "_APP_DEPLOYMENT", manifest),
             patch.object(server, "_active_deployment_app_id", None),
-            patch.object(server, "_active_deployment_permissions", {"params": set(), "updates": set(), "controls": set(), "cooks": set()}),
+            patch.object(server, "_active_deployment_permissions", {"params": set(), "updates": set(), "controls": set(), "cooks": set(), "files": set()}),
             patch.object(server, "_stop_active_cook"),
             patch.object(server, "_stop_runtime_services", return_value={}),
         ):
@@ -138,6 +139,43 @@ class EditorAppModeTests(unittest.TestCase):
 
             denied = client.patch("/nodes/text/params", json={"key": "undeclared", "value": "blocked"})
             self.assertEqual(denied.status_code, 403)
+
+    def test_active_app_file_browser_is_scoped_to_granted_types_and_roots(self):
+        workflow = _app_workflow()
+        fields = workflow["metadata"]["operator_view"]["sections"][0]["widgets"][0]["items"]
+        fields.append({
+            "node_id": "text",
+            "param": "value",
+            "label": "Scene",
+            "input": "file_path",
+            "extensions": [".usd"],
+        })
+        manifest = build_app_deployment([("customer.json", workflow)], deployment_id="customer-deployment")
+        with tempfile.TemporaryDirectory() as root_dir, tempfile.TemporaryDirectory() as outside_dir:
+            root = Path(root_dir)
+            outside = Path(outside_dir)
+            (root / "scene.usd").write_text("scene", encoding="utf-8")
+            (root / "secret.txt").write_text("secret", encoding="utf-8")
+            with (
+                patch.object(server, "_APP_DEPLOYMENT", manifest),
+                patch.object(server, "_APP_FILE_ROOTS", (root.resolve(),)),
+                patch.object(server, "_active_deployment_app_id", None),
+                patch.object(server, "_active_deployment_permissions", {"params": set(), "updates": set(), "controls": set(), "cooks": set(), "files": set()}),
+                patch.object(server, "_stop_active_cook"),
+                patch.object(server, "_stop_runtime_services", return_value={}),
+            ):
+                client = TestClient(server.app)
+                self.assertEqual(client.post("/app-deployment/apps/customer-app/activate").status_code, 200)
+
+                listing = client.post("/filesystem/browse", json={"path": str(root), "extensions": ["usd"]})
+                self.assertEqual(listing.status_code, 200, listing.text)
+                self.assertEqual([item["name"] for item in listing.json()["entries"]], ["scene.usd"])
+                self.assertEqual(listing.json()["roots"], [str(root.resolve())])
+
+                denied_type = client.post("/filesystem/browse", json={"path": str(root), "extensions": ["txt"]})
+                self.assertEqual(denied_type.status_code, 403)
+                denied_path = client.post("/filesystem/browse", json={"path": str(outside), "extensions": ["usd"]})
+                self.assertEqual(denied_path.status_code, 403)
 
     def test_packaged_app_serves_spa_and_same_origin_api(self):
         manifest = build_app_deployment(

--- a/tests/test_editor_operator_view.py
+++ b/tests/test_editor_operator_view.py
@@ -79,7 +79,7 @@ def test_operator_view_embeds_declared_interactive_viewer_urls():
     assert "function OperatorViewer" in view
     assert "if (widget.type === 'viewer')" in view
     assert "normalizeViewerUrl" in view
-    assert 'sandbox="allow-forms allow-pointer-lock allow-same-origin allow-scripts"' in view
+    assert "sandbox={viewerSandbox(url)}" in view
     assert 'allow="fullscreen"' in view
     assert 'referrerPolicy="no-referrer"' in view
     assert ".bn-operator-viewer-frame iframe" in styles

--- a/tests/test_editor_operator_view.py
+++ b/tests/test_editor_operator_view.py
@@ -78,8 +78,9 @@ def test_operator_view_embeds_declared_interactive_viewer_urls():
 
     assert "function OperatorViewer" in view
     assert "if (widget.type === 'viewer')" in view
-    assert "if (/^(https?:\\/\\/|\\/(?!\\/))/i.test(trimmed))" in view
-    assert 'allow="clipboard-read; clipboard-write; fullscreen"' in view
+    assert "normalizeViewerUrl" in view
+    assert 'sandbox="allow-forms allow-pointer-lock allow-same-origin allow-scripts"' in view
+    assert 'allow="fullscreen"' in view
     assert 'referrerPolicy="no-referrer"' in view
     assert ".bn-operator-viewer-frame iframe" in styles
 

--- a/tests/test_filesystem_access.py
+++ b/tests/test_filesystem_access.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITOR_SERVER = ROOT / "editor-server"
+if str(EDITOR_SERVER) not in sys.path:
+    sys.path.insert(0, str(EDITOR_SERVER))
+
+from filesystem_access import browse_listing, normalize_extensions  # noqa: E402
+
+
+class FilesystemAccessTests(unittest.TestCase):
+    def test_normalizes_and_validates_extensions(self):
+        self.assertEqual(normalize_extensions(["USD", ".usda"]), frozenset({".usd", ".usda"}))
+        with self.assertRaisesRegex(ValueError, "Invalid file extension"):
+            normalize_extensions(["../secret"])
+
+    def test_restricted_listing_stays_inside_root(self):
+        with tempfile.TemporaryDirectory() as root_dir, tempfile.TemporaryDirectory() as outside_dir:
+            root = Path(root_dir).resolve()
+            (root / "scene.usd").write_text("scene", encoding="utf-8")
+            (root / "notes.txt").write_text("notes", encoding="utf-8")
+
+            listing = browse_listing(str(root), ["usd"], roots=(root,))
+
+            self.assertEqual([item["name"] for item in listing["entries"]], ["scene.usd"])
+            self.assertEqual(listing["parent"], "")
+            with self.assertRaises(PermissionError):
+                browse_listing(outside_dir, ["usd"], roots=(root,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- scope packaged-App file browsing to declared extensions and configured host roots
- validate the full operator-view v1 contract and sandbox embedded viewers
- add Vitest component/contract tests and a Playwright packaged-App flow
- lazy-load heavy panels; initial JS falls from ~1.14 MB to ~481 KB
- replace Rust async raw-pointer sharing, fix exact cycle-edge rollback, and add runtime/core/value tests
- add merged-source-lock validation and a coordinated lock-update workflow
- run editor tests and full Rust tests in CI

## Verification
- python -m unittest discover -s tests (592 passed, 8 skipped)
- CI python -m pytest (all 852 collected tests pass; 13 skipped)
- npm test (11 passed)
- npm run test:e2e (1 Chromium flow passed)
- npm run build (clean; no large-chunk warning)
- cargo test --workspace --all-targets (7 passed)
- python scripts/update_device_source_lock.py --verify-merged

## Managed Runtime release decision
The core portion is editor/server, tests, release tooling, and an unused Rust prototype path, so it does not alter the managed device bundle. The Newton extension change is released separately and does require a Runtime patch as the operator-visible update trigger; that Runtime release and the final merged-SHA lock PR will follow.