### PR TITLE
release: pin Runtime 0.4.16 sources

### DIFF
--- a/editor-server/device-runtime-sources.lock.json
+++ b/editor-server/device-runtime-sources.lock.json
@@ -3,11 +3,11 @@
   "python_minor": "3.11",
   "runtime": {
     "repository": "temiroff/blacknode-runtime",
-    "commit": "15104da6f3cba24f502a0683772815860bd1e01b"
+    "commit": "9112ba321bace724560709796880431ddd871ac7"
   },
   "core": {
     "repository": "temiroff/Blacknode",
-    "commit": "85a4bb87bf9d4658dd00e893cda93197d50ccf90"
+    "commit": "ebd2617cf7dba6f9721bf4f2e81608558c651633"
   },
   "hardware": {
     "repository": "temiroff/blacknode-robot",


### PR DESCRIPTION
## Summary
- pin merged blacknode-runtime 0.4.16 commit 9112ba3
- pin merged Blacknode core hardening commit ebd2617
- retain merged blacknode-robot commit 027bdd6

## Verification
- python scripts/update_device_source_lock.py --verify-merged
- python -m pytest tests/test_editor_devices.py tests/test_device_source_lock_script.py -q (146 passed)
- python -m unittest discover -s tests (592 passed, 8 skipped)

## Managed Runtime release decision
Required and complete after merge: this source lock connects the merged Runtime patch and core release to the managed-device Update flow. Merging publishes Latest; installed devices remain on Current until an operator uses Devices → Software → Check updates → Update all.